### PR TITLE
fix(observer): eliminate horizon jump at midnight via 3D zenith projection

### DIFF
--- a/src/astronomy/solar-position.ts
+++ b/src/astronomy/solar-position.ts
@@ -28,6 +28,28 @@ export function getLocalTimeInZone(
   }
 }
 
+const OBLIQUITY_DEG = 23.45;
+const OBLIQUITY_RAD = (OBLIQUITY_DEG * Math.PI) / 180;
+
+/**
+ * Day-of-year and local solar hour angle shared by computeSolarElevationDeg and
+ * computeZenithAngleFromSun. localSolarHour uses UTC + longitude offset (1 hour per
+ * 15° longitude), independent of civil timezone — true solar time.
+ */
+function computeSolarTimeParams(
+  lon: number,
+  date: Date
+): { dayOfYear: number; hourAngleRad: number } {
+  const startOfYear = Date.UTC(date.getUTCFullYear(), 0, 0);
+  const dayOfYear = Math.floor((date.getTime() - startOfYear) / 86400000);
+
+  const utcHour = date.getUTCHours() + date.getUTCMinutes() / 60 + date.getUTCSeconds() / 3600;
+  const localSolarHour = (((utcHour + lon / 15) % 24) + 24) % 24;
+  const hourAngleRad = ((localSolarHour - 12) * 15 * Math.PI) / 180;
+
+  return { dayOfYear, hourAngleRad };
+}
+
 /**
  * Compute the Sun's true altitude above the observer's horizon using spherical
  * astronomy. Returns degrees in [-90, 90].
@@ -37,28 +59,17 @@ export function getLocalTimeInZone(
  *   H  = 15° × (localSolarHour - 12)                    ← hour angle
  *   sin(alt) = sin(lat)×sin(δ) + cos(lat)×cos(δ)×cos(H)
  *
- * localSolarHour uses UTC + longitude offset (1 hour per 15° longitude),
- * which is independent of civil timezone and gives true solar time.
- *
  * @param {number} lat - observer latitude in degrees
  * @param {number} lon - observer longitude in degrees (positive east)
  * @param {Date} date
  * @returns {number} solar altitude in degrees
  */
 export function computeSolarElevationDeg(lat: number, lon: number, date: Date): number {
-  // Day of year (1 = Jan 1)
-  const startOfYear = Date.UTC(date.getUTCFullYear(), 0, 0);
-  const dayOfYear = Math.floor((date.getTime() - startOfYear) / 86400000);
+  const { dayOfYear, hourAngleRad } = computeSolarTimeParams(lon, date);
 
   // Solar declination in radians
-  const declRad = (-23.45 * Math.cos(((2 * Math.PI) / 365) * (dayOfYear + 10)) * Math.PI) / 180;
-
-  // Local solar hour: UTC fractional hours + longitude offset (15°/hr)
-  const utcHour = date.getUTCHours() + date.getUTCMinutes() / 60 + date.getUTCSeconds() / 3600;
-  const localSolarHour = (((utcHour + lon / 15) % 24) + 24) % 24;
-
-  // Hour angle in radians (positive in afternoon)
-  const hourAngleRad = ((localSolarHour - 12) * 15 * Math.PI) / 180;
+  const declRad =
+    (-OBLIQUITY_DEG * Math.cos(((2 * Math.PI) / 365) * (dayOfYear + 10)) * Math.PI) / 180;
 
   const latRad = (lat * Math.PI) / 180;
   const sinAlt =
@@ -66,6 +77,67 @@ export function computeSolarElevationDeg(lat: number, lon: number, date: Date): 
     Math.cos(latRad) * Math.cos(declRad) * Math.cos(hourAngleRad);
 
   return (Math.asin(Math.max(-1, Math.min(1, sinAlt))) * 180) / Math.PI;
+}
+
+/**
+ * Compute the observer's true zenith direction, projected onto the ecliptic plane and
+ * expressed as an angle relative to the Earth→Sun direction (0 = zenith points straight at
+ * the Sun, ±π = zenith points straight away).
+ *
+ * This replaces the earlier approach of inverting the (idealized, tent-shaped) 2D elevation
+ * formula and reattaching a sign borrowed from the approximate orbital model — that inversion
+ * is two-valued whenever true elevation at 2D-midnight isn't exactly -90°, which is almost
+ * always, producing a real jump every night (#78).
+ *
+ * Instead this builds the observer's zenith as a 3D unit vector in an equatorial frame whose
+ * X-axis is defined as the sun's current meridian (so the existing hour-angle is directly
+ * usable, no separate sidereal-time calculation needed), rotates it into ecliptic coordinates
+ * via the standard obliquity rotation, and reads off the angle of its ecliptic-plane
+ * projection relative to the (known, calendar-approximate) ecliptic longitude of the Sun.
+ * Because both the magnitude (elevation) and direction (this angle) now come from the same
+ * self-consistent physical model, they agree exactly at the noon/midnight boundaries instead
+ * of disagreeing there — eliminating the structural discontinuity.
+ *
+ * ponytail: near the Arctic/Antarctic Circle, right at the moment the sun grazes the horizon
+ * at solstice, the projected zenith vector's in-plane component shrinks toward zero and the
+ * angle becomes geometrically ill-defined (like a compass at the magnetic pole) — a brief,
+ * rare visual glitch there, not a daily one. Add hysteresis (carry the previous frame's angle)
+ * if this specific case ever needs smoothing.
+ *
+ * @param {number} lat - observer latitude in degrees
+ * @param {number} lon - observer longitude in degrees (positive east)
+ * @param {Date} date
+ * @returns {number} angle in radians, (-π, π], relative to the Earth→Sun direction
+ */
+export function computeZenithAngleFromSun(lat: number, lon: number, date: Date): number {
+  const { dayOfYear, hourAngleRad } = computeSolarTimeParams(lon, date);
+
+  // Ecliptic longitude of the Sun, calendar-approximate, phase-matched to the declination
+  // formula above (theta=0 -> winter solstice, theta=π -> summer solstice).
+  const theta = ((2 * Math.PI) / 365) * (dayOfYear + 10);
+  const lambdaSun = theta - Math.PI / 2;
+  const raSun = Math.atan2(Math.cos(OBLIQUITY_RAD) * Math.sin(lambdaSun), Math.cos(lambdaSun));
+
+  const latRad = (lat * Math.PI) / 180;
+
+  // Zenith in an equatorial frame whose X-axis points at the Sun's current meridian.
+  const zxCustom = Math.cos(latRad) * Math.cos(hourAngleRad);
+  const zyCustom = Math.cos(latRad) * Math.sin(hourAngleRad);
+  const zzCustom = Math.sin(latRad);
+
+  // Rotate into the standard equatorial frame (X-axis at the vernal equinox).
+  const zxStd = zxCustom * Math.cos(raSun) - zyCustom * Math.sin(raSun);
+  const zyStd = zxCustom * Math.sin(raSun) + zyCustom * Math.cos(raSun);
+
+  // Rotate into the ecliptic frame (obliquity rotation about the shared X-axis).
+  const zxEcl = zxStd;
+  const zyEcl = zyStd * Math.cos(OBLIQUITY_RAD) + zzCustom * Math.sin(OBLIQUITY_RAD);
+
+  const zenithEclipticLon = Math.atan2(zyEcl, zxEcl);
+  return Math.atan2(
+    Math.sin(zenithEclipticLon - lambdaSun),
+    Math.cos(zenithEclipticLon - lambdaSun)
+  );
 }
 
 /**

--- a/src/renderer/observer.ts
+++ b/src/renderer/observer.ts
@@ -1,6 +1,10 @@
 import { calculatePlanetPosition } from "../astronomy/orbital-mechanics.js";
 import { EARTH } from "../astronomy/planet-data.js";
-import { computeSolarElevationDeg, getLocalTimeInZone } from "../astronomy/solar-position.js";
+import {
+  computeSolarElevationDeg,
+  computeZenithAngleFromSun,
+  getLocalTimeInZone,
+} from "../astronomy/solar-position.js";
 import type { LocationData } from "../types.js";
 import { CENTER, createSvgElement, MAX_RADIUS, VIEW_SIZE } from "./svg-utils.js";
 
@@ -42,23 +46,6 @@ export function calculateSolarElevationDeg(observerAngle: number, earthAngle: nu
   const dirToSun = earthAngle + Math.PI;
   const diff = Math.atan2(Math.sin(observerAngle - dirToSun), Math.cos(observerAngle - dirToSun));
   return (Math.PI / 2 - Math.abs(diff)) * (180 / Math.PI);
-}
-
-// Inverts 2D elevation formula using accurate spherical elev; preserves AM/PM sign; clamps ±89° for polar extremes.
-export function computeDisplayObserverAngle(
-  observerAngle: number,
-  earthAngle: number,
-  elevationDeg: number
-): number {
-  const sunDirection = earthAngle + Math.PI;
-  const signedDiff = Math.atan2(
-    Math.sin(observerAngle - sunDirection),
-    Math.cos(observerAngle - sunDirection)
-  );
-  const sign = signedDiff >= 0 ? 1 : -1;
-  const clampedElev = Math.max(-89, Math.min(89, elevationDeg));
-  const correctedDiff = sign * (Math.PI / 2 - (clampedElev * Math.PI) / 180);
-  return sunDirection + correctedDiff;
 }
 
 /**
@@ -172,14 +159,16 @@ export function renderDayNightSplit(
       ? computeSolarElevationDeg(locationData.lat, locationData.lon, date)
       : calculateSolarElevationDeg(observerAngle, earthAngle);
 
-  // When lat/lon is available, derive a display angle from the accurate elevation.
-  // The 2D orbital model assumes 12h day/night; at high latitudes this diverges
-  // significantly from true sunrise/sunset. The corrected angle aligns the cone
-  // direction, horizon, and zenith with the real sky. The needle keeps the
-  // time-based observerAngle so it continues showing Earth's rotation.
+  // When lat/lon is available, derive a display angle from the observer's true zenith
+  // direction, projected onto the ecliptic plane. The 2D orbital model assumes 12h
+  // day/night; at high latitudes this diverges significantly from true sunrise/sunset.
+  // The projection is continuous through both solar noon and midnight by construction,
+  // unlike inverting elevation with a sign borrowed from the approximate 2D model (which
+  // jumped at midnight — see #78). The needle keeps the time-based observerAngle so it
+  // continues showing Earth's rotation.
   const displayObserverAngle =
-    locationData?.lat != null
-      ? computeDisplayObserverAngle(observerAngle, earthAngle, elevationDeg)
+    locationData && locationData.lat != null
+      ? earthAngle + Math.PI + computeZenithAngleFromSun(locationData.lat, locationData.lon, date)
       : observerAngle;
 
   let coneColor: string;

--- a/test/renderer/observer.test.ts
+++ b/test/renderer/observer.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { calculatePlanetPosition } from "../../src/astronomy/orbital-mechanics.js";
 import { PLANETS } from "../../src/astronomy/planet-data.js";
+import { computeSolarElevationDeg } from "../../src/astronomy/solar-position.js";
 import {
   CONE_ASTRONOMICAL,
   CONE_CIVIL,
@@ -485,5 +486,35 @@ describe("computeDisplayObserverAngle", () => {
       Math.atan2(Math.sin(corrected - sunDir), Math.cos(corrected - sunDir))
     );
     expect(diffCorrected).toBeLessThan(diff2D);
+  });
+
+  it("stays continuous across midnight — no large jump between consecutive 10-min samples", () => {
+    // Regression test for the sign-flip discontinuity at the atan2 ±π branch (astronomical
+    // midnight): correctedDiff's sign flips there while its magnitude stays the same,
+    // producing a jump of ~2*(π/2 - elevRad) — largest when elevation is deep negative (night).
+    const lat = 40;
+    const lon = -97;
+    const timezone = "America/Chicago";
+    const start = new Date("2025-01-15T00:00:00Z"); // window crosses local midnight
+
+    let prevDisplay: number | null = null;
+    let maxJumpDeg = 0;
+
+    for (let m = 0; m < 24 * 60; m += 10) {
+      const date = new Date(start.getTime() + m * 60000);
+      const earthAngle = calculatePlanetPosition(earth, date);
+      const observerAngle = calculateObserverAngle(earthAngle, date, timezone, lon);
+      const elevationDeg = computeSolarElevationDeg(lat, lon, date);
+      const display = computeDisplayObserverAngle(observerAngle, earthAngle, elevationDeg);
+
+      if (prevDisplay !== null) {
+        const jumpDeg = (angleDiff(display, prevDisplay) * 180) / Math.PI;
+        maxJumpDeg = Math.max(maxJumpDeg, jumpDeg);
+      }
+      prevDisplay = display;
+    }
+
+    // Sun's apparent motion is ~360°/24h ≈ 1.5° per 10-min step; allow generous margin.
+    expect(maxJumpDeg).toBeLessThan(5);
   });
 });

--- a/test/renderer/observer.test.ts
+++ b/test/renderer/observer.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { calculatePlanetPosition } from "../../src/astronomy/orbital-mechanics.js";
 import { PLANETS } from "../../src/astronomy/planet-data.js";
-import { computeSolarElevationDeg } from "../../src/astronomy/solar-position.js";
+import { computeZenithAngleFromSun } from "../../src/astronomy/solar-position.js";
 import {
   CONE_ASTRONOMICAL,
   CONE_CIVIL,
@@ -10,7 +10,6 @@ import {
   CONE_NIGHT,
   calculateObserverAngle,
   calculateSolarElevationDeg,
-  computeDisplayObserverAngle,
   rayCircleDistance,
   renderDayNightSplit,
   renderObserverNeedle,
@@ -279,19 +278,13 @@ describe("renderDayNightSplit cone bisector geometry", () => {
     expect(diffFromSun).toBeLessThan(Math.PI / 2);
   });
 
-  it("cone bisector extraction is consistent with direct computeDisplayObserverAngle", () => {
+  it("cone bisector extraction is consistent with direct azimuth-based angle", () => {
     // End-to-end check: bisector read from SVG should match the angle the fix computes.
     const date = new Date("2025-07-15T19:00:00Z");
     const locationData = { lat: 55, lon: 0, timezone: "Europe/London" };
     const earthAngle = calculatePlanetPosition(earth, date);
-    const observerAngle = calculateObserverAngle(
-      earthAngle,
-      date,
-      locationData.timezone,
-      locationData.lon
-    );
-    const elevationDeg = 8.5; // known spherical elevation for this scenario
-    const expectedBisector = computeDisplayObserverAngle(observerAngle, earthAngle, elevationDeg);
+    const expectedBisector =
+      earthAngle + Math.PI + computeZenithAngleFromSun(locationData.lat, locationData.lon, date);
 
     const svg = createSvg();
     renderDayNightSplit(svg, 200, date, earth.size, locationData);
@@ -418,48 +411,39 @@ describe("renderDayNightSplit horizon and zenith lines", () => {
   });
 });
 
-describe("computeDisplayObserverAngle", () => {
+describe("computeZenithAngleFromSun", () => {
   const earth = PLANETS.find((p) => p.name === "Earth");
 
-  it("round-trips correctly: displayAngle plugged back into 2D formula yields input elevation", () => {
-    // For any elevation in the non-clamped range, the display angle should reproduce
-    // that elevation when fed back into the 2D formula.
-    const earthAngle = 1.0;
-    const observerAngle = earthAngle + Math.PI / 3; // some arbitrary angle
-    for (const elev of [45, 30, 10, -5, -15]) {
-      const display = computeDisplayObserverAngle(observerAngle, earthAngle, elev);
-      const backCalc = calculateSolarElevationDeg(display, earthAngle);
-      expect(backCalc).toBeCloseTo(elev, 0);
-    }
+  it("at local solar noon (equator), zenith points almost exactly at the Sun", () => {
+    const date = new Date("2025-03-20T12:00:00Z"); // equinox, equator, lon=0 → local noon
+    const angle = computeZenithAngleFromSun(0, 0, date);
+    expect(Math.abs(angle)).toBeLessThan(0.02);
   });
 
-  it("preserves AM/PM side (morning observer stays in morning half-space)", () => {
-    // Observer on morning side: observerAngle is between midnight (earthAngle) and noon (earthAngle+π)
-    // In 2D, morning corresponds to signedDiff > 0 from sunDirection
-    const earthAngle = 1.0;
+  it("at local solar midnight (equator), zenith points almost exactly away from the Sun", () => {
+    const date = new Date("2025-03-20T00:00:00Z");
+    const angle = computeZenithAngleFromSun(0, 0, date);
+    expect(angleDiff(angle, Math.PI)).toBeLessThan(0.02);
+  });
+
+  it("with lat/lon at high latitude summer, angle stays within 90° of Sun (day), unlike raw 2D angle", () => {
+    // July at 55°N, 19:00 UTC: 2D model says night (~105° from Sun), spherical says day (+9.4°)
+    const date = new Date("2025-07-15T19:00:00Z");
+    const earthAngle = calculatePlanetPosition(earth, date);
     const sunDir = earthAngle + Math.PI;
-    // Place observer at earthAngle + π/4 (morning, between midnight and sunrise in 2D terms)
-    // signedDiff = observerAngle - sunDir ≈ -3π/4 → negative → "evening" side in solar terms
-    // Let's use a clearer setup: observer at sunDir - π/2 (sunrise-ish, morning side)
-    const observerAngle = sunDir - Math.PI / 2; // 90° before noon = morning
-    const display = computeDisplayObserverAngle(observerAngle, earthAngle, 0);
-    // Still on the morning side: signedDiff should remain negative
-    const correctedDiff = Math.atan2(Math.sin(display - sunDir), Math.cos(display - sunDir));
-    const originalDiff = Math.atan2(
-      Math.sin(observerAngle - sunDir),
-      Math.cos(observerAngle - sunDir)
+    const observerAngle2D = calculateObserverAngle(earthAngle, date, "Europe/London", 0);
+    const diff2D = Math.abs(
+      Math.atan2(Math.sin(observerAngle2D - sunDir), Math.cos(observerAngle2D - sunDir))
     );
-    expect(Math.sign(correctedDiff)).toBe(Math.sign(originalDiff));
-  });
 
-  it("clamps extreme polar elevation (±89°) to avoid collapse", () => {
-    const earthAngle = 0;
-    const observerAngle = earthAngle + Math.PI; // noon direction
-    // elevation = 95° is beyond physical range; should be clamped to 89°
-    const result = computeDisplayObserverAngle(observerAngle, earthAngle, 95);
-    const backCalc = calculateSolarElevationDeg(result, earthAngle);
-    // Should correspond to 89° (clamped), not collapse to 0° direction
-    expect(backCalc).toBeCloseTo(89, 0);
+    const angle = computeZenithAngleFromSun(55, 0, date);
+    expect(Math.abs(angle)).toBeLessThan(Math.PI / 2); // agrees with positive elevation: day side
+
+    const corrected = earthAngle + Math.PI + angle;
+    const diffCorrected = Math.abs(
+      Math.atan2(Math.sin(corrected - sunDir), Math.cos(corrected - sunDir))
+    );
+    expect(diffCorrected).toBeLessThan(diff2D);
   });
 
   it("without lat/lon, renderDayNightSplit horizon is perpendicular to observerAngle (no correction)", () => {
@@ -472,49 +456,33 @@ describe("computeDisplayObserverAngle", () => {
     expect(lines.length).toBe(2);
   });
 
-  it("with lat/lon at high latitude summer, corrected angle is closer to Sun than raw 2D angle", () => {
-    // July at 55°N, 19:00 UTC: 2D model says night (~105° from Sun), spherical says day (+8.5°)
-    const date = new Date("2025-07-15T19:00:00Z");
-    const earthAngle = calculatePlanetPosition(earth, date);
-    const sunDir = earthAngle + Math.PI;
-    const observerAngle2D = calculateObserverAngle(earthAngle, date, "Europe/London", 0);
-    const diff2D = Math.abs(
-      Math.atan2(Math.sin(observerAngle2D - sunDir), Math.cos(observerAngle2D - sunDir))
-    );
-    const corrected = computeDisplayObserverAngle(observerAngle2D, earthAngle, 8.5);
-    const diffCorrected = Math.abs(
-      Math.atan2(Math.sin(corrected - sunDir), Math.cos(corrected - sunDir))
-    );
-    expect(diffCorrected).toBeLessThan(diff2D);
-  });
-
-  it("stays continuous across midnight — no large jump between consecutive 10-min samples", () => {
-    // Regression test for the sign-flip discontinuity at the atan2 ±π branch (astronomical
-    // midnight): correctedDiff's sign flips there while its magnitude stays the same,
-    // producing a jump of ~2*(π/2 - elevRad) — largest when elevation is deep negative (night).
+  it("stays continuous across midnight — no large jump between consecutive 1-min samples", () => {
+    // Regression test for #78: the old inversion (magnitude from accurate elevation, sign
+    // reattached from the approximate 2D model) flipped sign at the atan2 ±π branch
+    // (astronomical midnight) while magnitude stayed the same, producing a jump of
+    // ~2*(π/2 - elevRad) — largest when elevation is deep negative (night). Projecting the
+    // true 3D zenith vector is continuous through that point by construction, since magnitude
+    // and direction now come from the same self-consistent physical model.
     const lat = 40;
     const lon = -97;
-    const timezone = "America/Chicago";
     const start = new Date("2025-01-15T00:00:00Z"); // window crosses local midnight
 
-    let prevDisplay: number | null = null;
+    let prevAngle: number | null = null;
     let maxJumpDeg = 0;
 
-    for (let m = 0; m < 24 * 60; m += 10) {
+    for (let m = 0; m < 24 * 60; m += 1) {
       const date = new Date(start.getTime() + m * 60000);
-      const earthAngle = calculatePlanetPosition(earth, date);
-      const observerAngle = calculateObserverAngle(earthAngle, date, timezone, lon);
-      const elevationDeg = computeSolarElevationDeg(lat, lon, date);
-      const display = computeDisplayObserverAngle(observerAngle, earthAngle, elevationDeg);
+      const angle = computeZenithAngleFromSun(lat, lon, date);
 
-      if (prevDisplay !== null) {
-        const jumpDeg = (angleDiff(display, prevDisplay) * 180) / Math.PI;
+      if (prevAngle !== null) {
+        const jumpDeg = (angleDiff(angle, prevAngle) * 180) / Math.PI;
         maxJumpDeg = Math.max(maxJumpDeg, jumpDeg);
       }
-      prevDisplay = display;
+      prevAngle = angle;
     }
 
-    // Sun's apparent motion is ~360°/24h ≈ 1.5° per 10-min step; allow generous margin.
-    expect(maxJumpDeg).toBeLessThan(5);
+    // Real azimuthal rate peaks near culmination (measured ~0.43°/min at this lat/season),
+    // well below the ~0.25°/min naive average but nowhere near the old bug's 122° jump.
+    expect(maxJumpDeg).toBeLessThan(2);
   });
 });


### PR DESCRIPTION
Closes #78.

## Problem

The horizon line jumped visibly as time crossed midnight, worst in deep night.

`computeDisplayObserverAngle` inverted the idealized (tent-shaped) 2D elevation formula and reattached a sign borrowed from the approximate orbital model. That inversion is two-valued whenever true elevation at 2D-midnight isn't exactly -90° — which is almost always true off-equator/off-equinox — producing a real discontinuity every night, confirmed at 122° for a Chicago/January scenario.

## Fix

Replaced with `computeZenithAngleFromSun`: builds the observer's true zenith as a 3D unit vector (equatorial frame anchored to the sun's current meridian, so the existing hour-angle is reused directly), rotates equatorial → ecliptic via obliquity, and reads off the projected angle relative to the Sun direction. Magnitude and direction now come from the same self-consistent physical model, so they agree exactly at the noon/midnight boundaries instead of disagreeing there.

A documented remaining edge case (`ponytail:` comment in the code): right at the Arctic/Antarctic Circle during the exact hour the sun grazes the horizon at solstice, the projected zenith vector's in-plane component shrinks toward zero and the angle becomes geometrically ill-defined — a brief, rare visual glitch there, not a daily one like the original bug.

## Test plan

- [x] Regression test added first (red), confirmed it failed against the pre-fix code (122° jump)
- [x] Fix applied, regression test green (max jump 0.43°/min at Chicago/January, threshold 2°/min)
- [x] `npm run test:coverage` — 420 tests pass, 100% coverage
- [x] `npm run check:ci` — typecheck + biome + prettier clean
- [x] `/ponytail-review` run, findings applied (shared time-param helper, single obliquity constant source, merged overlapping tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)