### PR TITLE
Prep repo for HACS default store submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Planetary Solar System Card
 
-[![HACS Default](https://img.shields.io/badge/HACS-Default-41BDF5.svg)](https://hacs.xyz)
 [![GitHub Release](https://img.shields.io/github/release/marcintk/ha-planetary-solar-system-card.svg)](https://github.com/marcintk/ha-planetary-solar-system-card/releases)
 [![CI](https://github.com/marcintk/ha-planetary-solar-system-card/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/marcintk/ha-planetary-solar-system-card/actions/workflows/build-and-test.yml)
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "Planetary Solar System Card",
   "render_readme": true,
-  "filename": "dist/card.js"
+  "filename": "card.js"
 }


### PR DESCRIPTION
## Summary

- Fix `filename` in `hacs.json`: was `dist/card.js`, now `card.js` to match the actual release asset name
- Remove premature HACS Default badge from README (will add back once accepted)

## Test plan

- [ ] Verify `hacs-validation.yml` CI passes on this PR
- [ ] Confirm latest release still has `card.js` asset attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)