### PR TITLE
chore: bump ha-card-shared to v1.1.1

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,6 +23,19 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "missing=\"\"; [ -f ~/.claude/.ponytail-active ] || missing=\"ponytail \"; grep -q caveman ~/.claude/settings.json 2>/dev/null || missing=\"${missing}caveman \"; [ -n \"$missing\" ] && echo \"⚠️  Missing required plugins: ${missing}— install per CLAUDE-SHARED.md\" || true",
+            "timeout": 5,
+            "statusMessage": "ha-card-shared: checking required plugins"
+          }
+        ]
+      }
     ]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@rollup/plugin-terser": "^1.0.0",
         "@rollup/plugin-typescript": "^12.3.0",
         "@vitest/coverage-v8": "^4.1.8",
-        "ha-card-shared": "github:marcintk/ha-card-shared#v1.0.0",
+        "ha-card-shared": "github:marcintk/ha-card-shared#v1.1.1",
         "jsdom": "^28.0.0",
         "prettier": "^3.8.1",
         "rollup": "^4.57.1",
@@ -1826,9 +1826,10 @@
       }
     },
     "node_modules/ha-card-shared": {
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/marcintk/ha-card-shared.git#cbd14a55d56eac5a4c1c9f68ca18bfae2d39b2fd",
+      "version": "1.1.1",
+      "resolved": "git+ssh://git@github.com/marcintk/ha-card-shared.git#b7a201b512fa78b041b407d1d7203b9d33333434",
       "dev": true,
+      "hasInstallScript": true,
       "peerDependencies": {
         "@biomejs/biome": ">=2",
         "@rollup/plugin-node-resolve": ">=15",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@rollup/plugin-terser": "^1.0.0",
     "@rollup/plugin-typescript": "^12.3.0",
     "@vitest/coverage-v8": "^4.1.8",
-    "ha-card-shared": "github:marcintk/ha-card-shared#v1.0.0",
+    "ha-card-shared": "github:marcintk/ha-card-shared#v1.1.1",
     "jsdom": "^28.0.0",
     "prettier": "^3.8.1",
     "rollup": "^4.57.1",


### PR DESCRIPTION
Bumps ha-card-shared to v1.1.1. Postinstall auto-configures .claude/settings.json. Future bumps handled automatically by Dependabot.