### PR TITLE
Fix demo page broken by custom element rename

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -39,7 +39,7 @@
       max-width: 100%;
     }
 
-    ha-solar-view-card {
+    ha-planetary-solar-system-card {
       display: block;
       width: 100%;
     }
@@ -68,7 +68,7 @@
   </p>
 
   <div class="card-wrapper">
-    <ha-solar-view-card id="demo-card"></ha-solar-view-card>
+    <ha-planetary-solar-system-card id="demo-card"></ha-planetary-solar-system-card>
   </div>
 
   <footer>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "ha-solar-view-card",
+  "name": "ha-planetary-solar-system-card",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "ha-solar-view-card",
+      "name": "ha-planetary-solar-system-card",
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
@@ -372,7 +372,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -413,7 +412,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1862,7 +1860,6 @@
       "integrity": "sha512-KDYJgZ6T2TKdU8yBfYueq5EPG/EylMsBvCaenWMJb2OXmjgczzwveRCoJ+Hgj1lXPDyasvrgneSn4GBuR1hYyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -2433,7 +2430,6 @@
       "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -2758,7 +2754,6 @@
       "integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/runtime": "0.115.0",
         "lightningcss": "^1.32.0",
@@ -2838,7 +2833,6 @@
       "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.0",
         "@vitest/mocker": "4.1.0",


### PR DESCRIPTION
## Summary

- Update `docs/index.html` to use `ha-planetary-solar-system-card` (CSS selector + HTML tag) — the old `ha-solar-view-card` name was left behind when the element was renamed, causing the GitHub Pages demo to render nothing
- Sync `package-lock.json` `name` field to match `package.json`

## Root cause

The rename commit updated `src/index.js` and `package.json` but `docs/index.html` referenced the element by tag name in two places (CSS rule + DOM element), both still using the old name.

## Test plan

- [ ] GitHub Pages demo renders the solar system card after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)