### PR TITLE
chore: add Dependabot config to auto-update ha-shared

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch", "version-update:semver-minor", "version-update:semver-major"]
+    allow:
+      - dependency-name: ha-shared


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` to track `ha-shared` (GitHub-sourced dependency)
- Dependabot will open a PR weekly when `ha-shared` has new commits
- All other deps are ignored to keep noise low

🤖 Generated with [Claude Code](https://claude.com/claude-code)