### PR TITLE
feat: change ecliptic_view from boolean to "north"/"south" string

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,15 +48,15 @@ default_zoom: 2
 
 ## Configuration
 
-| Option                 | Type    | Default   | Description                                                 |
-| ---------------------- | ------- | --------- | ----------------------------------------------------------- |
-| `refresh_mins`         | number  | `1`       | Auto-update interval in minutes                             |
-| `default_zoom`         | number  | `1`       | Starting zoom level                                         |
-| `zoom_animate`         | boolean | `true`    | Animate zoom transitions                                    |
-| `periodic_zoom_change` | boolean | `false`   | Cycle zoom levels on each refresh tick                      |
-| `periodic_zoom_max`    | number  | `4`       | Maximum zoom level for auto-cycle (2–4)                     |
-| `colors`               | object  | see below | Color overrides (see Colors)                                |
-| `ecliptic_view`        | boolean | `false`   | View from the south ecliptic pole (orbits appear clockwise) |
+| Option                 | Type                   | Default   | Description                                                                                |
+| ---------------------- | ---------------------- | --------- | ------------------------------------------------------------------------------------------ |
+| `refresh_mins`         | number                 | `1`       | Auto-update interval in minutes                                                            |
+| `default_zoom`         | number                 | `1`       | Starting zoom level                                                                        |
+| `zoom_animate`         | boolean                | `true`    | Animate zoom transitions                                                                   |
+| `periodic_zoom_change` | boolean                | `false`   | Cycle zoom levels on each refresh tick                                                     |
+| `periodic_zoom_max`    | number                 | `4`       | Maximum zoom level for auto-cycle (2–4)                                                    |
+| `colors`               | object                 | see below | Color overrides (see Colors)                                                               |
+| `ecliptic_view`        | `"north"` \| `"south"` | `"north"` | Viewing pole: `"north"` = counter-clockwise orbits (default); `"south"` = clockwise orbits |
 
 ### Colors
 

--- a/src/card/card.js
+++ b/src/card/card.js
@@ -87,7 +87,7 @@ export class SolarViewCard extends HTMLElement {
       label: config.colors?.label ?? DEFAULT_COLORS.label,
     };
 
-    this._eclipticView = config.ecliptic_view === true;
+    this._eclipticView = config.ecliptic_view === "south";
 
     // Recreate timer if already connected
     if (this._autoUpdateTimer != null) {

--- a/test/card/card.test.js
+++ b/test/card/card.test.js
@@ -25,15 +25,21 @@ describe("SolarViewCard", () => {
     expect(card._eclipticView).toBe(false);
   });
 
-  it("ecliptic_view is true when config.ecliptic_view is true", () => {
+  it("ecliptic_view is true when config.ecliptic_view is 'south'", () => {
     const card = document.createElement("ha-planetary-solar-system-card-test");
-    card.setConfig({ ecliptic_view: true });
+    card.setConfig({ ecliptic_view: "south" });
     expect(card._eclipticView).toBe(true);
   });
 
-  it("ecliptic_view coerces non-boolean truthy to false", () => {
+  it("ecliptic_view is false when config.ecliptic_view is 'north'", () => {
     const card = document.createElement("ha-planetary-solar-system-card-test");
-    card.setConfig({ ecliptic_view: 1 });
+    card.setConfig({ ecliptic_view: "north" });
+    expect(card._eclipticView).toBe(false);
+  });
+
+  it("ecliptic_view ignores unrecognised values", () => {
+    const card = document.createElement("ha-planetary-solar-system-card-test");
+    card.setConfig({ ecliptic_view: true });
     expect(card._eclipticView).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

- Replaces `ecliptic_view: true/false` with `ecliptic_view: "north" | "south"`
- `"north"` (default) = view from north ecliptic pole, counter-clockwise orbits
- `"south"` = view from south ecliptic pole, clockwise orbits
- Old `ecliptic_view: true` configs silently fall back to `"north"` (the safe default)
- README, card config parsing, and tests all updated

## Test plan

- [x] `ecliptic_view: "south"` activates south-pole view
- [x] `ecliptic_view: "north"` and omitted both produce north-pole view (default)
- [x] Unrecognised values (e.g. old `true`) are ignored and default to north
- [x] All 421 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)