### PR TITLE
fix: open PR for version bump instead of pushing directly to main

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   release:
@@ -28,17 +29,24 @@ jobs:
 
       - run: npm run build:prod
 
-      - name: Tag and publish release
+      - name: Create release branch, tag, and open PR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          BRANCH="release/v${{ github.event.inputs.version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
           git add package.json dist/card.js
           git commit -m "chore: bump version to ${{ github.event.inputs.version }}"
-          git push origin HEAD:main
+          git push origin "$BRANCH"
           git tag "v${{ github.event.inputs.version }}"
           git push origin "v${{ github.event.inputs.version }}"
+          gh pr create \
+            --title "chore: bump version to ${{ github.event.inputs.version }}" \
+            --body "Automated version bump for release v${{ github.event.inputs.version }}." \
+            --base main \
+            --head "$BRANCH"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3


### PR DESCRIPTION
## Summary
- Release workflow was failing with `GH006: Protected branch update failed` because `main` requires PRs
- Changed "Tag and publish release" step to push to a `release/v{version}` branch instead of directly to `main`
- The tag and GitHub Release are created from the release branch (HACS gets the artifact immediately)
- A PR is automatically opened to merge the version bump back into `main`

## Test plan
- [ ] Trigger the Publish Release workflow with a version number
- [ ] Confirm the workflow succeeds and a `release/v{version}` branch + PR are created
- [ ] Confirm the GitHub Release and tag exist with `dist/card.js` attached
- [ ] Merge the auto-generated PR to sync `main`'s `package.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)