### PR TITLE
fix: prevent timer freeze at midnight and on kiosk startup

### DIFF
--- a/src/card/card.js
+++ b/src/card/card.js
@@ -15,6 +15,7 @@ export class SolarViewCard extends HTMLElement {
     super();
     this.attachShadow({ mode: "open" });
     this._currentDate = new Date();
+    this._isLiveMode = true; // false when user has navigated away from today
     this._viewState = null; // initialized on first render
     this._defaultZoomLevel = DEFAULT_ZOOM_LEVEL;
     this._hemisphere = "north"; // Hemisphere for season labels (default: north)
@@ -98,21 +99,27 @@ export class SolarViewCard extends HTMLElement {
   connectedCallback() {
     this._render();
     this._startAutoUpdateTimer();
+    this._onVisibilityChange = () => {
+      if (!document.hidden && this._isLiveMode) {
+        this._currentDate = new Date();
+        this._render();
+      }
+    };
+    document.addEventListener("visibilitychange", this._onVisibilityChange);
   }
 
   disconnectedCallback() {
     clearInterval(this._autoUpdateTimer);
     this._autoUpdateTimer = null;
+    document.removeEventListener("visibilitychange", this._onVisibilityChange);
+    this._onVisibilityChange = null;
   }
 
   _startAutoUpdateTimer() {
     clearInterval(this._autoUpdateTimer);
     const interval = this._refreshMs || 60000;
     this._autoUpdateTimer = setInterval(() => {
-      if (
-        this._formatDate(this._currentDate).slice(0, 10) ===
-        this._formatDate(new Date()).slice(0, 10)
-      ) {
+      if (this._isLiveMode) {
         this._currentDate = new Date();
         this._render();
       }
@@ -141,11 +148,13 @@ export class SolarViewCard extends HTMLElement {
   }
 
   _navigate(deltaMs) {
+    this._isLiveMode = false;
     this._currentDate = new Date(this._currentDate.getTime() + deltaMs);
     this._render();
   }
 
   _goToday() {
+    this._isLiveMode = true;
     this._currentDate = new Date();
     this._render();
   }

--- a/test/card/card.test.js
+++ b/test/card/card.test.js
@@ -884,16 +884,51 @@ describe("SolarViewCard", () => {
       card.remove();
     });
 
-    it("does not re-render when showing a different date", () => {
+    it("syncs to current time on visibilitychange when in live mode", () => {
       vi.useFakeTimers({ now: new Date("2026-02-15T10:00:00") });
       const card = document.createElement("ha-planetary-solar-system-card-test");
       document.body.appendChild(card);
-      // Navigate to a past date
-      card._currentDate = new Date("2026-01-01T10:00:00");
-      card._render();
+      // Simulate time passing while tab was hidden (timer throttled)
+      vi.setSystemTime(new Date("2026-02-15T10:45:00"));
+      // Card still shows stale time — timer never fired
+      expect(card._formatDate(card._currentDate)).toContain("10:00");
+      // Tab becomes visible
+      Object.defineProperty(document, "hidden", { value: false, configurable: true });
+      document.dispatchEvent(new Event("visibilitychange"));
+      // Card should now show current time
+      expect(card._formatDate(card._currentDate)).toContain("10:45");
+      card.remove();
+    });
+
+    it("does not sync on visibilitychange when user has navigated away", () => {
+      vi.useFakeTimers({ now: new Date("2026-02-15T10:00:00") });
+      const card = document.createElement("ha-planetary-solar-system-card-test");
+      document.body.appendChild(card);
+      card._navigate(-45 * 86400000); // user went to a past date
+      vi.setSystemTime(new Date("2026-02-15T10:45:00"));
+      Object.defineProperty(document, "hidden", { value: false, configurable: true });
+      document.dispatchEvent(new Event("visibilitychange"));
+      // Should still show the navigated-to date
+      expect(card._formatDate(card._currentDate)).not.toContain("26-02-15");
+      card.remove();
+    });
+
+    it("removes visibilitychange listener on disconnectedCallback", () => {
+      const card = createAndMount();
+      expect(card._onVisibilityChange).not.toBeNull();
+      card.remove();
+      expect(card._onVisibilityChange).toBeNull();
+    });
+
+    it("does not re-render when user has navigated to a different date", () => {
+      vi.useFakeTimers({ now: new Date("2026-02-15T10:00:00") });
+      const card = document.createElement("ha-planetary-solar-system-card-test");
+      document.body.appendChild(card);
+      // Navigate backwards 45 days via the proper navigation path, which sets _isLiveMode=false
+      card._navigate(-45 * 86400000);
       vi.advanceTimersByTime(60000);
-      // Should still show the past date
-      expect(card._formatDate(card._currentDate)).toContain("26-01-01");
+      // Should still show the navigated-to date, not auto-advance to today
+      expect(card._formatDate(card._currentDate)).not.toContain("26-02-15");
       card.remove();
     });
   });


### PR DESCRIPTION
## Summary

- Replaces the fragile date-string equality guard in the auto-update timer with an explicit `_isLiveMode` flag — fixes a bug where the card would freeze **permanently after midnight** because the day-boundary string comparison would fail once `new Date()` crossed to the next day, even with no user interaction
- Adds a `visibilitychange` listener so the card immediately syncs to the current time when the browser tab or kiosk display becomes visible, recovering from browser timer throttling during startup without the user needing to press "Now"
- `_isLiveMode` is `true` by default, set to `false` only by `_navigate()` (button presses), and restored to `true` by `_goToday()` — so neither fix affects navigation state

## Test plan

- [ ] Card updates every minute overnight and does not freeze after midnight
- [ ] Card on kiosk startup immediately shows correct time when display wakes or tab becomes active
- [ ] Navigating to a past date and waiting one minute still shows the past date (live mode off)
- [ ] Pressing "Now" after navigating restores live updates
- [ ] `npm test` passes (424 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)