### PR TITLE
Fix version right-alignment and bump status-bar font size

### DIFF
--- a/src/card/card-styles.js
+++ b/src/card/card-styles.js
@@ -24,7 +24,7 @@ export const CARD_STYLES = `
     left: 0;
     right: 0;
     background: rgba(42, 42, 42, 0.3);
-    font-size: 9px;
+    font-size: 10px;
     color: rgba(255, 255, 255, 0.85);
     display: flex;
     justify-content: space-between;
@@ -58,6 +58,7 @@ export const CARD_STYLES = `
     align-items: center;
     gap: 4px;
     margin-top: 2px;
+    position: relative;
   }
   .nav button {
     background: rgba(42, 42, 42, 0.3);
@@ -109,8 +110,9 @@ export const CARD_STYLES = `
   .card-version {
     font-size: 9px;
     color: rgba(255, 255, 255, 0.3);
-    margin-left: 4px;
     user-select: none;
     font-family: sans-serif;
+    position: absolute;
+    right: 0;
   }
 `;


### PR DESCRIPTION
## Summary

- Pin `.card-version` to the right edge of the nav bar using `position: absolute; right: 0` (with `position: relative` on `.nav`), so it no longer sits inside the centered flex flow
- Increase `.status-bar` font-size from `9px` → `10px` for better legibility

## Test plan

- [ ] Version label appears flush to the right of the nav bar
- [ ] Centered buttons (nav, zoom) remain visually centered
- [ ] Status bar text (location, sky mode, next transition) is visibly larger
- [ ] All 408 unit tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)