### PR TITLE
Add flip_view / eclipticView config option + fix card background

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ default_zoom: 2
 | `periodic_zoom_change` | boolean | `false`   | Cycle zoom levels on each refresh tick                      |
 | `periodic_zoom_max`    | number  | `4`       | Maximum zoom level for auto-cycle (2–4)                     |
 | `colors`               | object  | see below | Color overrides (see Colors)                                |
-| `south_ecliptic_pole`  | boolean | `false`   | View from the south ecliptic pole (orbits appear clockwise) |
+| `ecliptic_view`        | boolean | `false`   | View from the south ecliptic pole (orbits appear clockwise) |
 
 ### Colors
 

--- a/README.md
+++ b/README.md
@@ -48,14 +48,15 @@ default_zoom: 2
 
 ## Configuration
 
-| Option                 | Type    | Default   | Description                             |
-| ---------------------- | ------- | --------- | --------------------------------------- |
-| `refresh_mins`         | number  | `1`       | Auto-update interval in minutes         |
-| `default_zoom`         | number  | `1`       | Starting zoom level                     |
-| `zoom_animate`         | boolean | `true`    | Animate zoom transitions                |
-| `periodic_zoom_change` | boolean | `false`   | Cycle zoom levels on each refresh tick  |
-| `periodic_zoom_max`    | number  | `4`       | Maximum zoom level for auto-cycle (2–4) |
-| `colors`               | object  | see below | Color overrides (see Colors)            |
+| Option                 | Type    | Default   | Description                                                                  |
+| ---------------------- | ------- | --------- | ---------------------------------------------------------------------------- |
+| `refresh_mins`         | number  | `1`       | Auto-update interval in minutes                                              |
+| `default_zoom`         | number  | `1`       | Starting zoom level                                                          |
+| `zoom_animate`         | boolean | `true`    | Animate zoom transitions                                                     |
+| `periodic_zoom_change` | boolean | `false`   | Cycle zoom levels on each refresh tick                                       |
+| `periodic_zoom_max`    | number  | `4`       | Maximum zoom level for auto-cycle (2–4)                                      |
+| `colors`               | object  | see below | Color overrides (see Colors)                                                 |
+| `flip_view`            | boolean | `false`   | Mirror the view vertically (south-pole perspective, orbits appear clockwise) |
 
 ### Colors
 

--- a/README.md
+++ b/README.md
@@ -48,15 +48,15 @@ default_zoom: 2
 
 ## Configuration
 
-| Option                 | Type    | Default   | Description                                                                  |
-| ---------------------- | ------- | --------- | ---------------------------------------------------------------------------- |
-| `refresh_mins`         | number  | `1`       | Auto-update interval in minutes                                              |
-| `default_zoom`         | number  | `1`       | Starting zoom level                                                          |
-| `zoom_animate`         | boolean | `true`    | Animate zoom transitions                                                     |
-| `periodic_zoom_change` | boolean | `false`   | Cycle zoom levels on each refresh tick                                       |
-| `periodic_zoom_max`    | number  | `4`       | Maximum zoom level for auto-cycle (2–4)                                      |
-| `colors`               | object  | see below | Color overrides (see Colors)                                                 |
-| `flip_view`            | boolean | `false`   | Mirror the view vertically (south-pole perspective, orbits appear clockwise) |
+| Option                 | Type    | Default   | Description                                                 |
+| ---------------------- | ------- | --------- | ----------------------------------------------------------- |
+| `refresh_mins`         | number  | `1`       | Auto-update interval in minutes                             |
+| `default_zoom`         | number  | `1`       | Starting zoom level                                         |
+| `zoom_animate`         | boolean | `true`    | Animate zoom transitions                                    |
+| `periodic_zoom_change` | boolean | `false`   | Cycle zoom levels on each refresh tick                      |
+| `periodic_zoom_max`    | number  | `4`       | Maximum zoom level for auto-cycle (2–4)                     |
+| `colors`               | object  | see below | Color overrides (see Colors)                                |
+| `south_ecliptic_pole`  | boolean | `false`   | View from the south ecliptic pole (orbits appear clockwise) |
 
 ### Colors
 

--- a/dist/card.js
+++ b/dist/card.js
@@ -1355,6 +1355,7 @@ function renderOffscreenMarkers(positions, viewState) {
 const CARD_STYLES = `
   :host {
     display: block;
+    background: #090909;
   }
   .card {
     background: #090909;
@@ -1930,6 +1931,7 @@ class SolarViewCard extends HTMLElement {
       this._viewState.zoomLevel
     );
 
+    this.style.background = this._colors.background;
     this.shadowRoot.querySelector(".card").style.background = this._colors.background;
 
     const container = this.shadowRoot.getElementById("solar-view");

--- a/dist/card.js
+++ b/dist/card.js
@@ -208,17 +208,20 @@ function expandBounds(bounds, x, y, margin) {
   bounds.maxY = Math.max(bounds.maxY, y + margin);
 }
 
-const ORBIT_COLOR$1 = "rgba(255, 255, 255, 0.12)";
-const LABEL_COLOR$1 = "rgba(255, 255, 255, 0.5)";
+const ORBIT_COLOR = "rgba(255, 255, 255, 0.12)";
+const AU_LABEL_COLOR = "rgba(255, 255, 255, 0.5)";
+const DEFAULT_LABEL_COLOR$1 = "#ffffff";
 
-function renderOrbit(svg, radius, auLabel) {
+function renderOrbit(svg, radius, auLabel, colors = {}) {
+  const orbitColor = colors.orbit ?? ORBIT_COLOR;
+
   svg.appendChild(
     createSvgElement("circle", {
       cx: CENTER,
       cy: CENTER,
       r: radius,
       fill: "none",
-      stroke: ORBIT_COLOR$1,
+      stroke: orbitColor,
       "stroke-width": 1,
       "stroke-dasharray": "5, 5",
     })
@@ -229,7 +232,7 @@ function renderOrbit(svg, radius, auLabel) {
   const offset = 3;
   const horizontalOffset = 3;
   const labelAttrs = {
-    fill: LABEL_COLOR$1,
+    fill: AU_LABEL_COLOR,
     "font-size": "9",
     "font-family": "sans-serif",
     "text-anchor": "start",
@@ -254,7 +257,9 @@ function renderOrbit(svg, radius, auLabel) {
   ).textContent = `${Number(auLabel).toFixed(1)} AU`;
 }
 
-function renderBody(svg, x, y, body, showLabel = true) {
+function renderBody(svg, x, y, body, showLabel = true, colors = {}) {
+  const labelColor = colors.label ?? DEFAULT_LABEL_COLOR$1;
+
   svg.appendChild(
     createSvgElement("circle", {
       cx: x,
@@ -269,7 +274,7 @@ function renderBody(svg, x, y, body, showLabel = true) {
       createSvgElement("text", {
         x: x,
         y: y - body.size - 6,
-        fill: "#ffffff",
+        fill: labelColor,
         "font-size": "11",
         "font-family": "sans-serif",
         "text-anchor": "middle",
@@ -311,8 +316,9 @@ function renderSaturnRings(svg, x, y, body, _renderSize) {
   );
 }
 
-const ORBIT_COLOR = "rgba(255, 255, 255, 0.12)";
+const DEFAULT_ORBIT_COLOR = "rgba(255, 255, 255, 0.12)";
 const TAIL_COLOR = "rgba(136, 204, 255, 0.5)";
+const DEFAULT_LABEL_COLOR = "#ffffff";
 
 /**
  * Compute the visual ellipse parameters in pixel space for a comet.
@@ -342,7 +348,8 @@ function computeCometVisualEllipse(comet) {
  * Render a comet's orbit as an SVG ellipse in pixel space.
  * The ellipse is offset so the Sun (at CENTER) sits at one focus.
  */
-function renderCometOrbit(svg, comet) {
+function renderCometOrbit(svg, comet, colors = {}) {
+  const orbitColor = colors.orbit ?? DEFAULT_ORBIT_COLOR;
   const { aPx, bPx, cPx, rotationDeg } = computeCometVisualEllipse(comet);
 
   svg.appendChild(
@@ -352,7 +359,7 @@ function renderCometOrbit(svg, comet) {
       rx: aPx,
       ry: bPx,
       fill: "none",
-      stroke: ORBIT_COLOR,
+      stroke: orbitColor,
       "stroke-width": 1,
       "stroke-dasharray": "4, 8",
       transform: `rotate(${-rotationDeg}, ${CENTER}, ${CENTER}) translate(${-cPx}, 0)`,
@@ -364,7 +371,8 @@ function renderCometOrbit(svg, comet) {
  * Render the comet body and its anti-sunward tail.
  * The tail always points directly away from the Sun.
  */
-function renderCometBody(svg, x, y, comet, sunX, sunY, dynamicTailLength) {
+function renderCometBody(svg, x, y, comet, sunX, sunY, dynamicTailLength, colors = {}) {
+  const labelColor = colors.label ?? DEFAULT_LABEL_COLOR;
   // Direction away from the Sun
   const dx = x - sunX;
   const dy = y - sunY;
@@ -406,7 +414,7 @@ function renderCometBody(svg, x, y, comet, sunX, sunY, dynamicTailLength) {
     createSvgElement("text", {
       x: x,
       y: y - comet.size - 6,
-      fill: "#ffffff",
+      fill: labelColor,
       "font-size": "11",
       "font-family": "sans-serif",
       "text-anchor": "middle",
@@ -755,7 +763,8 @@ function renderVisibilityCone(
   observerAngle,
   halfAngleDeg,
   clipId,
-  fillColor
+  fillColor,
+  eclipticViewDirection = -1
 ) {
   const D = VIEW_SIZE;
   const HALF_ANGLE = (halfAngleDeg * Math.PI) / 180;
@@ -765,9 +774,9 @@ function renderVisibilityCone(
   const leftAngle = observerAngle + HALF_ANGLE;
   const rightAngle = observerAngle - HALF_ANGLE;
   const leftX = anchorX + D * Math.cos(leftAngle);
-  const leftY = anchorY - D * Math.sin(leftAngle);
+  const leftY = anchorY + eclipticViewDirection * D * Math.sin(leftAngle);
   const rightX = anchorX + D * Math.cos(rightAngle);
-  const rightY = anchorY - D * Math.sin(rightAngle);
+  const rightY = anchorY + eclipticViewDirection * D * Math.sin(rightAngle);
 
   // SVG path: MoveTo apex, LineTo left edge, Arc to right edge, ClosePath
   const pathD = `M ${anchorX} ${anchorY} L ${leftX} ${leftY} A ${D} ${D} 0 ${largeArcFlag} 1 ${rightX} ${rightY} Z`;
@@ -790,7 +799,14 @@ function renderVisibilityCone(
   );
 }
 
-function renderDayNightSplit(svg, earthRadius, date, earthBodySize, locationData) {
+function renderDayNightSplit(
+  svg,
+  earthRadius,
+  date,
+  earthBodySize,
+  locationData,
+  eclipticViewDirection = -1
+) {
   const earth = PLANETS.find((p) => p.name === "Earth");
   const earthAngle = calculatePlanetPosition(earth, date);
   const observerAngle = calculateObserverAngle(
@@ -807,9 +823,9 @@ function renderDayNightSplit(svg, earthRadius, date, earthBodySize, locationData
 
   // Anchor point at Earth's surface
   const earthOrbitalX = CENTER + earthRadius * earthDirX;
-  const earthOrbitalY = CENTER - earthRadius * earthDirY;
+  const earthOrbitalY = CENTER + eclipticViewDirection * earthRadius * earthDirY;
   const anchorX = earthOrbitalX + earthBodySize * obsDirX;
-  const anchorY = earthOrbitalY - earthBodySize * obsDirY;
+  const anchorY = earthOrbitalY + eclipticViewDirection * earthBodySize * obsDirY;
 
   // Filled cone — colour determined by which twilight phase the solar elevation falls in.
   // Half-angle = 90° − elevationDeg expands the cone below the horizon during twilight.
@@ -826,7 +842,16 @@ function renderDayNightSplit(svg, earthRadius, date, earthBodySize, locationData
   else if (elevationDeg >= -18) coneColor = CONE_ASTRONOMICAL;
   else coneColor = CONE_NIGHT;
   const halfAngle = elevationDeg >= 0 || elevationDeg < -18 ? 90 : 90 - elevationDeg;
-  renderVisibilityCone(svg, anchorX, anchorY, observerAngle, halfAngle, "sky-clip", coneColor);
+  renderVisibilityCone(
+    svg,
+    anchorX,
+    anchorY,
+    observerAngle,
+    halfAngle,
+    "sky-clip",
+    coneColor,
+    eclipticViewDirection
+  );
 
   // Shared constants for horizon and zenith lines
   const CLIP_R = MAX_RADIUS + 30;
@@ -845,7 +870,7 @@ function renderDayNightSplit(svg, earthRadius, date, earthBodySize, locationData
       anchorX,
       anchorY,
       Math.cos(leftAngle),
-      -Math.sin(leftAngle),
+      eclipticViewDirection * Math.sin(leftAngle),
       CENTER,
       CENTER,
       CLIP_R
@@ -855,7 +880,7 @@ function renderDayNightSplit(svg, earthRadius, date, earthBodySize, locationData
       anchorX,
       anchorY,
       Math.cos(rightAngle),
-      -Math.sin(rightAngle),
+      eclipticViewDirection * Math.sin(rightAngle),
       CENTER,
       CENTER,
       CLIP_R
@@ -864,9 +889,9 @@ function renderDayNightSplit(svg, earthRadius, date, earthBodySize, locationData
     createSvgElement("line", {
       ...lineStyle,
       x1: anchorX + leftD * Math.cos(leftAngle),
-      y1: anchorY - leftD * Math.sin(leftAngle),
+      y1: anchorY + eclipticViewDirection * leftD * Math.sin(leftAngle),
       x2: anchorX + rightD * Math.cos(rightAngle),
-      y2: anchorY - rightD * Math.sin(rightAngle),
+      y2: anchorY + eclipticViewDirection * rightD * Math.sin(rightAngle),
     })
   );
 
@@ -876,7 +901,7 @@ function renderDayNightSplit(svg, earthRadius, date, earthBodySize, locationData
       anchorX,
       anchorY,
       Math.cos(observerAngle),
-      -Math.sin(observerAngle),
+      eclipticViewDirection * Math.sin(observerAngle),
       CENTER,
       CENTER,
       CLIP_R
@@ -887,14 +912,21 @@ function renderDayNightSplit(svg, earthRadius, date, earthBodySize, locationData
       x1: anchorX,
       y1: anchorY,
       x2: anchorX + zenithD * Math.cos(observerAngle),
-      y2: anchorY - zenithD * Math.sin(observerAngle),
+      y2: anchorY + eclipticViewDirection * zenithD * Math.sin(observerAngle),
     })
   );
 }
 
-function renderObserverNeedle(svg, earthX, earthY, observerAngle, earthSize) {
+function renderObserverNeedle(
+  svg,
+  earthX,
+  earthY,
+  observerAngle,
+  earthSize,
+  eclipticViewDirection = -1
+) {
   const tipX = earthX + earthSize * Math.cos(observerAngle);
-  const tipY = earthY - earthSize * Math.sin(observerAngle);
+  const tipY = earthY + eclipticViewDirection * earthSize * Math.sin(observerAngle);
 
   svg.appendChild(
     createSvgElement("line", {
@@ -919,11 +951,14 @@ function renderObserverNeedle(svg, earthX, earthY, observerAngle, earthSize) {
   );
 }
 
-const SEASON_LINE_COLOR = "rgba(255, 255, 255, 0.25)";
-const SEASON_LABEL_COLOR = "rgba(255, 255, 255, 0.5)";
+const DEFAULT_SEASON_LINE_COLOR = "rgba(255, 255, 255, 0.25)";
+const DEFAULT_SEASON_LABEL_COLOR = "rgba(255, 255, 255, 0.5)";
 const SEASON_FONT_SIZE = 20;
 
-function renderSeasonOverlay(svg, hemisphere) {
+function renderSeasonOverlay(svg, hemisphere, colors = {}, eclipticViewDirection = -1) {
+  const lineColor = colors.seasonLine ?? DEFAULT_SEASON_LINE_COLOR;
+  const labelColor = colors.seasonLabel ?? DEFAULT_SEASON_LABEL_COLOR;
+
   // Dotted dividing lines through the Sun
   svg.appendChild(
     createSvgElement("line", {
@@ -931,7 +966,7 @@ function renderSeasonOverlay(svg, hemisphere) {
       y1: CENTER,
       x2: VIEW_SIZE,
       y2: CENTER,
-      stroke: SEASON_LINE_COLOR,
+      stroke: lineColor,
       "stroke-width": 1,
       "stroke-dasharray": "4, 6",
     })
@@ -942,7 +977,7 @@ function renderSeasonOverlay(svg, hemisphere) {
       y1: 0,
       x2: CENTER,
       y2: VIEW_SIZE,
-      stroke: SEASON_LINE_COLOR,
+      stroke: lineColor,
       "stroke-width": 1,
       "stroke-dasharray": "4, 6",
     })
@@ -980,16 +1015,19 @@ function renderSeasonOverlay(svg, hemisphere) {
 
     // Top-half arcs (0–90° and 90–180°) render text upside-down because the
     // default arc sweeps right-to-left in SVG space. Reverse them so textPath
-    // flows left-to-right for readable labels.
-    const isTopHalf = season.startAngle >= 0 && season.endAngle <= 180 && season.startAngle < 180;
+    // flows left-to-right for readable labels. When the view is flipped (eclipticViewDirection=1)
+    // the visual top/bottom halves swap, so invert the flag.
+    const naturallyTopHalf =
+      season.startAngle >= 0 && season.endAngle <= 180 && season.startAngle < 180;
+    const isTopHalf = eclipticViewDirection === -1 ? naturallyTopHalf : !naturallyTopHalf;
     // Use a smaller radius for top-half labels so they appear visually
     // at the same distance from Neptune's orbit as bottom-half labels
     const arcRadius = isTopHalf ? labelRadius - 12 : labelRadius;
 
     const x1 = CENTER + arcRadius * Math.cos(startRad);
-    const y1 = CENTER - arcRadius * Math.sin(startRad);
+    const y1 = CENTER + eclipticViewDirection * arcRadius * Math.sin(startRad);
     const x2 = CENTER + arcRadius * Math.cos(endRad);
-    const y2 = CENTER - arcRadius * Math.sin(endRad);
+    const y2 = CENTER + eclipticViewDirection * arcRadius * Math.sin(endRad);
 
     const arcPath = createSvgElement("path", {
       id: pathId,
@@ -1001,7 +1039,7 @@ function renderSeasonOverlay(svg, hemisphere) {
     defs.appendChild(arcPath);
 
     const text = createSvgElement("text", {
-      fill: SEASON_LABEL_COLOR,
+      fill: labelColor,
       "font-size": SEASON_FONT_SIZE,
       "font-family": "sans-serif",
     });
@@ -1021,9 +1059,20 @@ function renderSeasonOverlay(svg, hemisphere) {
  * @param {Date} date - date to calculate positions for
  * @param {string} [hemisphere="north"] - "north" or "south" for season labels
  * @param {{ lat: number, lon: number, timezone: string } | null} [locationData] - observer location from HA config
+ * @param {{ background?: string, orbit?: string, label?: string, seasonLine?: string, seasonLabel?: string }} [colors] - optional color overrides
  * @returns {{ svg: SVGElement, bounds: { minX: number, minY: number, maxX: number, maxY: number } }}
  */
-function renderSolarSystem(date, hemisphere = "north", locationData = null) {
+function renderSolarSystem(
+  date,
+  hemisphere = "north",
+  locationData = null,
+  colors = {},
+  eclipticView = false
+) {
+  const eclipticViewDirection = eclipticView ? 1 : -1;
+  const orbitColor = colors.orbit ?? ORBIT_COLOR;
+  const labelColor = colors.label ?? "#ffffff";
+
   const svg = createSvgElement("svg", {
     viewBox: `0 0 ${VIEW_SIZE} ${VIEW_SIZE}`,
     width: "100%",
@@ -1037,22 +1086,22 @@ function renderSolarSystem(date, hemisphere = "north", locationData = null) {
   // Day/night split (rendered first, behind everything)
   const earth = PLANETS.find((p) => p.name === "Earth");
   const earthRadius = auToRadius(1.0);
-  renderDayNightSplit(svg, earthRadius, date, earth.size, locationData);
+  renderDayNightSplit(svg, earthRadius, date, earth.size, locationData, eclipticViewDirection);
 
   // Season quadrant overlay (after day/night, before orbits)
-  renderSeasonOverlay(svg, hemisphere);
+  renderSeasonOverlay(svg, hemisphere, colors, eclipticViewDirection);
 
   // Draw orbits (planets then comets, so all orbits are behind bodies)
   for (const planet of PLANETS) {
     const radius = auToRadius(planet.au);
-    renderOrbit(svg, radius, planet.au);
+    renderOrbit(svg, radius, planet.au, colors);
   }
   for (const comet of COMETS) {
-    renderCometOrbit(svg, comet);
+    renderCometOrbit(svg, comet, colors);
   }
 
   // Sun at center
-  renderBody(svg, CENTER, CENTER, SUN, false);
+  renderBody(svg, CENTER, CENTER, SUN, false, colors);
   expandBounds(bounds, CENTER, CENTER, SUN.size);
 
   // Draw planets
@@ -1060,13 +1109,13 @@ function renderSolarSystem(date, hemisphere = "north", locationData = null) {
     const angle = calculatePlanetPosition(planet, date);
     const radius = auToRadius(planet.au);
     const x = CENTER + radius * Math.cos(angle);
-    const y = CENTER - radius * Math.sin(angle);
+    const y = CENTER + eclipticViewDirection * radius * Math.sin(angle);
     positions.push({ name: planet.name, x, y, color: planet.color });
     if (planet.name === "Saturn") {
       // Shrink Saturn's body to make room for top-down circular ring
       const saturnRenderSize = Math.round(planet.size / 2);
       const saturnOverride = { ...planet, size: saturnRenderSize };
-      renderBody(svg, x, y, saturnOverride, false);
+      renderBody(svg, x, y, saturnOverride, false, colors);
       expandBounds(bounds, x, y, saturnOverride.size + 20);
       renderSaturnRings(svg, x, y, planet);
       // Draw label after rings so it paints on top
@@ -1074,7 +1123,7 @@ function renderSolarSystem(date, hemisphere = "north", locationData = null) {
         createSvgElement("text", {
           x: x,
           y: y - saturnRenderSize - 16,
-          fill: "#ffffff",
+          fill: labelColor,
           "font-size": "11",
           "font-family": "sans-serif",
           "text-anchor": "middle",
@@ -1083,7 +1132,7 @@ function renderSolarSystem(date, hemisphere = "north", locationData = null) {
       // Total footprint: ring outer edge = ringRadius + strokeWidth/2 = (planet.size - 2) + 2 = planet.size
       expandBounds(bounds, x, y, planet.size);
     } else {
-      renderBody(svg, x, y, planet);
+      renderBody(svg, x, y, planet, true, colors);
       // Account for body size + label height (~17px above body)
       expandBounds(bounds, x, y, planet.size + 17);
     }
@@ -1095,12 +1144,12 @@ function renderSolarSystem(date, hemisphere = "north", locationData = null) {
     const { aPx, ePx } = computeCometVisualEllipse(comet);
     const rPx = (aPx * (1 - ePx * ePx)) / (1 + ePx * Math.cos(trueAnomaly));
     const cx = CENTER + rPx * Math.cos(angle);
-    const cy = CENTER - rPx * Math.sin(angle);
+    const cy = CENTER + eclipticViewDirection * rPx * Math.sin(angle);
     // Tail scales inversely with distance from Sun
     const perihelion = comet.semiMajorAxis * (1 - comet.eccentricity);
     const tailScale = Math.min(1, perihelion / radius);
     const dynamicTail = comet.tailLength * tailScale;
-    renderCometBody(svg, cx, cy, comet, CENTER, CENTER, dynamicTail);
+    renderCometBody(svg, cx, cy, comet, CENTER, CENTER, dynamicTail, colors);
     positions.push({ name: comet.name, x: cx, y: cy, color: comet.color });
     expandBounds(bounds, cx, cy, comet.size + dynamicTail);
   }
@@ -1109,12 +1158,12 @@ function renderSolarSystem(date, hemisphere = "north", locationData = null) {
   const earthAngle = calculatePlanetPosition(earth, date);
   const earthPixelRadius = auToRadius(earth.au);
   const earthX = CENTER + earthPixelRadius * Math.cos(earthAngle);
-  const earthY = CENTER - earthPixelRadius * Math.sin(earthAngle);
+  const earthY = CENTER + eclipticViewDirection * earthPixelRadius * Math.sin(earthAngle);
 
   const moonAngle = calculateMoonPosition(date);
   const moonPixelOffset = 22; // pixels from Earth
   const moonX = earthX + moonPixelOffset * Math.cos(moonAngle);
-  const moonY = earthY - moonPixelOffset * Math.sin(moonAngle);
+  const moonY = earthY + eclipticViewDirection * moonPixelOffset * Math.sin(moonAngle);
   positions.push({ name: MOON.name, x: moonX, y: moonY, color: MOON.color, offscreen: false });
 
   // Moon orbit (dotted circle centered on Earth)
@@ -1124,13 +1173,13 @@ function renderSolarSystem(date, hemisphere = "north", locationData = null) {
       cy: earthY,
       r: moonPixelOffset,
       fill: "none",
-      stroke: ORBIT_COLOR$1,
+      stroke: orbitColor,
       "stroke-width": 0.5,
       "stroke-dasharray": "2, 3",
     })
   );
 
-  renderBody(svg, moonX, moonY, MOON, false);
+  renderBody(svg, moonX, moonY, MOON, false, colors);
   expandBounds(bounds, moonX, moonY, MOON.size + 17);
 
   // Observer needle on Earth (tip at surface)
@@ -1140,7 +1189,7 @@ function renderSolarSystem(date, hemisphere = "north", locationData = null) {
     locationData?.timezone,
     locationData?.lon
   );
-  renderObserverNeedle(svg, earthX, earthY, observerAngle, earth.size);
+  renderObserverNeedle(svg, earthX, earthY, observerAngle, earth.size, eclipticViewDirection);
 
   // Moon phase indicator (rendered last so it appears on top)
   renderMoonPhaseIndicator(svg, date, hemisphere);
@@ -1308,7 +1357,7 @@ const CARD_STYLES = `
     display: block;
   }
   .card {
-    background: transparent;
+    background: #090909;
     border-radius: 0px;
     padding: 0px;
     color: #ffffff;
@@ -1329,7 +1378,7 @@ const CARD_STYLES = `
     left: 0;
     right: 0;
     background: rgba(42, 42, 42, 0.3);
-    font-size: 9px;
+    font-size: 10px;
     color: rgba(255, 255, 255, 0.85);
     display: flex;
     justify-content: space-between;
@@ -1363,6 +1412,7 @@ const CARD_STYLES = `
     align-items: center;
     gap: 4px;
     margin-top: 2px;
+    position: relative;
   }
   .nav button {
     background: rgba(42, 42, 42, 0.3);
@@ -1414,9 +1464,10 @@ const CARD_STYLES = `
   .card-version {
     font-size: 9px;
     color: rgba(255, 255, 255, 0.3);
-    margin-left: 4px;
     user-select: none;
     font-family: sans-serif;
+    position: absolute;
+    right: 0;
   }
 `;
 
@@ -1650,6 +1701,12 @@ class ZoomAnimator {
   }
 }
 
+const DEFAULT_COLORS = {
+  background: "#090909",
+  orbit: "rgba(255, 255, 255, 0.12)",
+  label: "#ffffff",
+};
+
 class SolarViewCard extends HTMLElement {
   constructor() {
     super();
@@ -1663,6 +1720,7 @@ class SolarViewCard extends HTMLElement {
     this._timezone = null;
     this._locationName = null;
     this._autoUpdateTimer = null; // Auto-update timer
+    this._colors = { ...DEFAULT_COLORS };
   }
 
   // ---------------------------------------------------------------------------
@@ -1719,6 +1777,14 @@ class SolarViewCard extends HTMLElement {
     this._periodicZoomMax =
       Number.isInteger(rawMax) && rawMax >= 2 && rawMax <= MAX_ZOOM ? rawMax : MAX_ZOOM;
     this._zoomAnimate = config.zoom_animate !== false;
+
+    this._colors = {
+      background: config.colors?.background ?? DEFAULT_COLORS.background,
+      orbit: config.colors?.orbit ?? DEFAULT_COLORS.orbit,
+      label: config.colors?.label ?? DEFAULT_COLORS.label,
+    };
+
+    this._eclipticView = config.ecliptic_view === true;
 
     // Recreate timer if already connected
     if (this._autoUpdateTimer != null) {
@@ -1864,8 +1930,16 @@ class SolarViewCard extends HTMLElement {
       this._viewState.zoomLevel
     );
 
+    this.shadowRoot.querySelector(".card").style.background = this._colors.background;
+
     const container = this.shadowRoot.getElementById("solar-view");
-    const { svg, positions } = renderSolarSystem(this._currentDate, this._hemisphere, locationData);
+    const { svg, positions } = renderSolarSystem(
+      this._currentDate,
+      this._hemisphere,
+      locationData,
+      this._colors,
+      this._eclipticView
+    );
     this._positions = positions;
     container.appendChild(svg);
 
@@ -1936,6 +2010,11 @@ class SolarViewCard extends HTMLElement {
       periodic_zoom_max: 4,
       refresh_mins: 1,
       zoom_animate: true,
+      colors: {
+        background: DEFAULT_COLORS.background,
+        orbit: DEFAULT_COLORS.orbit,
+        label: DEFAULT_COLORS.label,
+      },
     };
   }
 }

--- a/src/card/card-styles.js
+++ b/src/card/card-styles.js
@@ -1,6 +1,7 @@
 export const CARD_STYLES = `
   :host {
     display: block;
+    background: #090909;
   }
   .card {
     background: #090909;

--- a/src/card/card.js
+++ b/src/card/card.js
@@ -87,6 +87,8 @@ export class SolarViewCard extends HTMLElement {
       label: config.colors?.label ?? DEFAULT_COLORS.label,
     };
 
+    this._flipView = config.flip_view === true;
+
     // Recreate timer if already connected
     if (this._autoUpdateTimer != null) {
       this._startAutoUpdateTimer();
@@ -238,7 +240,8 @@ export class SolarViewCard extends HTMLElement {
       this._currentDate,
       this._hemisphere,
       locationData,
-      this._colors
+      this._colors,
+      this._flipView
     );
     this._positions = positions;
     container.appendChild(svg);

--- a/src/card/card.js
+++ b/src/card/card.js
@@ -87,7 +87,7 @@ export class SolarViewCard extends HTMLElement {
       label: config.colors?.label ?? DEFAULT_COLORS.label,
     };
 
-    this._southEclipticPole = config.south_ecliptic_pole === true;
+    this._eclipticView = config.ecliptic_view === true;
 
     // Recreate timer if already connected
     if (this._autoUpdateTimer != null) {
@@ -241,7 +241,7 @@ export class SolarViewCard extends HTMLElement {
       this._hemisphere,
       locationData,
       this._colors,
-      this._southEclipticPole
+      this._eclipticView
     );
     this._positions = positions;
     container.appendChild(svg);

--- a/src/card/card.js
+++ b/src/card/card.js
@@ -233,6 +233,7 @@ export class SolarViewCard extends HTMLElement {
       this._viewState.zoomLevel
     );
 
+    this.style.background = this._colors.background;
     this.shadowRoot.querySelector(".card").style.background = this._colors.background;
 
     const container = this.shadowRoot.getElementById("solar-view");

--- a/src/card/card.js
+++ b/src/card/card.js
@@ -87,7 +87,7 @@ export class SolarViewCard extends HTMLElement {
       label: config.colors?.label ?? DEFAULT_COLORS.label,
     };
 
-    this._flipView = config.flip_view === true;
+    this._southEclipticPole = config.south_ecliptic_pole === true;
 
     // Recreate timer if already connected
     if (this._autoUpdateTimer != null) {
@@ -241,7 +241,7 @@ export class SolarViewCard extends HTMLElement {
       this._hemisphere,
       locationData,
       this._colors,
-      this._flipView
+      this._southEclipticPole
     );
     this._positions = positions;
     container.appendChild(svg);

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -25,9 +25,9 @@ export function renderSolarSystem(
   hemisphere = "north",
   locationData = null,
   colors = {},
-  flipView = false
+  southEclipticPole = false
 ) {
-  const yDir = flipView ? 1 : -1;
+  const eclipticSign = southEclipticPole ? 1 : -1;
   const orbitColor = colors.orbit ?? ORBIT_COLOR;
   const labelColor = colors.label ?? "#ffffff";
 
@@ -44,10 +44,10 @@ export function renderSolarSystem(
   // Day/night split (rendered first, behind everything)
   const earth = PLANETS.find((p) => p.name === "Earth");
   const earthRadius = auToRadius(1.0);
-  renderDayNightSplit(svg, earthRadius, date, earth.size, locationData, yDir);
+  renderDayNightSplit(svg, earthRadius, date, earth.size, locationData, eclipticSign);
 
   // Season quadrant overlay (after day/night, before orbits)
-  renderSeasonOverlay(svg, hemisphere, colors, yDir);
+  renderSeasonOverlay(svg, hemisphere, colors, eclipticSign);
 
   // Draw orbits (planets then comets, so all orbits are behind bodies)
   for (const planet of PLANETS) {
@@ -67,7 +67,7 @@ export function renderSolarSystem(
     const angle = calculatePlanetPosition(planet, date);
     const radius = auToRadius(planet.au);
     const x = CENTER + radius * Math.cos(angle);
-    const y = CENTER + yDir * radius * Math.sin(angle);
+    const y = CENTER + eclipticSign * radius * Math.sin(angle);
     positions.push({ name: planet.name, x, y, color: planet.color });
     if (planet.name === "Saturn") {
       // Shrink Saturn's body to make room for top-down circular ring
@@ -102,7 +102,7 @@ export function renderSolarSystem(
     const { aPx, ePx } = computeCometVisualEllipse(comet);
     const rPx = (aPx * (1 - ePx * ePx)) / (1 + ePx * Math.cos(trueAnomaly));
     const cx = CENTER + rPx * Math.cos(angle);
-    const cy = CENTER + yDir * rPx * Math.sin(angle);
+    const cy = CENTER + eclipticSign * rPx * Math.sin(angle);
     // Tail scales inversely with distance from Sun
     const perihelion = comet.semiMajorAxis * (1 - comet.eccentricity);
     const tailScale = Math.min(1, perihelion / radius);
@@ -116,12 +116,12 @@ export function renderSolarSystem(
   const earthAngle = calculatePlanetPosition(earth, date);
   const earthPixelRadius = auToRadius(earth.au);
   const earthX = CENTER + earthPixelRadius * Math.cos(earthAngle);
-  const earthY = CENTER + yDir * earthPixelRadius * Math.sin(earthAngle);
+  const earthY = CENTER + eclipticSign * earthPixelRadius * Math.sin(earthAngle);
 
   const moonAngle = calculateMoonPosition(date);
   const moonPixelOffset = 22; // pixels from Earth
   const moonX = earthX + moonPixelOffset * Math.cos(moonAngle);
-  const moonY = earthY + yDir * moonPixelOffset * Math.sin(moonAngle);
+  const moonY = earthY + eclipticSign * moonPixelOffset * Math.sin(moonAngle);
   positions.push({ name: MOON.name, x: moonX, y: moonY, color: MOON.color, offscreen: false });
 
   // Moon orbit (dotted circle centered on Earth)
@@ -147,7 +147,7 @@ export function renderSolarSystem(
     locationData?.timezone,
     locationData?.lon
   );
-  renderObserverNeedle(svg, earthX, earthY, observerAngle, earth.size, yDir);
+  renderObserverNeedle(svg, earthX, earthY, observerAngle, earth.size, eclipticSign);
 
   // Moon phase indicator (rendered last so it appears on top)
   renderMoonPhaseIndicator(svg, date, hemisphere);

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -20,7 +20,14 @@ import { auToRadius, CENTER, createSvgElement, expandBounds, VIEW_SIZE } from ".
  * @param {{ background?: string, orbit?: string, label?: string, seasonLine?: string, seasonLabel?: string }} [colors] - optional color overrides
  * @returns {{ svg: SVGElement, bounds: { minX: number, minY: number, maxX: number, maxY: number } }}
  */
-export function renderSolarSystem(date, hemisphere = "north", locationData = null, colors = {}) {
+export function renderSolarSystem(
+  date,
+  hemisphere = "north",
+  locationData = null,
+  colors = {},
+  flipView = false
+) {
+  const yDir = flipView ? 1 : -1;
   const orbitColor = colors.orbit ?? ORBIT_COLOR;
   const labelColor = colors.label ?? "#ffffff";
 
@@ -37,10 +44,10 @@ export function renderSolarSystem(date, hemisphere = "north", locationData = nul
   // Day/night split (rendered first, behind everything)
   const earth = PLANETS.find((p) => p.name === "Earth");
   const earthRadius = auToRadius(1.0);
-  renderDayNightSplit(svg, earthRadius, date, earth.size, locationData);
+  renderDayNightSplit(svg, earthRadius, date, earth.size, locationData, yDir);
 
   // Season quadrant overlay (after day/night, before orbits)
-  renderSeasonOverlay(svg, hemisphere, colors);
+  renderSeasonOverlay(svg, hemisphere, colors, yDir);
 
   // Draw orbits (planets then comets, so all orbits are behind bodies)
   for (const planet of PLANETS) {
@@ -60,7 +67,7 @@ export function renderSolarSystem(date, hemisphere = "north", locationData = nul
     const angle = calculatePlanetPosition(planet, date);
     const radius = auToRadius(planet.au);
     const x = CENTER + radius * Math.cos(angle);
-    const y = CENTER - radius * Math.sin(angle);
+    const y = CENTER + yDir * radius * Math.sin(angle);
     positions.push({ name: planet.name, x, y, color: planet.color });
     if (planet.name === "Saturn") {
       // Shrink Saturn's body to make room for top-down circular ring
@@ -95,7 +102,7 @@ export function renderSolarSystem(date, hemisphere = "north", locationData = nul
     const { aPx, ePx } = computeCometVisualEllipse(comet);
     const rPx = (aPx * (1 - ePx * ePx)) / (1 + ePx * Math.cos(trueAnomaly));
     const cx = CENTER + rPx * Math.cos(angle);
-    const cy = CENTER - rPx * Math.sin(angle);
+    const cy = CENTER + yDir * rPx * Math.sin(angle);
     // Tail scales inversely with distance from Sun
     const perihelion = comet.semiMajorAxis * (1 - comet.eccentricity);
     const tailScale = Math.min(1, perihelion / radius);
@@ -109,12 +116,12 @@ export function renderSolarSystem(date, hemisphere = "north", locationData = nul
   const earthAngle = calculatePlanetPosition(earth, date);
   const earthPixelRadius = auToRadius(earth.au);
   const earthX = CENTER + earthPixelRadius * Math.cos(earthAngle);
-  const earthY = CENTER - earthPixelRadius * Math.sin(earthAngle);
+  const earthY = CENTER + yDir * earthPixelRadius * Math.sin(earthAngle);
 
   const moonAngle = calculateMoonPosition(date);
   const moonPixelOffset = 22; // pixels from Earth
   const moonX = earthX + moonPixelOffset * Math.cos(moonAngle);
-  const moonY = earthY - moonPixelOffset * Math.sin(moonAngle);
+  const moonY = earthY + yDir * moonPixelOffset * Math.sin(moonAngle);
   positions.push({ name: MOON.name, x: moonX, y: moonY, color: MOON.color, offscreen: false });
 
   // Moon orbit (dotted circle centered on Earth)
@@ -140,7 +147,7 @@ export function renderSolarSystem(date, hemisphere = "north", locationData = nul
     locationData?.timezone,
     locationData?.lon
   );
-  renderObserverNeedle(svg, earthX, earthY, observerAngle, earth.size);
+  renderObserverNeedle(svg, earthX, earthY, observerAngle, earth.size, yDir);
 
   // Moon phase indicator (rendered last so it appears on top)
   renderMoonPhaseIndicator(svg, date, hemisphere);

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -25,9 +25,9 @@ export function renderSolarSystem(
   hemisphere = "north",
   locationData = null,
   colors = {},
-  southEclipticPole = false
+  eclipticView = false
 ) {
-  const eclipticSign = southEclipticPole ? 1 : -1;
+  const eclipticViewDirection = eclipticView ? 1 : -1;
   const orbitColor = colors.orbit ?? ORBIT_COLOR;
   const labelColor = colors.label ?? "#ffffff";
 
@@ -44,10 +44,10 @@ export function renderSolarSystem(
   // Day/night split (rendered first, behind everything)
   const earth = PLANETS.find((p) => p.name === "Earth");
   const earthRadius = auToRadius(1.0);
-  renderDayNightSplit(svg, earthRadius, date, earth.size, locationData, eclipticSign);
+  renderDayNightSplit(svg, earthRadius, date, earth.size, locationData, eclipticViewDirection);
 
   // Season quadrant overlay (after day/night, before orbits)
-  renderSeasonOverlay(svg, hemisphere, colors, eclipticSign);
+  renderSeasonOverlay(svg, hemisphere, colors, eclipticViewDirection);
 
   // Draw orbits (planets then comets, so all orbits are behind bodies)
   for (const planet of PLANETS) {
@@ -67,7 +67,7 @@ export function renderSolarSystem(
     const angle = calculatePlanetPosition(planet, date);
     const radius = auToRadius(planet.au);
     const x = CENTER + radius * Math.cos(angle);
-    const y = CENTER + eclipticSign * radius * Math.sin(angle);
+    const y = CENTER + eclipticViewDirection * radius * Math.sin(angle);
     positions.push({ name: planet.name, x, y, color: planet.color });
     if (planet.name === "Saturn") {
       // Shrink Saturn's body to make room for top-down circular ring
@@ -102,7 +102,7 @@ export function renderSolarSystem(
     const { aPx, ePx } = computeCometVisualEllipse(comet);
     const rPx = (aPx * (1 - ePx * ePx)) / (1 + ePx * Math.cos(trueAnomaly));
     const cx = CENTER + rPx * Math.cos(angle);
-    const cy = CENTER + eclipticSign * rPx * Math.sin(angle);
+    const cy = CENTER + eclipticViewDirection * rPx * Math.sin(angle);
     // Tail scales inversely with distance from Sun
     const perihelion = comet.semiMajorAxis * (1 - comet.eccentricity);
     const tailScale = Math.min(1, perihelion / radius);
@@ -116,12 +116,12 @@ export function renderSolarSystem(
   const earthAngle = calculatePlanetPosition(earth, date);
   const earthPixelRadius = auToRadius(earth.au);
   const earthX = CENTER + earthPixelRadius * Math.cos(earthAngle);
-  const earthY = CENTER + eclipticSign * earthPixelRadius * Math.sin(earthAngle);
+  const earthY = CENTER + eclipticViewDirection * earthPixelRadius * Math.sin(earthAngle);
 
   const moonAngle = calculateMoonPosition(date);
   const moonPixelOffset = 22; // pixels from Earth
   const moonX = earthX + moonPixelOffset * Math.cos(moonAngle);
-  const moonY = earthY + eclipticSign * moonPixelOffset * Math.sin(moonAngle);
+  const moonY = earthY + eclipticViewDirection * moonPixelOffset * Math.sin(moonAngle);
   positions.push({ name: MOON.name, x: moonX, y: moonY, color: MOON.color, offscreen: false });
 
   // Moon orbit (dotted circle centered on Earth)
@@ -147,7 +147,7 @@ export function renderSolarSystem(
     locationData?.timezone,
     locationData?.lon
   );
-  renderObserverNeedle(svg, earthX, earthY, observerAngle, earth.size, eclipticSign);
+  renderObserverNeedle(svg, earthX, earthY, observerAngle, earth.size, eclipticViewDirection);
 
   // Moon phase indicator (rendered last so it appears on top)
   renderMoonPhaseIndicator(svg, date, hemisphere);

--- a/src/renderer/observer.js
+++ b/src/renderer/observer.js
@@ -77,7 +77,8 @@ function renderVisibilityCone(
   observerAngle,
   halfAngleDeg,
   clipId,
-  fillColor
+  fillColor,
+  yDir = -1
 ) {
   const D = VIEW_SIZE;
   const HALF_ANGLE = (halfAngleDeg * Math.PI) / 180;
@@ -87,9 +88,9 @@ function renderVisibilityCone(
   const leftAngle = observerAngle + HALF_ANGLE;
   const rightAngle = observerAngle - HALF_ANGLE;
   const leftX = anchorX + D * Math.cos(leftAngle);
-  const leftY = anchorY - D * Math.sin(leftAngle);
+  const leftY = anchorY + yDir * D * Math.sin(leftAngle);
   const rightX = anchorX + D * Math.cos(rightAngle);
-  const rightY = anchorY - D * Math.sin(rightAngle);
+  const rightY = anchorY + yDir * D * Math.sin(rightAngle);
 
   // SVG path: MoveTo apex, LineTo left edge, Arc to right edge, ClosePath
   const pathD = `M ${anchorX} ${anchorY} L ${leftX} ${leftY} A ${D} ${D} 0 ${largeArcFlag} 1 ${rightX} ${rightY} Z`;
@@ -112,7 +113,14 @@ function renderVisibilityCone(
   );
 }
 
-export function renderDayNightSplit(svg, earthRadius, date, earthBodySize, locationData) {
+export function renderDayNightSplit(
+  svg,
+  earthRadius,
+  date,
+  earthBodySize,
+  locationData,
+  yDir = -1
+) {
   const earth = PLANETS.find((p) => p.name === "Earth");
   const earthAngle = calculatePlanetPosition(earth, date);
   const observerAngle = calculateObserverAngle(
@@ -129,9 +137,9 @@ export function renderDayNightSplit(svg, earthRadius, date, earthBodySize, locat
 
   // Anchor point at Earth's surface
   const earthOrbitalX = CENTER + earthRadius * earthDirX;
-  const earthOrbitalY = CENTER - earthRadius * earthDirY;
+  const earthOrbitalY = CENTER + yDir * earthRadius * earthDirY;
   const anchorX = earthOrbitalX + earthBodySize * obsDirX;
-  const anchorY = earthOrbitalY - earthBodySize * obsDirY;
+  const anchorY = earthOrbitalY + yDir * earthBodySize * obsDirY;
 
   // Filled cone — colour determined by which twilight phase the solar elevation falls in.
   // Half-angle = 90° − elevationDeg expands the cone below the horizon during twilight.
@@ -148,7 +156,16 @@ export function renderDayNightSplit(svg, earthRadius, date, earthBodySize, locat
   else if (elevationDeg >= -18) coneColor = CONE_ASTRONOMICAL;
   else coneColor = CONE_NIGHT;
   const halfAngle = elevationDeg >= 0 || elevationDeg < -18 ? 90 : 90 - elevationDeg;
-  renderVisibilityCone(svg, anchorX, anchorY, observerAngle, halfAngle, "sky-clip", coneColor);
+  renderVisibilityCone(
+    svg,
+    anchorX,
+    anchorY,
+    observerAngle,
+    halfAngle,
+    "sky-clip",
+    coneColor,
+    yDir
+  );
 
   // Shared constants for horizon and zenith lines
   const CLIP_R = MAX_RADIUS + 30;
@@ -167,7 +184,7 @@ export function renderDayNightSplit(svg, earthRadius, date, earthBodySize, locat
       anchorX,
       anchorY,
       Math.cos(leftAngle),
-      -Math.sin(leftAngle),
+      yDir * Math.sin(leftAngle),
       CENTER,
       CENTER,
       CLIP_R
@@ -177,7 +194,7 @@ export function renderDayNightSplit(svg, earthRadius, date, earthBodySize, locat
       anchorX,
       anchorY,
       Math.cos(rightAngle),
-      -Math.sin(rightAngle),
+      yDir * Math.sin(rightAngle),
       CENTER,
       CENTER,
       CLIP_R
@@ -186,9 +203,9 @@ export function renderDayNightSplit(svg, earthRadius, date, earthBodySize, locat
     createSvgElement("line", {
       ...lineStyle,
       x1: anchorX + leftD * Math.cos(leftAngle),
-      y1: anchorY - leftD * Math.sin(leftAngle),
+      y1: anchorY + yDir * leftD * Math.sin(leftAngle),
       x2: anchorX + rightD * Math.cos(rightAngle),
-      y2: anchorY - rightD * Math.sin(rightAngle),
+      y2: anchorY + yDir * rightD * Math.sin(rightAngle),
     })
   );
 
@@ -198,7 +215,7 @@ export function renderDayNightSplit(svg, earthRadius, date, earthBodySize, locat
       anchorX,
       anchorY,
       Math.cos(observerAngle),
-      -Math.sin(observerAngle),
+      yDir * Math.sin(observerAngle),
       CENTER,
       CENTER,
       CLIP_R
@@ -209,14 +226,14 @@ export function renderDayNightSplit(svg, earthRadius, date, earthBodySize, locat
       x1: anchorX,
       y1: anchorY,
       x2: anchorX + zenithD * Math.cos(observerAngle),
-      y2: anchorY - zenithD * Math.sin(observerAngle),
+      y2: anchorY + yDir * zenithD * Math.sin(observerAngle),
     })
   );
 }
 
-export function renderObserverNeedle(svg, earthX, earthY, observerAngle, earthSize) {
+export function renderObserverNeedle(svg, earthX, earthY, observerAngle, earthSize, yDir = -1) {
   const tipX = earthX + earthSize * Math.cos(observerAngle);
-  const tipY = earthY - earthSize * Math.sin(observerAngle);
+  const tipY = earthY + yDir * earthSize * Math.sin(observerAngle);
 
   svg.appendChild(
     createSvgElement("line", {

--- a/src/renderer/observer.js
+++ b/src/renderer/observer.js
@@ -78,7 +78,7 @@ function renderVisibilityCone(
   halfAngleDeg,
   clipId,
   fillColor,
-  yDir = -1
+  eclipticSign = -1
 ) {
   const D = VIEW_SIZE;
   const HALF_ANGLE = (halfAngleDeg * Math.PI) / 180;
@@ -88,9 +88,9 @@ function renderVisibilityCone(
   const leftAngle = observerAngle + HALF_ANGLE;
   const rightAngle = observerAngle - HALF_ANGLE;
   const leftX = anchorX + D * Math.cos(leftAngle);
-  const leftY = anchorY + yDir * D * Math.sin(leftAngle);
+  const leftY = anchorY + eclipticSign * D * Math.sin(leftAngle);
   const rightX = anchorX + D * Math.cos(rightAngle);
-  const rightY = anchorY + yDir * D * Math.sin(rightAngle);
+  const rightY = anchorY + eclipticSign * D * Math.sin(rightAngle);
 
   // SVG path: MoveTo apex, LineTo left edge, Arc to right edge, ClosePath
   const pathD = `M ${anchorX} ${anchorY} L ${leftX} ${leftY} A ${D} ${D} 0 ${largeArcFlag} 1 ${rightX} ${rightY} Z`;
@@ -119,7 +119,7 @@ export function renderDayNightSplit(
   date,
   earthBodySize,
   locationData,
-  yDir = -1
+  eclipticSign = -1
 ) {
   const earth = PLANETS.find((p) => p.name === "Earth");
   const earthAngle = calculatePlanetPosition(earth, date);
@@ -137,9 +137,9 @@ export function renderDayNightSplit(
 
   // Anchor point at Earth's surface
   const earthOrbitalX = CENTER + earthRadius * earthDirX;
-  const earthOrbitalY = CENTER + yDir * earthRadius * earthDirY;
+  const earthOrbitalY = CENTER + eclipticSign * earthRadius * earthDirY;
   const anchorX = earthOrbitalX + earthBodySize * obsDirX;
-  const anchorY = earthOrbitalY + yDir * earthBodySize * obsDirY;
+  const anchorY = earthOrbitalY + eclipticSign * earthBodySize * obsDirY;
 
   // Filled cone — colour determined by which twilight phase the solar elevation falls in.
   // Half-angle = 90° − elevationDeg expands the cone below the horizon during twilight.
@@ -164,7 +164,7 @@ export function renderDayNightSplit(
     halfAngle,
     "sky-clip",
     coneColor,
-    yDir
+    eclipticSign
   );
 
   // Shared constants for horizon and zenith lines
@@ -184,7 +184,7 @@ export function renderDayNightSplit(
       anchorX,
       anchorY,
       Math.cos(leftAngle),
-      yDir * Math.sin(leftAngle),
+      eclipticSign * Math.sin(leftAngle),
       CENTER,
       CENTER,
       CLIP_R
@@ -194,7 +194,7 @@ export function renderDayNightSplit(
       anchorX,
       anchorY,
       Math.cos(rightAngle),
-      yDir * Math.sin(rightAngle),
+      eclipticSign * Math.sin(rightAngle),
       CENTER,
       CENTER,
       CLIP_R
@@ -203,9 +203,9 @@ export function renderDayNightSplit(
     createSvgElement("line", {
       ...lineStyle,
       x1: anchorX + leftD * Math.cos(leftAngle),
-      y1: anchorY + yDir * leftD * Math.sin(leftAngle),
+      y1: anchorY + eclipticSign * leftD * Math.sin(leftAngle),
       x2: anchorX + rightD * Math.cos(rightAngle),
-      y2: anchorY + yDir * rightD * Math.sin(rightAngle),
+      y2: anchorY + eclipticSign * rightD * Math.sin(rightAngle),
     })
   );
 
@@ -215,7 +215,7 @@ export function renderDayNightSplit(
       anchorX,
       anchorY,
       Math.cos(observerAngle),
-      yDir * Math.sin(observerAngle),
+      eclipticSign * Math.sin(observerAngle),
       CENTER,
       CENTER,
       CLIP_R
@@ -226,14 +226,21 @@ export function renderDayNightSplit(
       x1: anchorX,
       y1: anchorY,
       x2: anchorX + zenithD * Math.cos(observerAngle),
-      y2: anchorY + yDir * zenithD * Math.sin(observerAngle),
+      y2: anchorY + eclipticSign * zenithD * Math.sin(observerAngle),
     })
   );
 }
 
-export function renderObserverNeedle(svg, earthX, earthY, observerAngle, earthSize, yDir = -1) {
+export function renderObserverNeedle(
+  svg,
+  earthX,
+  earthY,
+  observerAngle,
+  earthSize,
+  eclipticSign = -1
+) {
   const tipX = earthX + earthSize * Math.cos(observerAngle);
-  const tipY = earthY + yDir * earthSize * Math.sin(observerAngle);
+  const tipY = earthY + eclipticSign * earthSize * Math.sin(observerAngle);
 
   svg.appendChild(
     createSvgElement("line", {

--- a/src/renderer/observer.js
+++ b/src/renderer/observer.js
@@ -78,7 +78,7 @@ function renderVisibilityCone(
   halfAngleDeg,
   clipId,
   fillColor,
-  eclipticSign = -1
+  eclipticViewDirection = -1
 ) {
   const D = VIEW_SIZE;
   const HALF_ANGLE = (halfAngleDeg * Math.PI) / 180;
@@ -88,9 +88,9 @@ function renderVisibilityCone(
   const leftAngle = observerAngle + HALF_ANGLE;
   const rightAngle = observerAngle - HALF_ANGLE;
   const leftX = anchorX + D * Math.cos(leftAngle);
-  const leftY = anchorY + eclipticSign * D * Math.sin(leftAngle);
+  const leftY = anchorY + eclipticViewDirection * D * Math.sin(leftAngle);
   const rightX = anchorX + D * Math.cos(rightAngle);
-  const rightY = anchorY + eclipticSign * D * Math.sin(rightAngle);
+  const rightY = anchorY + eclipticViewDirection * D * Math.sin(rightAngle);
 
   // SVG path: MoveTo apex, LineTo left edge, Arc to right edge, ClosePath
   const pathD = `M ${anchorX} ${anchorY} L ${leftX} ${leftY} A ${D} ${D} 0 ${largeArcFlag} 1 ${rightX} ${rightY} Z`;
@@ -119,7 +119,7 @@ export function renderDayNightSplit(
   date,
   earthBodySize,
   locationData,
-  eclipticSign = -1
+  eclipticViewDirection = -1
 ) {
   const earth = PLANETS.find((p) => p.name === "Earth");
   const earthAngle = calculatePlanetPosition(earth, date);
@@ -137,9 +137,9 @@ export function renderDayNightSplit(
 
   // Anchor point at Earth's surface
   const earthOrbitalX = CENTER + earthRadius * earthDirX;
-  const earthOrbitalY = CENTER + eclipticSign * earthRadius * earthDirY;
+  const earthOrbitalY = CENTER + eclipticViewDirection * earthRadius * earthDirY;
   const anchorX = earthOrbitalX + earthBodySize * obsDirX;
-  const anchorY = earthOrbitalY + eclipticSign * earthBodySize * obsDirY;
+  const anchorY = earthOrbitalY + eclipticViewDirection * earthBodySize * obsDirY;
 
   // Filled cone — colour determined by which twilight phase the solar elevation falls in.
   // Half-angle = 90° − elevationDeg expands the cone below the horizon during twilight.
@@ -164,7 +164,7 @@ export function renderDayNightSplit(
     halfAngle,
     "sky-clip",
     coneColor,
-    eclipticSign
+    eclipticViewDirection
   );
 
   // Shared constants for horizon and zenith lines
@@ -184,7 +184,7 @@ export function renderDayNightSplit(
       anchorX,
       anchorY,
       Math.cos(leftAngle),
-      eclipticSign * Math.sin(leftAngle),
+      eclipticViewDirection * Math.sin(leftAngle),
       CENTER,
       CENTER,
       CLIP_R
@@ -194,7 +194,7 @@ export function renderDayNightSplit(
       anchorX,
       anchorY,
       Math.cos(rightAngle),
-      eclipticSign * Math.sin(rightAngle),
+      eclipticViewDirection * Math.sin(rightAngle),
       CENTER,
       CENTER,
       CLIP_R
@@ -203,9 +203,9 @@ export function renderDayNightSplit(
     createSvgElement("line", {
       ...lineStyle,
       x1: anchorX + leftD * Math.cos(leftAngle),
-      y1: anchorY + eclipticSign * leftD * Math.sin(leftAngle),
+      y1: anchorY + eclipticViewDirection * leftD * Math.sin(leftAngle),
       x2: anchorX + rightD * Math.cos(rightAngle),
-      y2: anchorY + eclipticSign * rightD * Math.sin(rightAngle),
+      y2: anchorY + eclipticViewDirection * rightD * Math.sin(rightAngle),
     })
   );
 
@@ -215,7 +215,7 @@ export function renderDayNightSplit(
       anchorX,
       anchorY,
       Math.cos(observerAngle),
-      eclipticSign * Math.sin(observerAngle),
+      eclipticViewDirection * Math.sin(observerAngle),
       CENTER,
       CENTER,
       CLIP_R
@@ -226,7 +226,7 @@ export function renderDayNightSplit(
       x1: anchorX,
       y1: anchorY,
       x2: anchorX + zenithD * Math.cos(observerAngle),
-      y2: anchorY + eclipticSign * zenithD * Math.sin(observerAngle),
+      y2: anchorY + eclipticViewDirection * zenithD * Math.sin(observerAngle),
     })
   );
 }
@@ -237,10 +237,10 @@ export function renderObserverNeedle(
   earthY,
   observerAngle,
   earthSize,
-  eclipticSign = -1
+  eclipticViewDirection = -1
 ) {
   const tipX = earthX + earthSize * Math.cos(observerAngle);
-  const tipY = earthY + eclipticSign * earthSize * Math.sin(observerAngle);
+  const tipY = earthY + eclipticViewDirection * earthSize * Math.sin(observerAngle);
 
   svg.appendChild(
     createSvgElement("line", {

--- a/src/renderer/seasons.js
+++ b/src/renderer/seasons.js
@@ -4,7 +4,7 @@ const DEFAULT_SEASON_LINE_COLOR = "rgba(255, 255, 255, 0.25)";
 const DEFAULT_SEASON_LABEL_COLOR = "rgba(255, 255, 255, 0.5)";
 const SEASON_FONT_SIZE = 20;
 
-export function renderSeasonOverlay(svg, hemisphere, colors = {}, eclipticSign = -1) {
+export function renderSeasonOverlay(svg, hemisphere, colors = {}, eclipticViewDirection = -1) {
   const lineColor = colors.seasonLine ?? DEFAULT_SEASON_LINE_COLOR;
   const labelColor = colors.seasonLabel ?? DEFAULT_SEASON_LABEL_COLOR;
 
@@ -64,19 +64,19 @@ export function renderSeasonOverlay(svg, hemisphere, colors = {}, eclipticSign =
 
     // Top-half arcs (0–90° and 90–180°) render text upside-down because the
     // default arc sweeps right-to-left in SVG space. Reverse them so textPath
-    // flows left-to-right for readable labels. When the view is flipped (eclipticSign=1)
+    // flows left-to-right for readable labels. When the view is flipped (eclipticViewDirection=1)
     // the visual top/bottom halves swap, so invert the flag.
     const naturallyTopHalf =
       season.startAngle >= 0 && season.endAngle <= 180 && season.startAngle < 180;
-    const isTopHalf = eclipticSign === -1 ? naturallyTopHalf : !naturallyTopHalf;
+    const isTopHalf = eclipticViewDirection === -1 ? naturallyTopHalf : !naturallyTopHalf;
     // Use a smaller radius for top-half labels so they appear visually
     // at the same distance from Neptune's orbit as bottom-half labels
     const arcRadius = isTopHalf ? labelRadius - 12 : labelRadius;
 
     const x1 = CENTER + arcRadius * Math.cos(startRad);
-    const y1 = CENTER + eclipticSign * arcRadius * Math.sin(startRad);
+    const y1 = CENTER + eclipticViewDirection * arcRadius * Math.sin(startRad);
     const x2 = CENTER + arcRadius * Math.cos(endRad);
-    const y2 = CENTER + eclipticSign * arcRadius * Math.sin(endRad);
+    const y2 = CENTER + eclipticViewDirection * arcRadius * Math.sin(endRad);
 
     const arcPath = createSvgElement("path", {
       id: pathId,

--- a/src/renderer/seasons.js
+++ b/src/renderer/seasons.js
@@ -4,7 +4,7 @@ const DEFAULT_SEASON_LINE_COLOR = "rgba(255, 255, 255, 0.25)";
 const DEFAULT_SEASON_LABEL_COLOR = "rgba(255, 255, 255, 0.5)";
 const SEASON_FONT_SIZE = 20;
 
-export function renderSeasonOverlay(svg, hemisphere, colors = {}, yDir = -1) {
+export function renderSeasonOverlay(svg, hemisphere, colors = {}, eclipticSign = -1) {
   const lineColor = colors.seasonLine ?? DEFAULT_SEASON_LINE_COLOR;
   const labelColor = colors.seasonLabel ?? DEFAULT_SEASON_LABEL_COLOR;
 
@@ -64,19 +64,19 @@ export function renderSeasonOverlay(svg, hemisphere, colors = {}, yDir = -1) {
 
     // Top-half arcs (0–90° and 90–180°) render text upside-down because the
     // default arc sweeps right-to-left in SVG space. Reverse them so textPath
-    // flows left-to-right for readable labels. When the view is flipped (yDir=1)
+    // flows left-to-right for readable labels. When the view is flipped (eclipticSign=1)
     // the visual top/bottom halves swap, so invert the flag.
     const naturallyTopHalf =
       season.startAngle >= 0 && season.endAngle <= 180 && season.startAngle < 180;
-    const isTopHalf = yDir === -1 ? naturallyTopHalf : !naturallyTopHalf;
+    const isTopHalf = eclipticSign === -1 ? naturallyTopHalf : !naturallyTopHalf;
     // Use a smaller radius for top-half labels so they appear visually
     // at the same distance from Neptune's orbit as bottom-half labels
     const arcRadius = isTopHalf ? labelRadius - 12 : labelRadius;
 
     const x1 = CENTER + arcRadius * Math.cos(startRad);
-    const y1 = CENTER + yDir * arcRadius * Math.sin(startRad);
+    const y1 = CENTER + eclipticSign * arcRadius * Math.sin(startRad);
     const x2 = CENTER + arcRadius * Math.cos(endRad);
-    const y2 = CENTER + yDir * arcRadius * Math.sin(endRad);
+    const y2 = CENTER + eclipticSign * arcRadius * Math.sin(endRad);
 
     const arcPath = createSvgElement("path", {
       id: pathId,

--- a/src/renderer/seasons.js
+++ b/src/renderer/seasons.js
@@ -4,7 +4,7 @@ const DEFAULT_SEASON_LINE_COLOR = "rgba(255, 255, 255, 0.25)";
 const DEFAULT_SEASON_LABEL_COLOR = "rgba(255, 255, 255, 0.5)";
 const SEASON_FONT_SIZE = 20;
 
-export function renderSeasonOverlay(svg, hemisphere, colors = {}) {
+export function renderSeasonOverlay(svg, hemisphere, colors = {}, yDir = -1) {
   const lineColor = colors.seasonLine ?? DEFAULT_SEASON_LINE_COLOR;
   const labelColor = colors.seasonLabel ?? DEFAULT_SEASON_LABEL_COLOR;
 
@@ -64,16 +64,19 @@ export function renderSeasonOverlay(svg, hemisphere, colors = {}) {
 
     // Top-half arcs (0–90° and 90–180°) render text upside-down because the
     // default arc sweeps right-to-left in SVG space. Reverse them so textPath
-    // flows left-to-right for readable labels.
-    const isTopHalf = season.startAngle >= 0 && season.endAngle <= 180 && season.startAngle < 180;
+    // flows left-to-right for readable labels. When the view is flipped (yDir=1)
+    // the visual top/bottom halves swap, so invert the flag.
+    const naturallyTopHalf =
+      season.startAngle >= 0 && season.endAngle <= 180 && season.startAngle < 180;
+    const isTopHalf = yDir === -1 ? naturallyTopHalf : !naturallyTopHalf;
     // Use a smaller radius for top-half labels so they appear visually
     // at the same distance from Neptune's orbit as bottom-half labels
     const arcRadius = isTopHalf ? labelRadius - 12 : labelRadius;
 
     const x1 = CENTER + arcRadius * Math.cos(startRad);
-    const y1 = CENTER - arcRadius * Math.sin(startRad);
+    const y1 = CENTER + yDir * arcRadius * Math.sin(startRad);
     const x2 = CENTER + arcRadius * Math.cos(endRad);
-    const y2 = CENTER - arcRadius * Math.sin(endRad);
+    const y2 = CENTER + yDir * arcRadius * Math.sin(endRad);
 
     const arcPath = createSvgElement("path", {
       id: pathId,

--- a/test/card/card.test.js
+++ b/test/card/card.test.js
@@ -19,22 +19,22 @@ describe("SolarViewCard", () => {
     expect(card._config).toEqual({ title: "test" });
   });
 
-  it("flip_view defaults to false when not set", () => {
+  it("south_ecliptic_pole defaults to false when not set", () => {
     const card = document.createElement("ha-planetary-solar-system-card-test");
     card.setConfig({});
-    expect(card._flipView).toBe(false);
+    expect(card._southEclipticPole).toBe(false);
   });
 
-  it("flip_view is true when config.flip_view is true", () => {
+  it("south_ecliptic_pole is true when config.south_ecliptic_pole is true", () => {
     const card = document.createElement("ha-planetary-solar-system-card-test");
-    card.setConfig({ flip_view: true });
-    expect(card._flipView).toBe(true);
+    card.setConfig({ south_ecliptic_pole: true });
+    expect(card._southEclipticPole).toBe(true);
   });
 
-  it("flip_view coerces non-boolean truthy to false", () => {
+  it("south_ecliptic_pole coerces non-boolean truthy to false", () => {
     const card = document.createElement("ha-planetary-solar-system-card-test");
-    card.setConfig({ flip_view: 1 });
-    expect(card._flipView).toBe(false);
+    card.setConfig({ south_ecliptic_pole: 1 });
+    expect(card._southEclipticPole).toBe(false);
   });
 
   it("getCardSize returns 6", () => {

--- a/test/card/card.test.js
+++ b/test/card/card.test.js
@@ -19,6 +19,24 @@ describe("SolarViewCard", () => {
     expect(card._config).toEqual({ title: "test" });
   });
 
+  it("flip_view defaults to false when not set", () => {
+    const card = document.createElement("ha-planetary-solar-system-card-test");
+    card.setConfig({});
+    expect(card._flipView).toBe(false);
+  });
+
+  it("flip_view is true when config.flip_view is true", () => {
+    const card = document.createElement("ha-planetary-solar-system-card-test");
+    card.setConfig({ flip_view: true });
+    expect(card._flipView).toBe(true);
+  });
+
+  it("flip_view coerces non-boolean truthy to false", () => {
+    const card = document.createElement("ha-planetary-solar-system-card-test");
+    card.setConfig({ flip_view: 1 });
+    expect(card._flipView).toBe(false);
+  });
+
   it("getCardSize returns 6", () => {
     const card = document.createElement("ha-planetary-solar-system-card-test");
     expect(card.getCardSize()).toBe(6);

--- a/test/card/card.test.js
+++ b/test/card/card.test.js
@@ -19,22 +19,22 @@ describe("SolarViewCard", () => {
     expect(card._config).toEqual({ title: "test" });
   });
 
-  it("south_ecliptic_pole defaults to false when not set", () => {
+  it("ecliptic_view defaults to false when not set", () => {
     const card = document.createElement("ha-planetary-solar-system-card-test");
     card.setConfig({});
-    expect(card._southEclipticPole).toBe(false);
+    expect(card._eclipticView).toBe(false);
   });
 
-  it("south_ecliptic_pole is true when config.south_ecliptic_pole is true", () => {
+  it("ecliptic_view is true when config.ecliptic_view is true", () => {
     const card = document.createElement("ha-planetary-solar-system-card-test");
-    card.setConfig({ south_ecliptic_pole: true });
-    expect(card._southEclipticPole).toBe(true);
+    card.setConfig({ ecliptic_view: true });
+    expect(card._eclipticView).toBe(true);
   });
 
-  it("south_ecliptic_pole coerces non-boolean truthy to false", () => {
+  it("ecliptic_view coerces non-boolean truthy to false", () => {
     const card = document.createElement("ha-planetary-solar-system-card-test");
-    card.setConfig({ south_ecliptic_pole: 1 });
-    expect(card._southEclipticPole).toBe(false);
+    card.setConfig({ ecliptic_view: 1 });
+    expect(card._eclipticView).toBe(false);
   });
 
   it("getCardSize returns 6", () => {

--- a/test/renderer/index.test.js
+++ b/test/renderer/index.test.js
@@ -10,6 +10,7 @@ import {
   CONE_NIGHT,
   calculateObserverAngle,
 } from "../../src/renderer/observer.js";
+import { auToRadius } from "../../src/renderer/svg-utils.js";
 
 function renderInto(container, date) {
   const { svg, bounds } = renderSolarSystem(date);
@@ -612,5 +613,40 @@ describe("renderSolarSystem", () => {
     expect(indicator.querySelector("circle")).not.toBeNull();
     expect(indicator.querySelector("text")).not.toBeNull();
     expect(indicator.querySelector("text").textContent.length).toBeGreaterThan(0);
+  });
+});
+
+describe("renderSolarSystem flip_view", () => {
+  const DATE = new Date("2026-06-01");
+  const CENTER = 400;
+
+  function getEarthPosition(flipView) {
+    const { positions } = renderSolarSystem(DATE, "north", null, {}, flipView);
+    return positions.find((p) => p.name === "Earth");
+  }
+
+  it("planet Y-coordinates mirror around CENTER when flipped", () => {
+    const normal = getEarthPosition(false);
+    const flipped = getEarthPosition(true);
+    expect(normal.x).toBeCloseTo(flipped.x, 3);
+    expect(normal.y + flipped.y).toBeCloseTo(2 * CENTER, 3);
+  });
+
+  it("default (flipView=false) places planet at CENTER - radius*sin(angle)", () => {
+    const earth = PLANETS.find((p) => p.name === "Earth");
+    const angle = calculatePlanetPosition(earth, DATE);
+    const radius = auToRadius(earth.au);
+    const { positions } = renderSolarSystem(DATE, "north", null, {}, false);
+    const pos = positions.find((p) => p.name === "Earth");
+    expect(pos.y).toBeCloseTo(CENTER - radius * Math.sin(angle), 5);
+  });
+
+  it("flipped view produces a different Y for a planet not on the equator", () => {
+    const normal = getEarthPosition(false);
+    const flipped = getEarthPosition(true);
+    // Only equal if sin(angle) == 0 (planet on X-axis), extremely unlikely
+    if (Math.abs(normal.y - CENTER) > 0.5) {
+      expect(normal.y).not.toBeCloseTo(flipped.y, 1);
+    }
   });
 });

--- a/test/renderer/index.test.js
+++ b/test/renderer/index.test.js
@@ -616,12 +616,12 @@ describe("renderSolarSystem", () => {
   });
 });
 
-describe("renderSolarSystem flip_view", () => {
+describe("renderSolarSystem south_ecliptic_pole", () => {
   const DATE = new Date("2026-06-01");
   const CENTER = 400;
 
-  function getEarthPosition(flipView) {
-    const { positions } = renderSolarSystem(DATE, "north", null, {}, flipView);
+  function getEarthPosition(southEclipticPole) {
+    const { positions } = renderSolarSystem(DATE, "north", null, {}, southEclipticPole);
     return positions.find((p) => p.name === "Earth");
   }
 
@@ -632,7 +632,7 @@ describe("renderSolarSystem flip_view", () => {
     expect(normal.y + flipped.y).toBeCloseTo(2 * CENTER, 3);
   });
 
-  it("default (flipView=false) places planet at CENTER - radius*sin(angle)", () => {
+  it("default (southEclipticPole=false) places planet at CENTER - radius*sin(angle)", () => {
     const earth = PLANETS.find((p) => p.name === "Earth");
     const angle = calculatePlanetPosition(earth, DATE);
     const radius = auToRadius(earth.au);

--- a/test/renderer/index.test.js
+++ b/test/renderer/index.test.js
@@ -616,12 +616,12 @@ describe("renderSolarSystem", () => {
   });
 });
 
-describe("renderSolarSystem south_ecliptic_pole", () => {
+describe("renderSolarSystem ecliptic_view", () => {
   const DATE = new Date("2026-06-01");
   const CENTER = 400;
 
-  function getEarthPosition(southEclipticPole) {
-    const { positions } = renderSolarSystem(DATE, "north", null, {}, southEclipticPole);
+  function getEarthPosition(eclipticView) {
+    const { positions } = renderSolarSystem(DATE, "north", null, {}, eclipticView);
     return positions.find((p) => p.name === "Earth");
   }
 
@@ -632,7 +632,7 @@ describe("renderSolarSystem south_ecliptic_pole", () => {
     expect(normal.y + flipped.y).toBeCloseTo(2 * CENTER, 3);
   });
 
-  it("default (southEclipticPole=false) places planet at CENTER - radius*sin(angle)", () => {
+  it("default (eclipticView=false) places planet at CENTER - radius*sin(angle)", () => {
     const earth = PLANETS.find((p) => p.name === "Earth");
     const angle = calculatePlanetPosition(earth, DATE);
     const radius = auToRadius(earth.au);

--- a/test/renderer/observer.test.js
+++ b/test/renderer/observer.test.js
@@ -167,6 +167,45 @@ describe("renderObserverNeedle", () => {
     expect(dot.getAttribute("cx")).toBe(line.getAttribute("x2"));
     expect(dot.getAttribute("cy")).toBe(line.getAttribute("y2"));
   });
+
+  it("yDir=1 mirrors tip Y around earthY compared to yDir=-1", () => {
+    const earthY = 400;
+    const angle = Math.PI / 4;
+    const size = 20;
+
+    const svgNormal = createSvg();
+    renderObserverNeedle(svgNormal, 400, earthY, angle, size, -1);
+    const lineNormal = svgNormal.querySelector("line");
+
+    const svgFlipped = createSvg();
+    renderObserverNeedle(svgFlipped, 400, earthY, angle, size, 1);
+    const lineFlipped = svgFlipped.querySelector("line");
+
+    const y1 = Number(lineNormal.getAttribute("y2"));
+    const y2 = Number(lineFlipped.getAttribute("y2"));
+    expect(y1 + y2).toBeCloseTo(2 * earthY, 5);
+    expect(lineNormal.getAttribute("x2")).toBe(lineFlipped.getAttribute("x2"));
+  });
+});
+
+describe("renderDayNightSplit flip_view", () => {
+  it("yDir=1 mirrors anchor Y around CENTER compared to yDir=-1", () => {
+    const earth = PLANETS.find((p) => p.name === "Earth");
+    const date = new Date("2025-06-15T06:00:00Z");
+
+    const svgNormal = createSvg();
+    renderDayNightSplit(svgNormal, 200, date, earth.size, null, -1);
+    const pathNormal = svgNormal.querySelector("clipPath path");
+
+    const svgFlipped = createSvg();
+    renderDayNightSplit(svgFlipped, 200, date, earth.size, null, 1);
+    const pathFlipped = svgFlipped.querySelector("clipPath path");
+
+    // Anchor Y is the first pair of numbers in the path "M anchorX anchorY ..."
+    const anchorYNormal = Number(pathNormal.getAttribute("d").match(/[-\d.]+/g)[1]);
+    const anchorYFlipped = Number(pathFlipped.getAttribute("d").match(/[-\d.]+/g)[1]);
+    expect(anchorYNormal + anchorYFlipped).toBeCloseTo(2 * CENTER, 1);
+  });
 });
 
 describe("rayCircleDistance", () => {

--- a/test/renderer/observer.test.js
+++ b/test/renderer/observer.test.js
@@ -168,7 +168,7 @@ describe("renderObserverNeedle", () => {
     expect(dot.getAttribute("cy")).toBe(line.getAttribute("y2"));
   });
 
-  it("eclipticSign=1 mirrors tip Y around earthY compared to eclipticSign=-1", () => {
+  it("eclipticViewDirection=1 mirrors tip Y around earthY compared to eclipticViewDirection=-1", () => {
     const earthY = 400;
     const angle = Math.PI / 4;
     const size = 20;
@@ -189,7 +189,7 @@ describe("renderObserverNeedle", () => {
 });
 
 describe("renderDayNightSplit flip_view", () => {
-  it("eclipticSign=1 mirrors anchor Y around CENTER compared to eclipticSign=-1", () => {
+  it("eclipticViewDirection=1 mirrors anchor Y around CENTER compared to eclipticViewDirection=-1", () => {
     const earth = PLANETS.find((p) => p.name === "Earth");
     const date = new Date("2025-06-15T06:00:00Z");
 

--- a/test/renderer/observer.test.js
+++ b/test/renderer/observer.test.js
@@ -168,7 +168,7 @@ describe("renderObserverNeedle", () => {
     expect(dot.getAttribute("cy")).toBe(line.getAttribute("y2"));
   });
 
-  it("yDir=1 mirrors tip Y around earthY compared to yDir=-1", () => {
+  it("eclipticSign=1 mirrors tip Y around earthY compared to eclipticSign=-1", () => {
     const earthY = 400;
     const angle = Math.PI / 4;
     const size = 20;
@@ -189,7 +189,7 @@ describe("renderObserverNeedle", () => {
 });
 
 describe("renderDayNightSplit flip_view", () => {
-  it("yDir=1 mirrors anchor Y around CENTER compared to yDir=-1", () => {
+  it("eclipticSign=1 mirrors anchor Y around CENTER compared to eclipticSign=-1", () => {
     const earth = PLANETS.find((p) => p.name === "Earth");
     const date = new Date("2025-06-15T06:00:00Z");
 

--- a/test/renderer/seasons.test.js
+++ b/test/renderer/seasons.test.js
@@ -139,7 +139,7 @@ describe("renderSeasonOverlay fixed label radius", () => {
   });
 });
 
-describe("renderSeasonOverlay flip_view", () => {
+describe("renderSeasonOverlay south_ecliptic_pole", () => {
   function getArcPaths(svg) {
     return Array.from(svg.querySelectorAll("defs path")).map((p) => p.getAttribute("d"));
   }

--- a/test/renderer/seasons.test.js
+++ b/test/renderer/seasons.test.js
@@ -139,6 +139,32 @@ describe("renderSeasonOverlay fixed label radius", () => {
   });
 });
 
+describe("renderSeasonOverlay flip_view", () => {
+  function getArcPaths(svg) {
+    return Array.from(svg.querySelectorAll("defs path")).map((p) => p.getAttribute("d"));
+  }
+
+  it("flipped arc paths differ from normal arc paths", () => {
+    const svgNormal = createSvg();
+    renderSeasonOverlay(svgNormal, "north", {}, -1);
+    const normal = getArcPaths(svgNormal);
+
+    const svgFlipped = createSvg();
+    renderSeasonOverlay(svgFlipped, "north", {}, 1);
+    const flipped = getArcPaths(svgFlipped);
+
+    expect(normal.length).toBe(flipped.length);
+    const anyDiffers = normal.some((p, i) => p !== flipped[i]);
+    expect(anyDiffers).toBe(true);
+  });
+
+  it("still renders 4 season labels when flipped", () => {
+    const svg = createSvg();
+    renderSeasonOverlay(svg, "north", {}, 1);
+    expect(svg.querySelectorAll("textPath").length).toBe(4);
+  });
+});
+
 describe("getCurrentSeason", () => {
   it("northern hemisphere returns correct season for each quarter", () => {
     expect(getCurrentSeason(new Date("2025-03-15"), "north")).toBe("Spring");


### PR DESCRIPTION
## Summary

- Adds `flip_view` config option (`ecliptic_view: true/false`) to mirror the solar system Y-axis, useful for southern hemisphere users viewing the ecliptic from below
- Renames internal variables for clarity: `yDir` → `eclipticSign`, `flipView` → `southEclipticPole`, exposed config as `ecliptic_view` / `eclipticViewDirection`
- Fixes card background showing HA's themed blue: adds `background` to `:host` and applies configured color to the host element so `ha-card`'s wrapper color no longer bleeds through

## Test plan

- [ ] 418 unit tests pass (`npm test`)
- [ ] Card renders with `#090909` background in HA (no blue bleed-through)
- [ ] `ecliptic_view: true` flips the Y-axis in the solar system view
- [ ] Default behavior (no config) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)