### PR TITLE
chore: remove dead code and consolidate duplicated constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![License](https://img.shields.io/github/license/marcintk/ha-planetary-solar-system-card.svg)](https://github.com/marcintk/ha-planetary-solar-system-card/blob/main/LICENSE)
 ![Maintenance](https://img.shields.io/maintenance/yes/2026)
 [![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)](https://github.com/marcintk/ha-planetary-solar-system-card/actions/workflows/build-and-test.yml)
+[![Lines of code](https://sloc.xyz/github/marcintk/ha-planetary-solar-system-card/?category=code)](https://github.com/marcintk/ha-planetary-solar-system-card)
 [![CI](https://github.com/marcintk/ha-planetary-solar-system-card/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/marcintk/ha-planetary-solar-system-card/actions/workflows/build-and-test.yml)
 
 Home Assistant custom Lovelace card showing all 8 planets, Moon and comet Halley aligned around the

--- a/src/astronomy/planet-data.ts
+++ b/src/astronomy/planet-data.ts
@@ -77,7 +77,6 @@ export const PLANETS: Planet[] = [
 
 export const MOON: MoonData = {
   name: "Moon",
-  auFromEarth: 0.00257,
   periodDays: 27.32,
   color: "#cccccc",
   size: 5,

--- a/src/card/card-view-state.ts
+++ b/src/card/card-view-state.ts
@@ -16,8 +16,7 @@ export class ViewState {
   centerY: number;
   zoomLevel: ZoomLevel;
   isDragging: boolean;
-  private _width: number;
-  private _height: number;
+  private _size: number;
   private _dragStartX: number;
   private _dragStartY: number;
   private _dragStartCenterX: number;
@@ -27,8 +26,7 @@ export class ViewState {
     this.centerX = FULL_SYSTEM_SIZE / 2;
     this.centerY = FULL_SYSTEM_SIZE / 2;
     this.zoomLevel = defaultZoomLevel;
-    this._width = ZOOM_LEVELS[defaultZoomLevel];
-    this._height = ZOOM_LEVELS[defaultZoomLevel];
+    this._size = ZOOM_LEVELS[defaultZoomLevel];
     this.isDragging = false;
     this._dragStartX = 0;
     this._dragStartY = 0;
@@ -36,26 +34,26 @@ export class ViewState {
     this._dragStartCenterY = 0;
   }
 
+  // ponytail: viewport is always square (aspect-ratio: 1 in CSS + ZOOM_LEVELS are uniform)
   get width(): number {
-    return this._width;
+    return this._size;
   }
   get height(): number {
-    return this._height;
+    return this._size;
   }
 
   /** Returns the SVG viewBox string for the current pan/zoom state. */
   get viewBox(): string {
-    const minX = this.centerX - this._width / 2;
-    const minY = this.centerY - this._height / 2;
-    return `${minX} ${minY} ${this._width} ${this._height}`;
+    const minX = this.centerX - this._size / 2;
+    const minY = this.centerY - this._size / 2;
+    return `${minX} ${minY} ${this._size} ${this._size}`;
   }
 
   /** Zoom in one discrete level. Returns true if zoom changed. */
   zoomIn(): boolean {
     if (this.zoomLevel >= MAX_ZOOM) return false;
     this.zoomLevel = (this.zoomLevel + 1) as ZoomLevel;
-    this._width = ZOOM_LEVELS[this.zoomLevel];
-    this._height = ZOOM_LEVELS[this.zoomLevel];
+    this._size = ZOOM_LEVELS[this.zoomLevel];
     return true;
   }
 
@@ -63,8 +61,7 @@ export class ViewState {
   zoomOut(): boolean {
     if (this.zoomLevel <= MIN_ZOOM) return false;
     this.zoomLevel = (this.zoomLevel - 1) as ZoomLevel;
-    this._width = ZOOM_LEVELS[this.zoomLevel];
-    this._height = ZOOM_LEVELS[this.zoomLevel];
+    this._size = ZOOM_LEVELS[this.zoomLevel];
     return true;
   }
 
@@ -72,14 +69,12 @@ export class ViewState {
   setZoomLevel(level: number): void {
     const clamped = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, level)) as ZoomLevel;
     this.zoomLevel = clamped;
-    this._width = ZOOM_LEVELS[clamped];
-    this._height = ZOOM_LEVELS[clamped];
+    this._size = ZOOM_LEVELS[clamped];
   }
 
-  /** Set viewport dimensions directly (for animation frames) without changing zoomLevel. */
-  setViewport(width: number, height: number): void {
-    this._width = width;
-    this._height = height;
+  /** Set viewport size directly (for animation frames) without changing zoomLevel. */
+  setViewport(size: number, _ignored: number): void {
+    this._size = size;
   }
 
   startDrag(clientX: number, clientY: number): void {
@@ -95,10 +90,9 @@ export class ViewState {
     if (!this.isDragging) return;
     const dx = clientX - this._dragStartX;
     const dy = clientY - this._dragStartY;
-    const scaleX = this._width / svgRect.width;
-    const scaleY = this._height / svgRect.height;
-    this.centerX = this._dragStartCenterX - dx * scaleX;
-    this.centerY = this._dragStartCenterY - dy * scaleY;
+    const scale = this._size / svgRect.width;
+    this.centerX = this._dragStartCenterX - dx * scale;
+    this.centerY = this._dragStartCenterY - dy * scale;
   }
 
   endDrag(): void {

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -75,6 +75,11 @@ export class SolarViewCard extends LitElement {
   get _isDragging(): boolean {
     return this._viewState?.isDragging ?? false;
   }
+  get _locationData(): LocationData | null {
+    return this._lat != null && this._lon != null
+      ? { lat: this._lat, lon: this._lon, timezone: this._timezone ?? "UTC" }
+      : null;
+  }
   get _viewCenterX(): number | null {
     return this._viewState?.centerX ?? null;
   }
@@ -166,12 +171,11 @@ export class SolarViewCard extends LitElement {
       this._hemisphere = this._lat < 0 ? "south" : "north";
     }
 
-    const locationData: LocationData | null =
-      this._lat != null && this._lon != null
-        ? { lat: this._lat, lon: this._lon, timezone: this._timezone ?? "UTC" }
-        : null;
-
-    const statusBarHtml = buildStatusBarHtml(locationData, this._locationName, this._currentDate);
+    const statusBarHtml = buildStatusBarHtml(
+      this._locationData,
+      this._locationName,
+      this._currentDate
+    );
     const zoomLevel = this._viewState?.zoomLevel ?? this._defaultZoomLevel;
     /* v8 ignore next */
     const background = this._colors.background ?? "";
@@ -212,11 +216,6 @@ export class SolarViewCard extends LitElement {
       this._zoomAnimator = new ZoomAnimator(this._viewState, () => this._updateViewBox());
     }
 
-    const locationData: LocationData | null =
-      this._lat != null && this._lon != null
-        ? { lat: this._lat, lon: this._lon, timezone: this._timezone ?? "UTC" }
-        : null;
-
     const container = (this.shadowRoot as ShadowRoot).getElementById("solar-view");
     /* v8 ignore next */
     if (container) {
@@ -224,7 +223,7 @@ export class SolarViewCard extends LitElement {
       const { svg, positions } = renderSolarSystem(
         this._currentDate,
         this._hemisphere,
-        locationData,
+        this._locationData,
         this._colors,
         this._eclipticView
       );

--- a/src/card/zoom-animator.ts
+++ b/src/card/zoom-animator.ts
@@ -16,7 +16,7 @@ export class ZoomAnimator {
   private _targetWidth: number;
   private _targetHeight: number;
   private _targetLevel: ZoomLevel;
-  private _startTime: number;
+  private _startTime: number | null;
 
   constructor(viewState: ViewState, onFrame: () => void) {
     this._viewState = viewState;
@@ -27,7 +27,7 @@ export class ZoomAnimator {
     this._targetWidth = 0;
     this._targetHeight = 0;
     this._targetLevel = 1;
-    this._startTime = -1;
+    this._startTime = null;
   }
 
   get isAnimating(): boolean {
@@ -47,10 +47,10 @@ export class ZoomAnimator {
     this._targetWidth = ZOOM_LEVELS[targetLevel];
     this._targetHeight = ZOOM_LEVELS[targetLevel];
     this._targetLevel = targetLevel;
-    this._startTime = -1;
+    this._startTime = null;
 
     const step = (timestamp: number) => {
-      if (this._startTime < 0) this._startTime = timestamp;
+      if (this._startTime === null) this._startTime = timestamp;
       const elapsed = timestamp - this._startTime;
       const t = Math.min(elapsed / ZOOM_ANIMATE_DURATION_MS, 1);
       const eased = easeInOutCubic(t);

--- a/src/renderer/bodies.ts
+++ b/src/renderer/bodies.ts
@@ -1,9 +1,8 @@
 import type { CelestialBody, Colors } from "../types.js";
-import { CENTER, createSvgElement } from "./svg-utils.js";
+import { CENTER, createSvgElement, DEFAULT_LABEL_COLOR } from "./svg-utils.js";
 
 export const ORBIT_COLOR = "rgba(255, 255, 255, 0.12)";
 const AU_LABEL_COLOR = "rgba(255, 255, 255, 0.5)";
-const DEFAULT_LABEL_COLOR = "#ffffff";
 
 export function renderOrbit(
   svg: SVGElement,

--- a/src/renderer/comets.ts
+++ b/src/renderer/comets.ts
@@ -1,9 +1,8 @@
 import type { Colors, Comet, CometVisualEllipse } from "../types.js";
-import { auToRadius, CENTER, createSvgElement } from "./svg-utils.js";
+import { ORBIT_COLOR } from "./bodies.js";
+import { auToRadius, CENTER, createSvgElement, DEFAULT_LABEL_COLOR } from "./svg-utils.js";
 
-const DEFAULT_ORBIT_COLOR = "rgba(255, 255, 255, 0.12)";
 const TAIL_COLOR = "rgba(136, 204, 255, 0.5)";
-const DEFAULT_LABEL_COLOR = "#ffffff";
 
 /**
  * Compute the visual ellipse parameters in pixel space for a comet.
@@ -34,7 +33,7 @@ export function computeCometVisualEllipse(comet: Comet): CometVisualEllipse {
  * The ellipse is offset so the Sun (at CENTER) sits at one focus.
  */
 export function renderCometOrbit(svg: SVGElement, comet: Comet, colors: Colors = {}): void {
-  const orbitColor = colors.orbit ?? DEFAULT_ORBIT_COLOR;
+  const orbitColor = colors.orbit ?? ORBIT_COLOR;
   const { aPx, bPx, cPx, rotationDeg } = computeCometVisualEllipse(comet);
 
   svg.appendChild(

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -11,7 +11,14 @@ import { computeCometVisualEllipse, renderCometBody, renderCometOrbit } from "./
 import { renderMoonPhaseIndicator } from "./moon-phase.js";
 import { calculateObserverAngle, renderDayNightSplit, renderObserverNeedle } from "./observer.js";
 import { renderSeasonOverlay } from "./seasons.js";
-import { auToRadius, CENTER, createSvgElement, expandBounds, VIEW_SIZE } from "./svg-utils.js";
+import {
+  auToRadius,
+  CENTER,
+  createSvgElement,
+  DEFAULT_LABEL_COLOR,
+  expandBounds,
+  VIEW_SIZE,
+} from "./svg-utils.js";
 
 /**
  * Renders the solar system SVG and returns it with bounding box metadata.
@@ -30,7 +37,7 @@ export function renderSolarSystem(
 ): { svg: SVGSVGElement; bounds: Bounds; positions: ViewPosition[] } {
   const eclipticViewDirection = eclipticView ? 1 : -1;
   const orbitColor = colors.orbit ?? ORBIT_COLOR;
-  const labelColor = colors.label ?? "#ffffff";
+  const labelColor = colors.label ?? DEFAULT_LABEL_COLOR;
 
   const svg = createSvgElement("svg", {
     viewBox: `0 0 ${VIEW_SIZE} ${VIEW_SIZE}`,

--- a/src/renderer/offscreen-markers.ts
+++ b/src/renderer/offscreen-markers.ts
@@ -4,7 +4,7 @@ import { createSvgElement } from "./svg-utils.js";
 const MARKER_SIZE = 8;
 const EDGE_MARGIN = 10;
 const LABEL_FONT_SIZE = 9;
-const MARKER_GROUP_ID = "offscreen-markers";
+export const MARKER_GROUP_ID = "offscreen-markers";
 
 /**
  * Compute the intersection of a ray from (cx, cy) to (px, py) with a rectangle.
@@ -183,5 +183,3 @@ export function renderOffscreenMarkers(
 
   return group;
 }
-
-export { MARKER_GROUP_ID };

--- a/src/renderer/svg-utils.ts
+++ b/src/renderer/svg-utils.ts
@@ -2,6 +2,7 @@ import { PLANETS } from "../astronomy/planet-data.js";
 import type { Bounds } from "../types.js";
 
 export const SVG_NS = "http://www.w3.org/2000/svg";
+export const DEFAULT_LABEL_COLOR = "#ffffff";
 export const VIEW_SIZE = 800;
 export const CENTER = VIEW_SIZE / 2;
 export const MIN_RADIUS = 40;

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,6 @@ export interface Planet extends CelestialBody {
 }
 
 export interface MoonData extends CelestialBody {
-  auFromEarth: number;
   periodDays: number;
   meanLongitudeJ2000: number;
 }

--- a/test/astronomy/planet-data.test.ts
+++ b/test/astronomy/planet-data.test.ts
@@ -30,7 +30,6 @@ describe("planet-data constants", () => {
 
   it("MOON has required fields", () => {
     expect(MOON.periodDays).toBeCloseTo(27.32, 1);
-    expect(MOON.auFromEarth).toBeDefined();
   });
 
   it("SUN has color and size", () => {


### PR DESCRIPTION
## Summary

- Consolidate `DEFAULT_LABEL_COLOR` (3 copies across `bodies.ts`, `comets.ts`, `index.ts`) into a single export in `svg-utils.ts`
- Import `ORBIT_COLOR` from `bodies.ts` in `comets.ts` instead of re-declaring the identical string
- Remove dead `auFromEarth` field from `MoonData` — never read; the 22px Moon pixel offset is hardcoded in the renderer
- Extract duplicate `locationData` construction into a `_locationData` getter in `card.ts` (was copy-pasted in both `render()` and `updated()`)
- Collapse `ViewState._width` / `_height` into a single `_size` field — viewport is always square (`aspect-ratio: 1` in CSS, `ZOOM_LEVELS` are uniform); both `width` and `height` getters return `_size`
- Promote `MARKER_GROUP_ID` to `export const` at its declaration site (was declared without export then re-exported at end of file)
- Change `ZoomAnimator._startTime` sentinel from `-1` to `null` (`number | null`)
- Add Lines of code badge to README

## Test plan

- [x] `npm run check` — biome lint + format clean
- [x] `npm test` — 418 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)