### PR TITLE
fix(styles): nudge card-date away from edge

### DIFF
--- a/src/card/card-styles.ts
+++ b/src/card/card-styles.ts
@@ -116,7 +116,7 @@ export const cardStyles = css`
     user-select: none;
     font-family: sans-serif;
     position: absolute;
-    right: 0;
-    bottom: 0;
+    right: 6px;
+    bottom: 4px;
   }
 `;

--- a/test/card/__snapshots__/card-styles.test.ts.snap
+++ b/test/card/__snapshots__/card-styles.test.ts.snap
@@ -117,8 +117,8 @@ exports[`cardStyles > matches snapshot 1`] = `
     user-select: none;
     font-family: sans-serif;
     position: absolute;
-    right: 0;
-    bottom: 0;
+    right: 6px;
+    bottom: 4px;
   }
 "
 `;


### PR DESCRIPTION
## Summary
- Adjust `.card-date` CSS offsets from `right: 0; bottom: 0` to `right: 6px; bottom: 4px`
- Prevents date label from clipping against the card edge inside the shadow DOM

## Test plan
- [ ] Build and load card in HA — verify date label has visible padding from bottom-right edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)