### PR TITLE
test: snapshot coverage for card styles and status bar

### DIFF
--- a/test/card/__snapshots__/card-styles.test.ts.snap
+++ b/test/card/__snapshots__/card-styles.test.ts.snap
@@ -1,0 +1,122 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`cardStyles > matches snapshot 1`] = `
+"
+  :host {
+    display: block;
+    background: #090909;
+  }
+  .card {
+    border-radius: 0px;
+    padding: 0px;
+    color: #ffffff;
+    font-family: sans-serif;
+  }
+  .date {
+    font-size: 11px;
+    color: rgba(255, 255, 255, 0.6);
+    margin: 2px 2px;
+  }
+  .solar-view-wrapper {
+    overflow: hidden;
+    position: relative;
+  }
+  .status-bar {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    background: rgba(42, 42, 42, 0.3);
+    font-size: 10px;
+    color: rgba(255, 255, 255, 0.85);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 3px 8px;
+    pointer-events: none;
+    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8);
+    font-family: sans-serif;
+    z-index: 1;
+  }
+  .status-bar span {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .status-bar span:first-child {
+    min-width: 0;
+  }
+  #solar-view {
+    width: 100%;
+    aspect-ratio: 1;
+  }
+  #solar-view svg {
+    cursor: grab;
+    user-select: none;
+    touch-action: none;
+  }
+  .nav {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 4px;
+    margin-top: 2px;
+    position: relative;
+  }
+  .nav button {
+    background: rgba(42, 42, 42, 0.3);
+    color: rgba(255, 255, 255, 0.8);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 6px;
+    height: 18px;
+    line-height: 18px;
+    padding: 0 5px;
+    min-width: 20px;
+    font-size: 10px;
+    cursor: pointer;
+    font-family: sans-serif;
+    box-sizing: border-box;
+  }
+  .nav button:hover {
+    background: #3a3a3a;
+  }
+  .btn-group {
+    display: flex;
+    gap: 0;
+  }
+  .btn-group button {
+    border-radius: 0;
+  }
+  .btn-group button:first-child {
+    border-radius: 6px 0 0 6px;
+  }
+  .btn-group button:last-child {
+    border-radius: 0 6px 6px 0;
+  }
+  .nav-spacer {
+    width: 8px;
+  }
+  .zoom-level {
+    background: #2a2a2a;
+    color: rgba(255, 255, 255, 0.8);
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    height: 18px;
+    line-height: 18px;
+    padding: 0 4px;
+    font-size: 9px;
+    font-family: sans-serif;
+    display: flex;
+    align-items: center;
+    box-sizing: border-box;
+  }
+  .card-version {
+    font-size: 9px;
+    color: rgba(255, 255, 255, 0.3);
+    user-select: none;
+    font-family: sans-serif;
+    position: absolute;
+    right: 0;
+  }
+"
+`;

--- a/test/card/__snapshots__/card-template.test.ts.snap
+++ b/test/card/__snapshots__/card-template.test.ts.snap
@@ -1,0 +1,22 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`buildStatusBar > rendered structure snapshots > full status bar with Next transition 1`] = `
+"<!----><div class="status-bar">
+    <span><!--?-->London | <!--?-->Day (<!--?-->32°)</span>
+    <!--?--><span>Next: <!--?-->Civil Twilight (<!--?-->17:25)</span>
+  </div>"
+`;
+
+exports[`buildStatusBar > rendered structure snapshots > null location name (empty before pipe) 1`] = `
+"<!----><div class="status-bar">
+    <span><!--?--> | <!--?-->Day (<!--?-->89°)</span>
+    <!--?--><span>Next: <!--?-->Civil Twilight (<!--?-->18:00)</span>
+  </div>"
+`;
+
+exports[`buildStatusBar > rendered structure snapshots > single span (polar night, no transition) 1`] = `
+"<!----><div class="status-bar">
+    <span><!--?-->Arctic | <!--?-->Night (<!--?-->-22°)</span>
+    <!--?-->
+  </div>"
+`;

--- a/test/card/card-styles.test.ts
+++ b/test/card/card-styles.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { cardStyles } from "../../src/card/card-styles.js";
+
+// cardStyles is a Lit CSSResult; .cssText is the raw stylesheet string.
+// Snapshotting it catches any structural CSS change (column sizes, layout,
+// colors) that no dedicated assertion covers.
+describe("cardStyles", () => {
+  it("matches snapshot", () => {
+    expect(cardStyles.cssText).toMatchSnapshot();
+  });
+});

--- a/test/card/card-template.test.ts
+++ b/test/card/card-template.test.ts
@@ -8,6 +8,15 @@ function renderToDOM(result) {
   return div;
 }
 
+// Lit injects comment markers like <!--?lit$013215205$--> and binding ids
+// whose numbers change between module loads. Strip the ids so the snapshot
+// is stable across runs while still capturing structure, classes, and text.
+function doc(result) {
+  return renderToDOM(result)
+    .innerHTML.replace(/<!--\?lit\$\d+\$-->/g, "<!--?-->")
+    .replace(/lit\$\d+\$/g, "lit$$$$");
+}
+
 describe("buildStatusBar", () => {
   it("returns nothing when locationData is null", () => {
     expect(buildStatusBar(null, null, new Date())).toBe(nothing);
@@ -89,5 +98,45 @@ describe("buildStatusBar", () => {
     const spans = root.querySelectorAll(".status-bar span");
     expect(spans.length).toBe(2);
     expect(spans[1].textContent).toMatch(/^Next: .+ \(\d{2}:\d{2}\)$/);
+  });
+
+  // Snapshots capture the full rendered structure (element nesting, classes,
+  // text) for each variant — anything the targeted asserts above don't pin.
+  describe("rendered structure snapshots", () => {
+    it("full status bar with Next transition", () => {
+      expect(
+        doc(
+          buildStatusBar(
+            { lat: 51.5, lon: -0.1, timezone: "Europe/London" },
+            "London",
+            new Date("2026-03-05T12:00:00Z")
+          )
+        )
+      ).toMatchSnapshot();
+    });
+
+    it("single span (polar night, no transition)", () => {
+      expect(
+        doc(
+          buildStatusBar(
+            { lat: 89, lon: 0, timezone: "UTC" },
+            "Arctic",
+            new Date("2026-12-21T12:00:00Z")
+          )
+        )
+      ).toMatchSnapshot();
+    });
+
+    it("null location name (empty before pipe)", () => {
+      expect(
+        doc(
+          buildStatusBar(
+            { lat: 0, lon: 0, timezone: "UTC" },
+            null,
+            new Date("2026-03-20T12:00:00Z")
+          )
+        )
+      ).toMatchSnapshot();
+    });
   });
 });


### PR DESCRIPTION
## What

Adds snapshot tests catching structural regressions that no targeted assertion covers:

- **`cardStyles.cssText`** — full stylesheet string snapshot. Catches layout/color/sizing changes. Snapshots the Lit `CSSResult`'s `.cssText` accessor, so no production change to `card-styles.ts`.
- **`buildStatusBar` rendered HTML** — normalized-innerHTML snapshots for the full-transition, polar-night, and null-name variants.

A `doc()` helper collapses Lit's run-varying comment markers (`<!--?lit$NNN$-->` → `<!--?-->`) so snapshots stay stable across module loads.

## Why

Behavioral asserts pin specific values; snapshots catch everything else — element nesting, classes, CSS structure — that silently regresses without a dedicated check.

## Verification

- 12 tests pass · coverage 100% · `tsc --noEmit` clean · `biome check src/ test/` clean · prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)