### PR TITLE
fix: rename camelCase color config keys to snake_case

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ default_zoom: 2
 The card forces a dark background by default so it renders correctly in both light and dark HA
 themes. Every color value accepts any valid CSS color string (`#rrggbb`, `rgba(…)`, named colors).
 
-| Key                  | Default                     | Description                          |
-| -------------------- | --------------------------- | ------------------------------------ |
-| `colors.background`  | `#090909`                   | Card background                      |
-| `colors.orbit`       | `rgba(255, 255, 255, 0.12)` | Orbit ring and moon-orbit stroke     |
-| `colors.label`       | `#ffffff`                   | Planet and comet name labels         |
-| `colors.seasonLine`  | `rgba(255, 255, 255, 0.25)` | Season quadrant divider lines        |
-| `colors.seasonLabel` | `rgba(255, 255, 255, 0.5)`  | Season name labels (curved arc text) |
+| Key                   | Default                     | Description                          |
+| --------------------- | --------------------------- | ------------------------------------ |
+| `colors.background`   | `#090909`                   | Card background                      |
+| `colors.orbit`        | `rgba(255, 255, 255, 0.12)` | Orbit ring and moon-orbit stroke     |
+| `colors.label`        | `#ffffff`                   | Planet and comet name labels         |
+| `colors.season_line`  | `rgba(255, 255, 255, 0.25)` | Season quadrant divider lines        |
+| `colors.season_label` | `rgba(255, 255, 255, 0.5)`  | Season name labels (curved arc text) |
 
 ```yaml
 type: custom:ha-planetary-solar-system-card

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -17,7 +17,7 @@ import { auToRadius, CENTER, createSvgElement, expandBounds, VIEW_SIZE } from ".
  * @param {Date} date - date to calculate positions for
  * @param {string} [hemisphere="north"] - "north" or "south" for season labels
  * @param {{ lat: number, lon: number, timezone: string } | null} [locationData] - observer location from HA config
- * @param {{ background?: string, orbit?: string, label?: string, seasonLine?: string, seasonLabel?: string }} [colors] - optional color overrides
+ * @param {{ background?: string, orbit?: string, label?: string, season_line?: string, season_label?: string }} [colors] - optional color overrides
  * @returns {{ svg: SVGElement, bounds: { minX: number, minY: number, maxX: number, maxY: number } }}
  */
 export function renderSolarSystem(

--- a/src/renderer/seasons.js
+++ b/src/renderer/seasons.js
@@ -5,8 +5,8 @@ const DEFAULT_SEASON_LABEL_COLOR = "rgba(255, 255, 255, 0.5)";
 const SEASON_FONT_SIZE = 20;
 
 export function renderSeasonOverlay(svg, hemisphere, colors = {}, eclipticViewDirection = -1) {
-  const lineColor = colors.seasonLine ?? DEFAULT_SEASON_LINE_COLOR;
-  const labelColor = colors.seasonLabel ?? DEFAULT_SEASON_LABEL_COLOR;
+  const lineColor = colors.season_line ?? DEFAULT_SEASON_LINE_COLOR;
+  const labelColor = colors.season_label ?? DEFAULT_SEASON_LABEL_COLOR;
   const isEcliptic = eclipticViewDirection === 1;
 
   // Dotted dividing lines through the Sun


### PR DESCRIPTION
## Summary

- Renames `colors.seasonLine` → `colors.season_line` and `colors.seasonLabel` → `colors.season_label` to match the snake_case convention used by all other user-facing config options (`refresh_mins`, `default_zoom`, `periodic_zoom_change`, etc.)
- Updates `src/renderer/seasons.js` (runtime key lookup), `src/renderer/index.js` (JSDoc), and `README.md` (docs table)

## Breaking change

Any existing config using `colors.seasonLine` or `colors.seasonLabel` will silently fall back to the defaults after this change. Users will need to rename those keys in their YAML.

## Test plan

- [ ] `npm test` passes (424 tests)
- [ ] Card renders season lines and labels with custom colors when `colors.season_line` / `colors.season_label` are set in YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)