### PR TITLE
chore: align version injection with teamtracker pattern

### DIFF
--- a/dist/card.js
+++ b/dist/card.js
@@ -1,3 +1,6 @@
+/* ha-planetary-solar-system-card v1.0.0 */
+const __CARD_VERSION__ = '1.0.0';
+
 // Orbital elements for comets at J2000 epoch
 // Sources: JPL Small-Body Database
 const COMETS = [
@@ -1472,8 +1475,6 @@ const CARD_STYLES = `
   }
 `;
 
-const CARD_VERSION = "1.0.0";
-
 /**
  * Build the status bar HTML fragment.
  *
@@ -1537,7 +1538,7 @@ function buildCardHtml(statusBarHtml, formattedDate, zoomLevel) {
           <span class="zoom-level">${zoomLevel}</span>
           <button data-action="zoom-in">+</button>
         </span>
-        <span class="card-version">v${CARD_VERSION}</span>
+        <span class="card-version">v${__CARD_VERSION__}</span>
       </div>
     </div>
   `;

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,28 +1,18 @@
 import { readFileSync } from "fs";
-import { resolve } from "path";
 import nodeResolve from "@rollup/plugin-node-resolve";
 import terser from "@rollup/plugin-terser";
 
-const pkg = JSON.parse(readFileSync("./package.json", "utf-8"));
-const versionModulePath = resolve("./src/card/version.js");
-
-const cardVersion = {
-  name: "card-version",
-  load(id) {
-    if (id === versionModulePath) {
-      return `export const CARD_VERSION = ${JSON.stringify(pkg.version)};`;
-    }
-  },
-};
+const { version } = JSON.parse(readFileSync("./package.json", "utf-8"));
 
 export default {
   input: "src/index.js",
   output: {
     file: "dist/card.js",
     format: "es",
+    banner: `/* ha-planetary-solar-system-card v${version} */`,
+    intro: `const __CARD_VERSION__ = '${version}';`,
   },
   plugins: [
-    cardVersion,
     nodeResolve(),
     ...(process.env.NODE_ENV === "production" ? [terser()] : []),
   ],

--- a/src/card/card-template.js
+++ b/src/card/card-template.js
@@ -4,7 +4,6 @@ import {
   getSkyMode,
 } from "../astronomy/solar-position.js";
 import { CARD_STYLES } from "./card-styles.js";
-import { CARD_VERSION } from "./version.js";
 
 /**
  * Build the status bar HTML fragment.
@@ -69,7 +68,7 @@ export function buildCardHtml(statusBarHtml, formattedDate, zoomLevel) {
           <span class="zoom-level">${zoomLevel}</span>
           <button data-action="zoom-in">+</button>
         </span>
-        <span class="card-version">v${CARD_VERSION}</span>
+        <span class="card-version">v${__CARD_VERSION__}</span>
       </div>
     </div>
   `;

--- a/src/card/version.js
+++ b/src/card/version.js
@@ -1,1 +1,0 @@
-export const CARD_VERSION = "1.0.0";

--- a/test/card/card-template.test.js
+++ b/test/card/card-template.test.js
@@ -165,10 +165,10 @@ describe("buildCardHtml", () => {
     expect(spans[1].textContent).toMatch(/^Next: .+ \(\d{2}:\d{2}\)$/);
   });
 
-  it("displays a version badge starting with 'v'", () => {
+  it("displays a version badge with the injected build version", () => {
     const root = parse(buildCardHtml("", "26-03-07 12:00", 1));
     const badge = root.querySelector(".card-version");
     expect(badge).not.toBeNull();
-    expect(badge.textContent).toMatch(/^v\d+\.\d+\.\d+$/);
+    expect(badge.textContent).toBe("vtest");
   });
 });

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  define: { __CARD_VERSION__: '"test"' },
   test: {
     environment: "jsdom",
     coverage: {


### PR DESCRIPTION
## Summary

- Replace custom `cardVersion` Rollup plugin and `src/card/version.js` virtual module with `output.intro` injection of `const __CARD_VERSION__ = '${version}';`
- Add top-level `define: { __CARD_VERSION__: '"test"' }` to `vitest.config.mjs` so tests resolve the constant without importing a real file
- Update `card-template.js` to use `__CARD_VERSION__` global directly instead of the named import
- Delete `src/card/version.js` (no longer needed)

Both cards now use the same mechanism: build version comes from `package.json` via Rollup intro, test version is the sentinel string `"test"`.

## Test plan

- [x] `npm test` — all 418 tests pass
- [x] `npm run test:coverage` — 100% coverage maintained
- [x] `npm run build` — `dist/card.js` opens with `/* ha-planetary-solar-system-card v1.0.0 */` banner and `const __CARD_VERSION__ = '1.0.0';` intro

🤖 Generated with [Claude Code](https://claude.com/claude-code)