### PR TITLE
chore: migrate to ha-card-shared v1.0.0

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec node_modules/ha-shared/.githooks/pre-commit
+exec node_modules/ha-card-shared/.githooks/pre-commit

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,13 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch", "version-update:semver-minor", "version-update:semver-major"]
     allow:
-      - dependency-name: ha-shared
+      - dependency-name: ha-card-shared
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch", "version-update:semver-minor", "version-update:semver-major"]
+    allow:
+      - dependency-name: marcintk/ha-card-shared

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: marcintk/ha-shared/.github/workflows/build-and-test.yml@main
+    uses: marcintk/ha-card-shared/.github/workflows/shared-build-and-test.yml@v1.0.0
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/deploy-demo-page.yml
+++ b/.github/workflows/deploy-demo-page.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    uses: marcintk/ha-shared/.github/workflows/deploy-demo-page.yml@main
+    uses: marcintk/ha-card-shared/.github/workflows/shared-deploy-demo-page.yml@v1.0.0
     permissions:
       contents: read
       pages: write

--- a/.github/workflows/hacs-validation.yml
+++ b/.github/workflows/hacs-validation.yml
@@ -11,4 +11,4 @@ on:
 jobs:
   validate:
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
-    uses: marcintk/ha-shared/.github/workflows/hacs-validation.yml@main
+    uses: marcintk/ha-card-shared/.github/workflows/shared-hacs-validation.yml@v1.0.0

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   release:
-    uses: marcintk/ha-shared/.github/workflows/publish-release.yml@main
+    uses: marcintk/ha-card-shared/.github/workflows/shared-publish-release.yml@v1.0.0
     permissions:
       contents: write

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,0 @@
-{
-  "proseWrap": "always",
-  "printWidth": 100
-}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-@node_modules/ha-shared/CLAUDE-SHARED.md @package.json @TODO.md
+@node_modules/ha-card-shared/CLAUDE-SHARED.md @package.json @TODO.md
 
 # ha-planetary-solar-system-card
 

--- a/biome.json
+++ b/biome.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
-  "extends": ["./node_modules/ha-shared/biome.json"]
+  "extends": ["./node_modules/ha-card-shared/biome.json"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@rollup/plugin-terser": "^1.0.0",
         "@rollup/plugin-typescript": "^12.3.0",
         "@vitest/coverage-v8": "^4.1.8",
-        "ha-shared": "github:marcintk/ha-shared",
+        "ha-card-shared": "github:marcintk/ha-card-shared#v1.0.0",
         "jsdom": "^28.0.0",
         "prettier": "^3.8.1",
         "rollup": "^4.57.1",
@@ -1825,15 +1825,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/ha-shared": {
+    "node_modules/ha-card-shared": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/marcintk/ha-shared.git#c47649713631f24bc0311c2650fd950dd3ad6cd3",
+      "resolved": "git+ssh://git@github.com/marcintk/ha-card-shared.git#cbd14a55d56eac5a4c1c9f68ca18bfae2d39b2fd",
       "dev": true,
       "peerDependencies": {
+        "@biomejs/biome": ">=2",
         "@rollup/plugin-node-resolve": ">=15",
         "@rollup/plugin-terser": ">=0.4",
         "@rollup/plugin-typescript": ">=11",
+        "@vitest/coverage-v8": ">=2",
+        "jsdom": ">=22",
+        "prettier": ">=3",
         "rollup": ">=4",
+        "typescript": ">=5",
         "vitest": ">=2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lovelace",
     "solar-system"
   ],
+  "prettier": "ha-card-shared/prettier.config.json",
   "license": "ISC",
   "devDependencies": {
     "@biomejs/biome": "^2.4.16",
@@ -33,7 +34,7 @@
     "@rollup/plugin-terser": "^1.0.0",
     "@rollup/plugin-typescript": "^12.3.0",
     "@vitest/coverage-v8": "^4.1.8",
-    "ha-shared": "github:marcintk/ha-shared",
+    "ha-card-shared": "github:marcintk/ha-card-shared#v1.0.0",
     "jsdom": "^28.0.0",
     "prettier": "^3.8.1",
     "rollup": "^4.57.1",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,3 +1,3 @@
-import { cardBundle } from "ha-shared/rollup.base.mjs";
+import { cardBundle } from "ha-card-shared/rollup.base.mjs";
 
 export default cardBundle();

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,5 +1,0 @@
-declare const __CARD_VERSION__: string;
-
-interface Window {
-  customCards?: Array<{ type: string; name: string; description: string }>;
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+/// <reference path="../node_modules/ha-card-shared/globals.d.ts" />
 import { SolarViewCard } from "./card/card.js";
 
 customElements.define("ha-planetary-solar-system-card", SolarViewCard);
@@ -7,4 +8,5 @@ window.customCards.push({
   type: "ha-planetary-solar-system-card",
   name: "Solar View Card",
   description: "Planetary solar system visualization card",
+  preview: false,
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "ha-shared/tsconfig.base.json",
+  "extends": "ha-card-shared/tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2022",
     "lib": ["ES2022", "DOM"],

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,4 +1,4 @@
-import { baseVitestConfig } from "ha-shared/vitest.base.mjs";
+import { baseVitestConfig } from "ha-card-shared/vitest.base.mjs";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig(baseVitestConfig);


### PR DESCRIPTION
## Summary

- Swaps `ha-shared` for `ha-card-shared#v1.0.0` in npm devDependencies
- Updates all 4 reusable workflow `uses:` refs to `shared-*.yml@v1.0.0` (pinned tag, new `shared-` prefix)
- Adds `github-actions` ecosystem block to Dependabot so workflow pins are auto-updated
- Delegates prettier config to `ha-card-shared/prettier.config.json` via `package.json` `"prettier"` key; drops local `.prettierrc`
- Replaces local `src/globals.d.ts` with a triple-slash reference to the shared one; adds required `preview: false` to `customCards.push()`
- Updates pre-commit hook delegate path

## Test plan

- [ ] CI: build-and-test passes (uses renamed shared workflow)
- [ ] CI: hacs-validation passes
- [ ] `npm run check:ci` clean locally (typecheck + biome + prettier)
- [ ] `npm run test:coverage` — 407/407, 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)