### PR TITLE
feat: inherit HA theme background color

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,16 +61,17 @@ default_zoom: 2
 
 ### Colors
 
-The card forces a dark background by default so it renders correctly in both light and dark HA
-themes. Every color value accepts any valid CSS color string (`#rrggbb`, `rgba(…)`, named colors).
+By default the card inherits the HA theme background via `--ha-card-background` (falling back to
+`--card-background-color`, then `--primary-background-color`). Set `colors.background` to override.
+Every color value accepts any valid CSS color string (`#rrggbb`, `rgba(…)`, named colors).
 
-| Key                   | Default                     | Description                          |
-| --------------------- | --------------------------- | ------------------------------------ |
-| `colors.background`   | `#090909`                   | Card background                      |
-| `colors.orbit`        | `rgba(255, 255, 255, 0.12)` | Orbit ring and moon-orbit stroke     |
-| `colors.label`        | `#ffffff`                   | Planet and comet name labels         |
-| `colors.season_line`  | `rgba(255, 255, 255, 0.25)` | Season quadrant divider lines        |
-| `colors.season_label` | `rgba(255, 255, 255, 0.5)`  | Season name labels (curved arc text) |
+| Key                   | Default                           | Description                          |
+| --------------------- | --------------------------------- | ------------------------------------ |
+| `colors.background`   | HA theme (`--ha-card-background`) | Card background                      |
+| `colors.orbit`        | `rgba(255, 255, 255, 0.12)`       | Orbit ring and moon-orbit stroke     |
+| `colors.label`        | `#ffffff`                         | Planet and comet name labels         |
+| `colors.season_line`  | `rgba(255, 255, 255, 0.25)`       | Season quadrant divider lines        |
+| `colors.season_label` | `rgba(255, 255, 255, 0.5)`        | Season name labels (curved arc text) |
 
 ```yaml
 type: custom:ha-planetary-solar-system-card

--- a/src/card/card-styles.ts
+++ b/src/card/card-styles.ts
@@ -3,7 +3,7 @@ import { css } from "lit";
 export const cardStyles = css`
   :host {
     display: block;
-    background: #090909;
+    background: var(--ha-card-background, var(--card-background-color, var(--primary-background-color, #090909)));
   }
   .card {
     border-radius: 0px;

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -16,7 +16,6 @@ import { DEFAULT_ZOOM_LEVEL, MAX_ZOOM, MIN_ZOOM, ViewState } from "./card-view-s
 import { ZoomAnimator } from "./zoom-animator.js";
 
 const DEFAULT_COLORS: Colors = {
-  background: "#090909",
   orbit: "rgba(255, 255, 255, 0.12)",
   label: "#ffffff",
 };

--- a/test/card/__snapshots__/card-styles.test.ts.snap
+++ b/test/card/__snapshots__/card-styles.test.ts.snap
@@ -4,7 +4,7 @@ exports[`cardStyles > matches snapshot 1`] = `
 "
   :host {
     display: block;
-    background: #090909;
+    background: var(--ha-card-background, var(--card-background-color, var(--primary-background-color, #090909)));
   }
   .card {
     border-radius: 0px;

--- a/test/card/card.test.ts
+++ b/test/card/card.test.ts
@@ -55,7 +55,6 @@ describe("SolarViewCard", () => {
       refresh_mins: 1,
       zoom_animate: true,
       colors: {
-        background: "#090909",
         orbit: "rgba(255, 255, 255, 0.12)",
         label: "#ffffff",
       },


### PR DESCRIPTION
## Summary

- Card background now uses `--ha-card-background` (with fallbacks to `--card-background-color` → `--primary-background-color` → `#090909`) instead of the hardcoded `#090909`
- `colors.background` in card config still overrides when set
- Updated README to document the new default behavior

## Test plan

- [ ] All 411 tests pass
- [ ] Snapshot updated to reflect new CSS variable chain
- [ ] `getStubConfig` no longer includes hardcoded background (omitting lets theme apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)