### PR TITLE
fix(card): replay anchors to displayed date, not real now

### DIFF
--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -292,9 +292,11 @@ export class SolarViewCard extends LitElement {
   }
 
   private _startReplay(): void {
+    const wasLiveMode = this._isLiveMode;
+    const endTime = this._currentDate.getTime();
+    const startTime = endTime - REPLAY_WINDOW_MS;
     this._isLiveMode = false;
     this._isReplaying = true;
-    const startTime = Date.now() - REPLAY_WINDOW_MS;
     let step = 0;
     this._currentDate = new Date(startTime);
     this._render();
@@ -302,7 +304,7 @@ export class SolarViewCard extends LitElement {
     this._replayTimer = setInterval(() => {
       step++;
       if (step >= REPLAY_STEPS) {
-        this._finishReplay();
+        this._finishReplay(endTime, wasLiveMode);
         return;
       }
       this._currentDate = new Date(startTime + step * REPLAY_STEP_MS);
@@ -310,13 +312,15 @@ export class SolarViewCard extends LitElement {
     }, REPLAY_INTERVAL_MS) as unknown as number;
   }
 
-  private _finishReplay(): void {
+  private _finishReplay(endTime: number, resumeLiveMode: boolean): void {
     /* v8 ignore next */
     clearInterval(this._replayTimer ?? undefined);
     this._replayTimer = null;
     this._isReplaying = false;
-    this._isLiveMode = true;
-    this._currentDate = new Date();
+    this._isLiveMode = resumeLiveMode;
+    // If replay started from live mode, land on real "now" (time passed during the
+    // animation); otherwise return exactly to the date the user had paused on.
+    this._currentDate = resumeLiveMode ? new Date() : new Date(endTime);
     this._render();
   }
 

--- a/test/card/card.test.ts
+++ b/test/card/card.test.ts
@@ -482,6 +482,24 @@ describe("SolarViewCard", () => {
       card.remove();
     });
 
+    it("replays the 24h ending at the currently displayed date, not real now", () => {
+      // Real "now" is Feb 15, but the user has navigated to a past date and paused there.
+      vi.useFakeTimers({ now: new Date("2026-02-15T12:00:00Z") });
+      const card = createAndMount();
+      card._currentDate = new Date("2026-01-01T06:00:00Z");
+      card._isLiveMode = false;
+      card._render();
+
+      clickButton(card, "replay");
+      expect(card._currentDate.toISOString()).toBe(new Date("2025-12-31T06:00:00Z").toISOString());
+
+      vi.advanceTimersByTime(208 * 72);
+      // Lands back exactly on the pre-replay date, not real now, and stays paused.
+      expect(card._currentDate.toISOString()).toBe(new Date("2026-01-01T06:00:00Z").toISOString());
+      expect(card._isLiveMode).toBe(false);
+      card.remove();
+    });
+
     it("clicking replay again cancels it mid-flight", () => {
       vi.useFakeTimers({ now: new Date("2026-02-15T12:00:00Z") });
       const card = createAndMount();


### PR DESCRIPTION
## Summary

- Replay's 24h window was always anchored to real \`Date.now()\`, ignoring where the user had navigated to. If you'd paused on a past date and clicked replay, it would jump to a window ending at real "now" instead of your displayed date.
- Now anchors to \`_currentDate\` (wherever the card is currently showing): replays the 24h ending there, and on completion returns exactly to that date, staying paused, unless the card was actually in live mode when replay started (in which case it lands on real "now", same as before, since live mode already tracks "now").

## Test plan

- [x] Test written first (red) against old \`Date.now()\`-anchored behavior
- [x] \`npm run test:coverage\` — 428 tests pass, 100% coverage
- [x] \`npm run check:ci\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)