### PR TITLE
chore: add dev script for rollup watch mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "prepare": "git config core.hooksPath .githooks 2>/dev/null || true",
     "build": "rollup -c",
     "build:prod": "NODE_ENV=production rollup -c",
+    "dev": "rollup -c -w",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",


### PR DESCRIPTION
## Summary

- \`CLAUDE-SHARED.md\`'s documented dev workflow references \`npm run dev\` for local iteration against the \`docs/\` demo page, but this repo's \`package.json\` never actually had that script.
- Adds \`"dev": "rollup -c -w"\` — watch mode, rebuilds \`dist/card.js\` (symlinked from \`docs/card.js\`) on save.

## Test plan

- [x] \`npm run dev\` builds cleanly and enters watch mode
- [x] \`npm run check:ci\` clean
- [x] Pre-commit hook (test:coverage + check) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)