### PR TITLE
feat: add show_version option, pin version label to bottom

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ default_zoom: 2
 | `periodic_zoom_max`    | number                 | `4`       | Maximum zoom level for auto-cycle (2–4)                                                    |
 | `colors`               | object                 | see below | Color overrides (see Colors)                                                               |
 | `ecliptic_view`        | `"north"` \| `"south"` | `"north"` | Viewing pole: `"north"` = counter-clockwise orbits (default); `"south"` = clockwise orbits |
+| `show_version`         | boolean                | `false`   | Show card version number in the bottom-right corner of the nav bar                         |
 
 ### Colors
 

--- a/src/astronomy/solar-position.ts
+++ b/src/astronomy/solar-position.ts
@@ -5,9 +5,12 @@
  * @param {string} timezone - IANA timezone string (e.g. "America/Chicago")
  * @returns {{ hours: number, minutes: number }}
  */
-import type { LocalTime, NextTransition } from "../types.js";
+import type { NextTransition } from "../types.js";
 
-export function getLocalTimeInZone(date: Date, timezone: string): LocalTime {
+export function getLocalTimeInZone(
+  date: Date,
+  timezone: string
+): { hours: number; minutes: number } {
   try {
     const parts = new Intl.DateTimeFormat("en-US", {
       timeZone: timezone,

--- a/src/card/card-styles.ts
+++ b/src/card/card-styles.ts
@@ -117,5 +117,6 @@ export const cardStyles = css`
     font-family: sans-serif;
     position: absolute;
     right: 0;
+    bottom: 0;
   }
 `;

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -1,4 +1,4 @@
-import { html, LitElement } from "lit";
+import { html, LitElement, nothing } from "lit";
 import { renderSolarSystem } from "../renderer/index.js";
 import { MARKER_GROUP_ID, renderOffscreenMarkers } from "../renderer/offscreen-markers.js";
 import type {
@@ -180,7 +180,7 @@ export class SolarViewCard extends LitElement {
             <span class="zoom-level">${zoomLevel}</span>
             <button data-action="zoom-in" @click=${this._onNavClick}>+</button>
           </span>
-          <span class="card-version">v${__CARD_VERSION__}</span>
+          ${this._config?.show_version ? html`<span class="card-version">v${__CARD_VERSION__}</span>` : nothing}
         </div>
       </div>
     `;

--- a/src/renderer/bodies.ts
+++ b/src/renderer/bodies.ts
@@ -26,8 +26,7 @@ export function renderOrbit(
 
   // AU labels on the vertical axis — mirrored above and below center
   // Offset right of the season dividing line to avoid overlap
-  const offset = 3;
-  const horizontalOffset = 3;
+  const LABEL_OFFSET = 3;
   const labelAttrs = {
     style: `fill: ${AU_LABEL_COLOR}`,
     "font-size": "9",
@@ -38,8 +37,8 @@ export function renderOrbit(
   // Top label
   svg.appendChild(
     createSvgElement("text", {
-      x: CENTER + horizontalOffset,
-      y: CENTER - radius - offset,
+      x: CENTER + LABEL_OFFSET,
+      y: CENTER - radius - LABEL_OFFSET,
       ...labelAttrs,
     })
   ).textContent = `${Number(auLabel).toFixed(1)} AU`;
@@ -47,8 +46,8 @@ export function renderOrbit(
   // Bottom label
   svg.appendChild(
     createSvgElement("text", {
-      x: CENTER + horizontalOffset,
-      y: CENTER + radius + offset + 6,
+      x: CENTER + LABEL_OFFSET,
+      y: CENTER + radius + LABEL_OFFSET + 6,
       ...labelAttrs,
     })
   ).textContent = `${Number(auLabel).toFixed(1)} AU`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,11 +86,6 @@ export interface NextTransition {
   toMode: string;
 }
 
-export interface LocalTime {
-  hours: number;
-  minutes: number;
-}
-
 // Home Assistant types
 
 export interface HASSConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,4 +110,5 @@ export interface CardConfig {
   zoom_animate?: boolean;
   colors?: Colors;
   ecliptic_view?: string;
+  show_version?: boolean;
 }

--- a/test/card/__snapshots__/card-styles.test.ts.snap
+++ b/test/card/__snapshots__/card-styles.test.ts.snap
@@ -118,6 +118,7 @@ exports[`cardStyles > matches snapshot 1`] = `
     font-family: sans-serif;
     position: absolute;
     right: 0;
+    bottom: 0;
   }
 "
 `;

--- a/test/card/card.test.ts
+++ b/test/card/card.test.ts
@@ -229,6 +229,32 @@ describe("SolarViewCard", () => {
     });
   });
 
+  describe("version display", () => {
+    it("hides version by default", () => {
+      const card = createAndMount();
+      expect(card.shadowRoot.querySelector(".card-version")).toBeNull();
+      card.remove();
+    });
+
+    it("shows version when show_version is true", () => {
+      const card = createAndMount();
+      card.setConfig({ show_version: true });
+      card._render();
+      const el = card.shadowRoot.querySelector(".card-version");
+      expect(el).toBeTruthy();
+      expect(el.textContent).toMatch(/^v/);
+      card.remove();
+    });
+
+    it("hides version when show_version is false", () => {
+      const card = createAndMount();
+      card.setConfig({ show_version: false });
+      card._render();
+      expect(card.shadowRoot.querySelector(".card-version")).toBeNull();
+      card.remove();
+    });
+  });
+
   describe("day navigation", () => {
     it("day-back rewinds by 1 day", () => {
       const card = createAndMount();


### PR DESCRIPTION
## Summary

- Adds `show_version: true` config option — version hidden by default
- Pins `.card-version` to the bottom of the nav bar (`bottom: 0`) instead of floating at flex static-position centre
- Inlines `LocalTime` interface (single-function return type, no other consumers)
- Collapses `offset`/`horizontalOffset` into `LABEL_OFFSET` in `renderOrbit`

## Test plan

- [ ] `show_version: true` renders `v…` span in nav bar
- [ ] Default (omitted) and `show_version: false` render no version span
- [ ] `npm run test:coverage` — 100% coverage maintained
- [ ] `npm run check:ci` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)