### PR TITLE
chore: mark Phase 1+2 migration as done in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,9 +55,9 @@ Release asset.
 Active issues and open gaps. Update when starting or completing significant work. Status: `open` ·
 `in-progress` · `done`
 
-| Status      | Area      | Description                                                       |
-| ----------- | --------- | ----------------------------------------------------------------- |
-| in-progress | migration | Phase 1: JS → TypeScript (branch: feature/typescript-migration)   |
-| in-progress | migration | Phase 2: TypeScript → Lit (PR #37, branch: feature/lit-migration) |
+| Status | Area      | Description                                   |
+| ------ | --------- | --------------------------------------------- |
+| done   | migration | Phase 1: JS → TypeScript (merged via PR #37)  |
+| done   | migration | Phase 2: TypeScript → Lit (merged via PR #37) |
 
 See [TODO.md](./TODO.md) for the full itemised checklist.


### PR DESCRIPTION
## Summary

- Updates Known Issues table in CLAUDE.md: both Phase 1 (JS→TS) and Phase 2 (TS→Lit) marked `done` following PR #37 merge

## Test plan
- [ ] No logic changes; docs-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)