### PR TITLE
fix: light theme support and ponytail cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,13 @@ By default the card inherits the HA theme background via `--ha-card-background` 
 `--card-background-color`, then `--primary-background-color`). Set `colors.background` to override.
 Every color value accepts any valid CSS color string (`#rrggbb`, `rgba(…)`, named colors).
 
-| Key                   | Default                           | Description                          |
-| --------------------- | --------------------------------- | ------------------------------------ |
-| `colors.background`   | HA theme (`--ha-card-background`) | Card background                      |
-| `colors.orbit`        | `rgba(255, 255, 255, 0.12)`       | Orbit ring and moon-orbit stroke     |
-| `colors.label`        | `#ffffff`                         | Planet and comet name labels         |
-| `colors.season_line`  | `rgba(255, 255, 255, 0.25)`       | Season quadrant divider lines        |
-| `colors.season_label` | `rgba(255, 255, 255, 0.5)`        | Season name labels (curved arc text) |
+| Key                   | Default                            | Description                          |
+| --------------------- | ---------------------------------- | ------------------------------------ |
+| `colors.background`   | HA theme (`--ha-card-background`)  | Card background                      |
+| `colors.orbit`        | 12% of theme text color (adaptive) | Orbit ring and moon-orbit stroke     |
+| `colors.label`        | theme text color (adaptive)        | Planet and comet name labels         |
+| `colors.season_line`  | 25% of theme text color (adaptive) | Season quadrant divider lines        |
+| `colors.season_label` | 50% of theme text color (adaptive) | Season name labels (curved arc text) |
 
 ```yaml
 type: custom:ha-planetary-solar-system-card

--- a/src/astronomy/planet-data.ts
+++ b/src/astronomy/planet-data.ts
@@ -75,6 +75,8 @@ export const PLANETS: Planet[] = [
   },
 ];
 
+export const EARTH: Planet = PLANETS[2];
+
 export const MOON: MoonData = {
   name: "Moon",
   periodDays: 27.32,

--- a/src/card/card-styles.ts
+++ b/src/card/card-styles.ts
@@ -3,17 +3,19 @@ import { css } from "lit";
 export const cardStyles = css`
   :host {
     display: block;
-    background: var(--ha-card-background, var(--card-background-color, var(--primary-background-color, #090909)));
+    color-scheme: light dark;
+    background: var(--ha-card-background, var(--card-background-color, var(--primary-background-color, Canvas)));
+    color: var(--primary-text-color, CanvasText);
   }
   .card {
     border-radius: 0px;
     padding: 0px;
-    color: #ffffff;
+    color: inherit;
     font-family: sans-serif;
   }
   .date {
     font-size: 11px;
-    color: rgba(255, 255, 255, 0.6);
+    color: var(--secondary-text-color, color-mix(in srgb, currentColor 60%, transparent));
     margin: 2px 2px;
   }
   .solar-view-wrapper {
@@ -25,15 +27,14 @@ export const cardStyles = css`
     top: 0;
     left: 0;
     right: 0;
-    background: rgba(42, 42, 42, 0.3);
+    background: color-mix(in srgb, currentColor 15%, transparent);
     font-size: 10px;
-    color: rgba(255, 255, 255, 0.85);
+    color: inherit;
     display: flex;
     justify-content: space-between;
     align-items: center;
     padding: 3px 8px;
     pointer-events: none;
-    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8);
     font-family: sans-serif;
     z-index: 1;
   }
@@ -63,9 +64,9 @@ export const cardStyles = css`
     position: relative;
   }
   .nav button {
-    background: rgba(42, 42, 42, 0.3);
-    color: rgba(255, 255, 255, 0.8);
-    border: 1px solid rgba(255, 255, 255, 0.1);
+    background: color-mix(in srgb, currentColor 15%, transparent);
+    color: inherit;
+    border: 1px solid var(--divider-color, color-mix(in srgb, currentColor 15%, transparent));
     border-radius: 6px;
     height: 18px;
     line-height: 18px;
@@ -77,7 +78,7 @@ export const cardStyles = css`
     box-sizing: border-box;
   }
   .nav button:hover {
-    background: #3a3a3a;
+    background: var(--secondary-background-color, color-mix(in srgb, currentColor 20%, transparent));
   }
   .btn-group {
     display: flex;
@@ -96,10 +97,10 @@ export const cardStyles = css`
     width: 8px;
   }
   .zoom-level {
-    background: #2a2a2a;
-    color: rgba(255, 255, 255, 0.8);
-    border-top: 1px solid rgba(255, 255, 255, 0.1);
-    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    background: color-mix(in srgb, currentColor 15%, transparent);
+    color: inherit;
+    border-top: 1px solid var(--divider-color, color-mix(in srgb, currentColor 15%, transparent));
+    border-bottom: 1px solid var(--divider-color, color-mix(in srgb, currentColor 15%, transparent));
     height: 18px;
     line-height: 18px;
     padding: 0 4px;
@@ -111,7 +112,7 @@ export const cardStyles = css`
   }
   .card-version {
     font-size: 9px;
-    color: rgba(255, 255, 255, 0.3);
+    color: var(--secondary-text-color, color-mix(in srgb, currentColor 30%, transparent));
     user-select: none;
     font-family: sans-serif;
     position: absolute;

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -111,11 +111,7 @@ export class SolarViewCard extends LitElement {
       Number.isInteger(rawMax) && rawMax >= 2 && rawMax <= MAX_ZOOM ? rawMax : MAX_ZOOM;
     this._zoomAnimate = config.zoom_animate !== false;
 
-    this._colors = {
-      background: config.colors?.background,
-      orbit: config.colors?.orbit,
-      label: config.colors?.label,
-    };
+    this._colors = config.colors ?? {};
 
     this._eclipticView = config.ecliptic_view === "south";
 

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -15,11 +15,6 @@ import { buildStatusBar } from "./card-template.js";
 import { DEFAULT_ZOOM_LEVEL, MAX_ZOOM, MIN_ZOOM, ViewState } from "./card-view-state.js";
 import { ZoomAnimator } from "./zoom-animator.js";
 
-const DEFAULT_COLORS: Colors = {
-  orbit: "rgba(255, 255, 255, 0.12)",
-  label: "#ffffff",
-};
-
 export class SolarViewCard extends LitElement {
   static styles = cardStyles;
 
@@ -57,7 +52,7 @@ export class SolarViewCard extends LitElement {
     this._timezone = null;
     this._locationName = null;
     this._autoUpdateTimer = null;
-    this._colors = { ...DEFAULT_COLORS };
+    this._colors = {};
     this._refreshMs = 60000;
     this._periodicZoomChange = false;
     this._periodicZoomMax = MAX_ZOOM;
@@ -117,9 +112,9 @@ export class SolarViewCard extends LitElement {
     this._zoomAnimate = config.zoom_animate !== false;
 
     this._colors = {
-      background: config.colors?.background ?? DEFAULT_COLORS.background,
-      orbit: config.colors?.orbit ?? DEFAULT_COLORS.orbit,
-      label: config.colors?.label ?? DEFAULT_COLORS.label,
+      background: config.colors?.background,
+      orbit: config.colors?.orbit,
+      label: config.colors?.label,
     };
 
     this._eclipticView = config.ecliptic_view === "south";
@@ -406,7 +401,7 @@ export class SolarViewCard extends LitElement {
       periodic_zoom_max: 4,
       refresh_mins: 1,
       zoom_animate: true,
-      colors: { ...DEFAULT_COLORS },
+      colors: {},
     };
   }
 }

--- a/src/renderer/bodies.ts
+++ b/src/renderer/bodies.ts
@@ -1,8 +1,8 @@
 import type { CelestialBody, Colors } from "../types.js";
 import { BODY_LABEL_ATTRS, CENTER, createSvgElement, DEFAULT_LABEL_COLOR } from "./svg-utils.js";
 
-export const ORBIT_COLOR = "rgba(255, 255, 255, 0.12)";
-const AU_LABEL_COLOR = "rgba(255, 255, 255, 0.5)";
+export const ORBIT_COLOR = "color-mix(in srgb, currentColor 12%, transparent)";
+const AU_LABEL_COLOR = "color-mix(in srgb, currentColor 50%, transparent)";
 
 export function renderOrbit(
   svg: SVGElement,
@@ -18,7 +18,7 @@ export function renderOrbit(
       cy: CENTER,
       r: radius,
       fill: "none",
-      stroke: orbitColor,
+      style: `stroke: ${orbitColor}`,
       "stroke-width": 1,
       "stroke-dasharray": "5, 5",
     })
@@ -29,7 +29,7 @@ export function renderOrbit(
   const offset = 3;
   const horizontalOffset = 3;
   const labelAttrs = {
-    fill: AU_LABEL_COLOR,
+    style: `fill: ${AU_LABEL_COLOR}`,
     "font-size": "9",
     "font-family": "sans-serif",
     "text-anchor": "start",
@@ -78,7 +78,7 @@ export function renderBody(
       createSvgElement("text", {
         x: x,
         y: y - body.size - 6,
-        fill: labelColor,
+        style: `fill: ${labelColor}`,
         ...BODY_LABEL_ATTRS,
       })
     ).textContent = body.name;

--- a/src/renderer/comets.ts
+++ b/src/renderer/comets.ts
@@ -49,7 +49,7 @@ export function renderCometOrbit(svg: SVGElement, comet: Comet, colors: Colors =
       rx: aPx,
       ry: bPx,
       fill: "none",
-      stroke: orbitColor,
+      style: `stroke: ${orbitColor}`,
       "stroke-width": 1,
       "stroke-dasharray": "4, 8",
       transform: `rotate(${-rotationDeg}, ${CENTER}, ${CENTER}) translate(${-cPx}, 0)`,
@@ -113,7 +113,7 @@ export function renderCometBody(
     createSvgElement("text", {
       x: x,
       y: y - comet.size - 6,
-      fill: labelColor,
+      style: `fill: ${labelColor}`,
       ...BODY_LABEL_ATTRS,
     })
   ).textContent = comet.name;

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -121,7 +121,7 @@ export function renderSolarSystem(
       cy: earthY,
       r: moonPixelOffset,
       fill: "none",
-      stroke: orbitColor,
+      style: `stroke: ${orbitColor}`,
       "stroke-width": 0.5,
       "stroke-dasharray": "2, 3",
     })

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -4,8 +4,8 @@ import {
   calculateMoonPosition,
   calculatePlanetPosition,
 } from "../astronomy/orbital-mechanics.js";
-import { MOON, PLANETS, SUN } from "../astronomy/planet-data.js";
-import type { Colors, Hemisphere, LocationData, Planet, ViewPosition } from "../types.js";
+import { EARTH, MOON, PLANETS, SUN } from "../astronomy/planet-data.js";
+import type { Colors, Hemisphere, LocationData, ViewPosition } from "../types.js";
 import { ORBIT_COLOR, renderBody, renderOrbit, renderSaturnRings } from "./bodies.js";
 import { computeCometVisualEllipse, renderCometBody, renderCometOrbit } from "./comets.js";
 import { renderMoonPhaseIndicator } from "./moon-phase.js";
@@ -41,9 +41,8 @@ export function renderSolarSystem(
   const positions: ViewPosition[] = [];
 
   // Day/night split (rendered first, behind everything)
-  const earth = PLANETS.find((p) => p.name === "Earth") as Planet;
   const earthRadius = auToRadius(1.0);
-  renderDayNightSplit(svg, earthRadius, date, earth.size, locationData, eclipticViewDirection);
+  renderDayNightSplit(svg, earthRadius, date, EARTH.size, locationData, eclipticViewDirection);
 
   // Season quadrant overlay (after day/night, before orbits)
   renderSeasonOverlay(svg, hemisphere, colors, eclipticViewDirection);
@@ -78,7 +77,7 @@ export function renderSolarSystem(
         createSvgElement("text", {
           x: x,
           y: y - saturnRenderSize - 16,
-          fill: labelColor,
+          style: `fill: ${labelColor}`,
           ...BODY_LABEL_ATTRS,
         })
       ).textContent = planet.name;
@@ -103,8 +102,8 @@ export function renderSolarSystem(
   }
 
   // Draw Moon near Earth
-  const earthAngle = calculatePlanetPosition(earth, date);
-  const earthPixelRadius = auToRadius(earth.au);
+  const earthAngle = calculatePlanetPosition(EARTH, date);
+  const earthPixelRadius = auToRadius(EARTH.au);
   const earthX = CENTER + earthPixelRadius * Math.cos(earthAngle);
   const earthY = CENTER + eclipticViewDirection * earthPixelRadius * Math.sin(earthAngle);
 
@@ -136,7 +135,7 @@ export function renderSolarSystem(
     locationData?.timezone,
     locationData?.lon
   );
-  renderObserverNeedle(svg, earthX, earthY, observerAngle, earth.size, eclipticViewDirection);
+  renderObserverNeedle(svg, earthX, earthY, observerAngle, EARTH.size, eclipticViewDirection);
 
   // Moon phase indicator (rendered last so it appears on top)
   renderMoonPhaseIndicator(svg, date, hemisphere);

--- a/src/renderer/observer.ts
+++ b/src/renderer/observer.ts
@@ -1,7 +1,7 @@
 import { calculatePlanetPosition } from "../astronomy/orbital-mechanics.js";
-import { PLANETS } from "../astronomy/planet-data.js";
+import { EARTH } from "../astronomy/planet-data.js";
 import { computeSolarElevationDeg, getLocalTimeInZone } from "../astronomy/solar-position.js";
-import type { LocationData, Planet } from "../types.js";
+import type { LocationData } from "../types.js";
 import { CENTER, createSvgElement, MAX_RADIUS, VIEW_SIZE } from "./svg-utils.js";
 
 const NEEDLE_COLOR = "color-mix(in srgb, currentColor 70%, transparent)";
@@ -127,8 +127,7 @@ export function renderDayNightSplit(
   locationData: LocationData | null,
   eclipticViewDirection = -1
 ): void {
-  const earth = PLANETS.find((p) => p.name === "Earth") as Planet;
-  const earthAngle = calculatePlanetPosition(earth, date);
+  const earthAngle = calculatePlanetPosition(EARTH, date);
   const observerAngle = calculateObserverAngle(
     earthAngle,
     date,

--- a/src/renderer/observer.ts
+++ b/src/renderer/observer.ts
@@ -4,7 +4,7 @@ import { computeSolarElevationDeg, getLocalTimeInZone } from "../astronomy/solar
 import type { LocationData, Planet } from "../types.js";
 import { CENTER, createSvgElement, MAX_RADIUS, VIEW_SIZE } from "./svg-utils.js";
 
-const NEEDLE_COLOR = "rgba(255, 255, 255, 0.7)";
+const NEEDLE_COLOR = "color-mix(in srgb, currentColor 70%, transparent)";
 
 export const CONE_DAY = "rgba(255, 255, 255, 0.1)"; // Sun above horizon
 export const CONE_CIVIL = "rgba(255, 220, 160, 0.08)"; // Civil twilight:        0° to -6°
@@ -177,7 +177,7 @@ export function renderDayNightSplit(
   const CLIP_R = MAX_RADIUS + 30;
   const EXTRA = 8;
   const lineStyle = {
-    stroke: "rgba(255, 255, 255, 0.3)",
+    style: "stroke: color-mix(in srgb, currentColor 30%, transparent)",
     "stroke-width": 1,
     "stroke-dasharray": "4, 4",
   };
@@ -254,7 +254,7 @@ export function renderObserverNeedle(
       y1: earthY,
       x2: tipX,
       y2: tipY,
-      stroke: NEEDLE_COLOR,
+      style: `stroke: ${NEEDLE_COLOR}`,
       "stroke-width": 2,
       "stroke-linecap": "round",
     })
@@ -266,7 +266,7 @@ export function renderObserverNeedle(
       cx: tipX,
       cy: tipY,
       r: 2,
-      fill: NEEDLE_COLOR,
+      style: `fill: ${NEEDLE_COLOR}`,
     })
   );
 }

--- a/src/renderer/offscreen-markers.ts
+++ b/src/renderer/offscreen-markers.ts
@@ -144,8 +144,6 @@ export function renderOffscreenMarkers(
 ): SVGGElement {
   const group = createSvgElement("g", { id: MARKER_GROUP_ID });
 
-  if (!positions || !viewState) return group;
-
   const w = viewState.width;
   const h = viewState.width;
   const left = viewState.centerX - w / 2;

--- a/src/renderer/seasons.ts
+++ b/src/renderer/seasons.ts
@@ -1,8 +1,8 @@
 import type { Colors, Hemisphere } from "../types.js";
 import { CENTER, createSvgElement, MAX_RADIUS, VIEW_SIZE } from "./svg-utils.js";
 
-const DEFAULT_SEASON_LINE_COLOR = "rgba(255, 255, 255, 0.25)";
-const DEFAULT_SEASON_LABEL_COLOR = "rgba(255, 255, 255, 0.5)";
+const DEFAULT_SEASON_LINE_COLOR = "color-mix(in srgb, currentColor 25%, transparent)";
+const DEFAULT_SEASON_LABEL_COLOR = "color-mix(in srgb, currentColor 50%, transparent)";
 const SEASON_FONT_SIZE = 20;
 
 export function renderSeasonOverlay(
@@ -22,7 +22,7 @@ export function renderSeasonOverlay(
       y1: CENTER,
       x2: VIEW_SIZE,
       y2: CENTER,
-      stroke: lineColor,
+      style: `stroke: ${lineColor}`,
       "stroke-width": 1,
       "stroke-dasharray": "4, 6",
     })
@@ -33,7 +33,7 @@ export function renderSeasonOverlay(
       y1: 0,
       x2: CENTER,
       y2: VIEW_SIZE,
-      stroke: lineColor,
+      style: `stroke: ${lineColor}`,
       "stroke-width": 1,
       "stroke-dasharray": "4, 6",
     })
@@ -102,7 +102,7 @@ export function renderSeasonOverlay(
     defs.appendChild(arcPath);
 
     const text = createSvgElement("text", {
-      fill: labelColor,
+      style: `fill: ${labelColor}`,
       "font-size": SEASON_FONT_SIZE,
       "font-family": "sans-serif",
     });

--- a/src/renderer/svg-utils.ts
+++ b/src/renderer/svg-utils.ts
@@ -1,7 +1,7 @@
 import { PLANETS } from "../astronomy/planet-data.js";
 
 export const SVG_NS = "http://www.w3.org/2000/svg";
-export const DEFAULT_LABEL_COLOR = "#ffffff";
+export const DEFAULT_LABEL_COLOR = "currentColor";
 export const VIEW_SIZE = 800;
 export const CENTER = VIEW_SIZE / 2;
 export const MIN_RADIUS = 40;

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,10 +12,7 @@ export interface Planet extends CelestialBody {
   meanLongitudeJ2000: number;
 }
 
-export interface MoonData extends CelestialBody {
-  periodDays: number;
-  meanLongitudeJ2000: number;
-}
+export type MoonData = Omit<Planet, "au">;
 
 export interface Comet {
   name: string;

--- a/test/card/__snapshots__/card-styles.test.ts.snap
+++ b/test/card/__snapshots__/card-styles.test.ts.snap
@@ -4,17 +4,19 @@ exports[`cardStyles > matches snapshot 1`] = `
 "
   :host {
     display: block;
-    background: var(--ha-card-background, var(--card-background-color, var(--primary-background-color, #090909)));
+    color-scheme: light dark;
+    background: var(--ha-card-background, var(--card-background-color, var(--primary-background-color, Canvas)));
+    color: var(--primary-text-color, CanvasText);
   }
   .card {
     border-radius: 0px;
     padding: 0px;
-    color: #ffffff;
+    color: inherit;
     font-family: sans-serif;
   }
   .date {
     font-size: 11px;
-    color: rgba(255, 255, 255, 0.6);
+    color: var(--secondary-text-color, color-mix(in srgb, currentColor 60%, transparent));
     margin: 2px 2px;
   }
   .solar-view-wrapper {
@@ -26,15 +28,14 @@ exports[`cardStyles > matches snapshot 1`] = `
     top: 0;
     left: 0;
     right: 0;
-    background: rgba(42, 42, 42, 0.3);
+    background: color-mix(in srgb, currentColor 15%, transparent);
     font-size: 10px;
-    color: rgba(255, 255, 255, 0.85);
+    color: inherit;
     display: flex;
     justify-content: space-between;
     align-items: center;
     padding: 3px 8px;
     pointer-events: none;
-    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8);
     font-family: sans-serif;
     z-index: 1;
   }
@@ -64,9 +65,9 @@ exports[`cardStyles > matches snapshot 1`] = `
     position: relative;
   }
   .nav button {
-    background: rgba(42, 42, 42, 0.3);
-    color: rgba(255, 255, 255, 0.8);
-    border: 1px solid rgba(255, 255, 255, 0.1);
+    background: color-mix(in srgb, currentColor 15%, transparent);
+    color: inherit;
+    border: 1px solid var(--divider-color, color-mix(in srgb, currentColor 15%, transparent));
     border-radius: 6px;
     height: 18px;
     line-height: 18px;
@@ -78,7 +79,7 @@ exports[`cardStyles > matches snapshot 1`] = `
     box-sizing: border-box;
   }
   .nav button:hover {
-    background: #3a3a3a;
+    background: var(--secondary-background-color, color-mix(in srgb, currentColor 20%, transparent));
   }
   .btn-group {
     display: flex;
@@ -97,10 +98,10 @@ exports[`cardStyles > matches snapshot 1`] = `
     width: 8px;
   }
   .zoom-level {
-    background: #2a2a2a;
-    color: rgba(255, 255, 255, 0.8);
-    border-top: 1px solid rgba(255, 255, 255, 0.1);
-    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    background: color-mix(in srgb, currentColor 15%, transparent);
+    color: inherit;
+    border-top: 1px solid var(--divider-color, color-mix(in srgb, currentColor 15%, transparent));
+    border-bottom: 1px solid var(--divider-color, color-mix(in srgb, currentColor 15%, transparent));
     height: 18px;
     line-height: 18px;
     padding: 0 4px;
@@ -112,7 +113,7 @@ exports[`cardStyles > matches snapshot 1`] = `
   }
   .card-version {
     font-size: 9px;
-    color: rgba(255, 255, 255, 0.3);
+    color: var(--secondary-text-color, color-mix(in srgb, currentColor 30%, transparent));
     user-select: none;
     font-family: sans-serif;
     position: absolute;

--- a/test/card/card.test.ts
+++ b/test/card/card.test.ts
@@ -54,10 +54,7 @@ describe("SolarViewCard", () => {
       periodic_zoom_max: 4,
       refresh_mins: 1,
       zoom_animate: true,
-      colors: {
-        orbit: "rgba(255, 255, 255, 0.12)",
-        label: "#ffffff",
-      },
+      colors: {},
     });
   });
 

--- a/test/renderer/bodies.test.ts
+++ b/test/renderer/bodies.test.ts
@@ -30,7 +30,7 @@ describe("renderOrbit", () => {
     renderOrbit(svg, 200, 1.0);
 
     const orbit = svg.querySelector('circle[stroke-dasharray="5, 5"]');
-    expect(orbit.getAttribute("stroke")).toBe(ORBIT_COLOR);
+    expect(orbit.getAttribute("style")).toBe(`stroke: ${ORBIT_COLOR}`);
   });
 
   it("appends two AU text labels (top and bottom)", () => {

--- a/test/renderer/index.test.ts
+++ b/test/renderer/index.test.ts
@@ -329,9 +329,11 @@ describe("renderSolarSystem", () => {
       const container = document.createElement("div");
       renderInto(container, date);
       const svg = container.querySelector("svg");
-      const horizonLine = svg.querySelector('line[stroke="rgba(255, 255, 255, 0.3)"]');
+      const horizonLine = svg.querySelector('line[stroke-dasharray="4, 4"]');
       expect(horizonLine).not.toBeNull();
-      expect(horizonLine.getAttribute("stroke-dasharray")).toBe("4, 4");
+      expect(horizonLine.getAttribute("style")).toBe(
+        "stroke: color-mix(in srgb, currentColor 30%, transparent)"
+      );
     }
   });
 
@@ -503,7 +505,7 @@ describe("renderSolarSystem", () => {
     expect(moonOrbit).not.toBeNull();
     expect(moonOrbit.getAttribute("r")).toBe("22");
     expect(moonOrbit.getAttribute("stroke-width")).toBe("0.5");
-    expect(moonOrbit.getAttribute("stroke")).toBe("rgba(255, 255, 255, 0.12)");
+    expect(moonOrbit.getAttribute("style")).toContain("color-mix(in srgb, currentColor 12%");
     expect(moonOrbit.getAttribute("fill")).toBe("none");
 
     // Should be centered at Earth's position
@@ -553,7 +555,7 @@ describe("renderSolarSystem", () => {
     renderInto(container, new Date("2026-02-14T15:00:00"));
 
     const svg = container.querySelector("svg");
-    const needle = svg.querySelector('line[stroke="rgba(255, 255, 255, 0.7)"]');
+    const needle = svg.querySelector('line[stroke-width="2"][style*="color-mix"]');
     expect(needle).not.toBeNull();
     expect(needle.getAttribute("stroke-width")).toBe("2");
   });
@@ -565,7 +567,7 @@ describe("renderSolarSystem", () => {
     renderInto(container, date);
 
     const svg = container.querySelector("svg");
-    const needle = svg.querySelector('line[stroke="rgba(255, 255, 255, 0.7)"]');
+    const needle = svg.querySelector('line[stroke-width="2"][style*="color-mix"]');
     const x1 = Number(needle.getAttribute("x1"));
     const y1 = Number(needle.getAttribute("y1"));
     const x2 = Number(needle.getAttribute("x2"));
@@ -594,7 +596,9 @@ describe("renderSolarSystem", () => {
 
     const svg = container.querySelector("svg");
     // Find the small dot at the needle tip (r=2, needle color)
-    const dots = svg.querySelectorAll('circle[fill="rgba(255, 255, 255, 0.7)"]');
+    const dots = Array.from(svg.querySelectorAll("circle[r='2']")).filter((el) =>
+      el.getAttribute("style")?.includes("color-mix")
+    );
     expect(dots.length).toBe(1);
     expect(dots[0].getAttribute("r")).toBe("2");
   });

--- a/test/renderer/observer.test.ts
+++ b/test/renderer/observer.test.ts
@@ -317,7 +317,9 @@ describe("renderDayNightSplit horizon and zenith lines", () => {
 
     const lines = svg.querySelectorAll('line[stroke-dasharray="4, 4"]');
     for (const line of lines) {
-      expect(line.getAttribute("stroke")).toBe("rgba(255, 255, 255, 0.3)");
+      expect(line.getAttribute("style")).toBe(
+        "stroke: color-mix(in srgb, currentColor 30%, transparent)"
+      );
       expect(line.getAttribute("stroke-width")).toBe("1");
     }
   });

--- a/test/renderer/offscreen-markers.test.ts
+++ b/test/renderer/offscreen-markers.test.ts
@@ -75,18 +75,6 @@ describe("renderOffscreenMarkers", () => {
     expect(group.children.length).toBe(0);
   });
 
-  it("returns empty group when positions is null", () => {
-    const group = renderOffscreenMarkers(null, makeViewState(1));
-    expect(group.tagName).toBe("g");
-    expect(group.children.length).toBe(0);
-  });
-
-  it("returns empty group when viewState is null", () => {
-    const group = renderOffscreenMarkers([{ name: "X", x: 0, y: 0, color: "#fff" }], null);
-    expect(group.tagName).toBe("g");
-    expect(group.children.length).toBe(0);
-  });
-
   it("places marker when edge intersection falls back to center (degenerate viewport)", () => {
     // A 1×1 viewport means the inset box (margin=10) degenerates, causing
     // edgeIntersection to return the fallback { x: cx, y: cy } (POSITIVE_INFINITY path).

--- a/test/renderer/seasons.test.ts
+++ b/test/renderer/seasons.test.ts
@@ -11,7 +11,7 @@ describe("renderSeasonOverlay", () => {
     const svg = createSvg();
     renderSeasonOverlay(svg, "north");
 
-    const lines = svg.querySelectorAll('line[stroke="rgba(255, 255, 255, 0.25)"]');
+    const lines = svg.querySelectorAll('line[stroke-dasharray="4, 6"]');
     expect(lines.length).toBe(2);
   });
 
@@ -19,7 +19,7 @@ describe("renderSeasonOverlay", () => {
     const svg = createSvg();
     renderSeasonOverlay(svg, "north");
 
-    const lines = Array.from(svg.querySelectorAll('line[stroke="rgba(255, 255, 255, 0.25)"]'));
+    const lines = Array.from(svg.querySelectorAll('line[stroke-dasharray="4, 6"]'));
     const horizontal = lines.find(
       (l) => l.getAttribute("y1") === "400" && l.getAttribute("y2") === "400"
     );


### PR DESCRIPTION
## Summary

- Replace all hardcoded `rgba(255,255,255,N)` colors with `color-mix(in srgb, currentColor N%, transparent)` so SVG elements adapt to HA theme text color
- Add `color-scheme: light dark` + `CanvasText`/`Canvas` fallbacks to `:host` — fixes invisible text when `--primary-text-color` is unset
- Replace dark-hardcoded status bar / button / zoom-level backgrounds with `color-mix`-based adaptive values
- Fix `setConfig` silently dropping `season_line`/`season_label` from user `colors` config
- Export `EARTH` constant from `planet-data.ts` alongside `SUN`/`MOON`; remove two `PLANETS.find()` scans
- Collapse `MoonData` interface to `Omit<Planet, "au">`
- Remove dead null guard in `renderOffscreenMarkers`

## Test plan

- [ ] Verify card renders correctly on dark HA theme (existing behavior unchanged)
- [ ] Verify text, orbits, season lines visible on light HA theme
- [ ] All 409 tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)