### PR TITLE
fix(observer): theme-symmetric twilight cone colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
 Home Assistant custom Lovelace card showing all 8 planets, Moon and comet Halley aligned around the
 Sun. Navigate time, zoom, and pan interactively.
 
+Have an idea or found a bug?
+[Open a GitHub issue](https://github.com/marcintk/ha-planetary-solar-system-card/issues/new).
+
 ## Preview
 
 [**→ Try the interactive demo**](https://marcintk.github.io/ha-planetary-solar-system-card/)
@@ -56,6 +59,7 @@ default_zoom: 2
 | `colors`               | object                 | see below | Color overrides (see Colors)                                                               |
 | `ecliptic_view`        | `"north"` \| `"south"` | `"north"` | Viewing pole: `"north"` = counter-clockwise orbits (default); `"south"` = clockwise orbits |
 | `show_version`         | boolean                | `false`   | Show card version number in the bottom-right corner of the nav bar                         |
+| `debug`                | boolean                | `false`   | Opt in to try in-progress/beta features — currently: replay button (↺, replays last 6h)    |
 
 ### Colors
 
@@ -78,6 +82,19 @@ colors:
   orbit: "rgba(100, 200, 255, 0.2)"
   label: "#e0e0ff"
 ```
+
+### Horizon Twilight Zones
+
+The visibility cone at Earth's orbit shades by how far the Sun is below your local horizon, using
+the standard astronomical twilight definitions:
+
+| Zone                  | Sun elevation | Meaning                                                          |
+| --------------------- | ------------- | ---------------------------------------------------------------- |
+| Day                   | ≥ 0°          | Sun is up                                                        |
+| Civil twilight        | 0° to -6°     | Bright enough for outdoor activity without lights                |
+| Nautical twilight     | -6° to -12°   | Horizon still visible at sea; too dark for most outdoor activity |
+| Astronomical twilight | -12° to -18°  | Sky background glow, faint stars washed out                      |
+| Night                 | < -18°        | Full dark; the Sun no longer lights the sky                      |
 
 ## Development
 

--- a/src/renderer/observer.ts
+++ b/src/renderer/observer.ts
@@ -10,11 +10,14 @@ import { CENTER, createSvgElement, MAX_RADIUS, VIEW_SIZE } from "./svg-utils.js"
 
 const NEEDLE_COLOR = "color-mix(in srgb, currentColor 70%, transparent)";
 
-export const CONE_DAY = "rgba(255, 255, 255, 0.1)"; // Sun above horizon
-export const CONE_CIVIL = "rgba(255, 220, 160, 0.08)"; // Civil twilight:        0° to -6°
-export const CONE_NAUTICAL = "rgba(160, 190, 255, 0.06)"; // Nautical twilight:   -6° to -12°
-export const CONE_ASTRONOMICAL = "rgba(80, 100, 200, 0.04)"; // Astronomical twilight: -12° to -18°
-export const CONE_NIGHT = "rgba(255, 255, 255, 0.01)"; // Sun below -18°
+// White-based (day family) pops on dark theme, fades on light theme.
+// Black-based (night family) pops on light theme, fades on dark theme.
+// Alpha blending onto a matching background gives this contrast flip for free.
+export const CONE_DAY = "rgba(255, 255, 255, 0.10)"; // Sun above horizon
+export const CONE_CIVIL = "rgba(255, 220, 160, 0.09)"; // Civil twilight:        0° to -6°
+export const CONE_NAUTICAL = "rgba(128, 128, 128, 0.08)"; // Nautical twilight:  -6° to -12°
+export const CONE_ASTRONOMICAL = "rgba(20, 20, 40, 0.10)"; // Astronomical twilight: -12° to -18°
+export const CONE_NIGHT = "rgba(0, 0, 0, 0.12)"; // Sun below -18°
 
 /**
  * Compute the distance from point (ax,ay) along direction (dx,dy) to the

--- a/test/renderer/observer.test.ts
+++ b/test/renderer/observer.test.ts
@@ -107,12 +107,18 @@ describe("cone color constants", () => {
     expect(colors.size).toBe(5);
   });
 
-  it("CONE_DAY is brightest (highest alpha)", () => {
-    const extractAlpha = (c) => Number(c.match(/[\d.]+(?=\))/)[0]);
-    expect(extractAlpha(CONE_DAY)).toBeGreaterThan(extractAlpha(CONE_CIVIL));
-    expect(extractAlpha(CONE_CIVIL)).toBeGreaterThan(extractAlpha(CONE_NAUTICAL));
-    expect(extractAlpha(CONE_NAUTICAL)).toBeGreaterThan(extractAlpha(CONE_ASTRONOMICAL));
-    expect(extractAlpha(CONE_ASTRONOMICAL)).toBeGreaterThan(extractAlpha(CONE_NIGHT));
+  it("cone colors darken from day (white) to night (black)", () => {
+    // Day-family zones are white-based (pop on dark theme, fade on light theme);
+    // night-family zones are black-based (pop on light theme, fade on dark theme).
+    // The RGB sum should fall monotonically across the elevation bands.
+    const rgbSum = (c) => {
+      const [, r, g, b] = c.match(/rgba\((\d+), (\d+), (\d+)/).map(Number);
+      return r + g + b;
+    };
+    expect(rgbSum(CONE_DAY)).toBeGreaterThan(rgbSum(CONE_CIVIL));
+    expect(rgbSum(CONE_CIVIL)).toBeGreaterThan(rgbSum(CONE_NAUTICAL));
+    expect(rgbSum(CONE_NAUTICAL)).toBeGreaterThan(rgbSum(CONE_ASTRONOMICAL));
+    expect(rgbSum(CONE_ASTRONOMICAL)).toBeGreaterThan(rgbSum(CONE_NIGHT));
   });
 });
 


### PR DESCRIPTION
## Summary
- Night-family cones (astronomical, night) flip to black-based colors so they're visible on light theme and blend on dark theme, mirroring day-family white-based cones — fixes low visibility in HA light mode.
- Nautical twilight becomes a neutral grey midpoint.
- README: document `debug` config option, add horizon twilight zone reference table, add GH issues callout.

## Test plan
- [x] `npm run test:coverage` — 429 passed, 100% coverage
- [x] `npm run check:ci` — typecheck + biome + prettier clean
- [x] `/ponytail-review` — no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)