### PR TITLE
Upgrade action-gh-release to v3 and drop FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 shim

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: ["main"]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 permissions:
   pull-requests: write
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,9 +7,6 @@ on:
         description: "Version number (e.g. 1.0.1)"
         required: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 permissions:
   contents: write
 
@@ -41,7 +38,7 @@ jobs:
           git push origin "v${{ github.event.inputs.version }}"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: "v${{ github.event.inputs.version }}"
           files: dist/card.js


### PR DESCRIPTION
## Summary

- Bump `softprops/action-gh-release` from `@v2` (node20) to `@v3` (node24) — eliminates the Node.js 20 deprecation warning on the Release workflow
- Remove `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` from both `publish-release.yml` and `build-and-test.yml` — all actions (`checkout@v5`, `setup-node@v5`, `vitest-coverage-report-action@v2`, `action-gh-release@v3`) now target node24 natively, so the workaround is no longer needed

## Test plan

- [ ] Build and Test workflow runs without Node.js deprecation warnings
- [ ] Release workflow runs without Node.js deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)