### PR TITLE
fix(observer): align twilight cone half-angle with projected zenith axis

### DIFF
--- a/src/renderer/observer.ts
+++ b/src/renderer/observer.ts
@@ -169,10 +169,12 @@ export function renderDayNightSplit(
   // unlike inverting elevation with a sign borrowed from the approximate 2D model (which
   // jumped at midnight — see #78). The needle keeps the time-based observerAngle so it
   // continues showing Earth's rotation.
-  const displayObserverAngle =
+  const zenithAngleFromSun =
     locationData && locationData.lat != null
-      ? earthAngle + Math.PI + computeZenithAngleFromSun(locationData.lat, locationData.lon, date)
-      : observerAngle;
+      ? computeZenithAngleFromSun(locationData.lat, locationData.lon, date)
+      : null;
+  const displayObserverAngle =
+    zenithAngleFromSun != null ? earthAngle + Math.PI + zenithAngleFromSun : observerAngle;
 
   let coneColor: string;
   if (elevationDeg >= 0) coneColor = CONE_DAY;
@@ -180,7 +182,20 @@ export function renderDayNightSplit(
   else if (elevationDeg >= -12) coneColor = CONE_NAUTICAL;
   else if (elevationDeg >= -18) coneColor = CONE_ASTRONOMICAL;
   else coneColor = CONE_NIGHT;
-  const halfAngle = elevationDeg >= 0 || elevationDeg < -18 ? 90 : 90 - elevationDeg;
+
+  // Twilight half-angle must expand in the SAME frame as displayObserverAngle (the cone's
+  // axis), or the two disagree away from solar noon/midnight. displayObserverAngle is built
+  // from zenithAngleFromSun, an ecliptic-PLANE PROJECTION of the true 3D zenith angle — so
+  // reuse that same projected magnitude here instead of the true unprojected (90 -
+  // elevationDeg), which was silently assumed to be interchangeable with it. Using the
+  // mismatched true-angle magnitude on a projected axis is exactly what pushed the -6/-12/-18
+  // cone edges away from the Sun's actual direction after sunset (worst at mid latitudes).
+  const halfAngle =
+    elevationDeg >= 0 || elevationDeg < -18
+      ? 90
+      : zenithAngleFromSun != null
+        ? (Math.abs(zenithAngleFromSun) * 180) / Math.PI
+        : 90 - elevationDeg;
   renderVisibilityCone(
     svg,
     anchorX,

--- a/test/renderer/observer.test.ts
+++ b/test/renderer/observer.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { calculatePlanetPosition } from "../../src/astronomy/orbital-mechanics.js";
 import { PLANETS } from "../../src/astronomy/planet-data.js";
-import { computeZenithAngleFromSun } from "../../src/astronomy/solar-position.js";
+import {
+  computeSolarElevationDeg,
+  computeZenithAngleFromSun,
+} from "../../src/astronomy/solar-position.js";
 import {
   CONE_ASTRONOMICAL,
   CONE_CIVIL,
@@ -298,6 +301,104 @@ describe("renderDayNightSplit cone bisector geometry", () => {
     const bisector = coneBisectorAngle(svg);
     expect(angleDiff(bisector, expectedBisector)).toBeLessThan(0.05); // within ~3°
   });
+});
+
+describe("renderDayNightSplit twilight cone/line edges drift from the Sun", () => {
+  // Extract the near-Sun cone edge angle from the rendered SVG clip path.
+  // Path format: "M anchorX anchorY L leftX leftY A D D 0 flag 1 rightX rightY Z"
+  function coneEdgeAngles(svg: SVGElement): { left: number; right: number } {
+    const path = svg.querySelector("clipPath path");
+    const coords = path
+      .getAttribute("d")
+      .match(/-?[\d.]+/g)
+      .map(Number);
+    const anchorX = coords[0];
+    const anchorY = coords[1];
+    const leftX = coords[2];
+    const leftY = coords[3];
+    const rightX = coords[9];
+    const rightY = coords[10];
+    // SVG y is inverted (eclipticViewDirection = -1), flip back to math coords
+    return {
+      left: Math.atan2(-(leftY - anchorY), leftX - anchorX),
+      right: Math.atan2(-(rightY - anchorY), rightX - anchorX),
+    };
+  }
+
+  const earth = PLANETS.find((p) => p.name === "Earth");
+
+  // Scan forward minute-by-minute from `start` and return the first dusk (descending)
+  // crossing time of each twilight boundary (-6, -12, -18), or null if not found within
+  // the window. Mirrors the bracket-scan approach already used by computeNextTransitionTime.
+  function findDuskCrossings(
+    lat: number,
+    lon: number,
+    start: Date,
+    windowHours = 36
+  ): Record<-6 | -12 | -18, Date | null> {
+    const targets = [-6, -12, -18] as const;
+    const result: Record<-6 | -12 | -18, Date | null> = { "-6": null, "-12": null, "-18": null };
+    let prevElev = computeSolarElevationDeg(lat, lon, start);
+    for (let m = 1; m <= windowHours * 60; m++) {
+      const t = new Date(start.getTime() + m * 60000);
+      const elev = computeSolarElevationDeg(lat, lon, t);
+      for (const target of targets) {
+        if (result[target] === null && prevElev > target && elev <= target) {
+          // Use the prior minute: still inside the band (elevationDeg > target), matching
+          // the renderer's own >= target convention for band membership.
+          result[target] = new Date(t.getTime() - 60000);
+        }
+      }
+      prevElev = elev;
+    }
+    return result;
+  }
+
+  // Angular gap (degrees) between the true Sun direction and the nearer edge of the
+  // rendered twilight cone, for a given observer location/time.
+  function nearSunEdgeDiffDeg(lat: number, lon: number, date: Date): number {
+    const earthAngle = calculatePlanetPosition(earth, date);
+    const sunDir = earthAngle + Math.PI;
+
+    const svg = createSvg();
+    renderDayNightSplit(svg, 200, date, earth.size, { lat, lon });
+
+    const { left, right } = coneEdgeAngles(svg);
+    const nearSunDiff = Math.min(angleDiff(left, sunDir), angleDiff(right, sunDir));
+    return (nearSunDiff * 180) / Math.PI;
+  }
+
+  // Locations spanning both hemispheres, low/mid/high latitude — the projection error
+  // scales with latitude and season, so a single-location test could get lucky.
+  const locations = [
+    { name: "Denton, TX (mid-lat, N)", lat: 33.2148, lon: -97.1331 },
+    { name: "London, UK (mid-lat, N)", lat: 51.5074, lon: -0.1278 },
+    { name: "Sydney, AU (mid-lat, S)", lat: -33.8688, lon: 151.2093 },
+    { name: "Reykjavik, IS (high-lat, N)", lat: 64.1466, lon: -21.9426 },
+    { name: "Quito, EC (equator)", lat: -0.1807, lon: -78.4678 },
+  ];
+  // Two seasons per location so the check isn't tied to one time of year.
+  const seasonStarts = [new Date("2026-01-01T00:00:00Z"), new Date("2026-07-01T00:00:00Z")];
+
+  for (const loc of locations) {
+    for (const seasonStart of seasonStarts) {
+      const crossings = findDuskCrossings(loc.lat, loc.lon, seasonStart);
+      for (const target of [-6, -12, -18] as const) {
+        const crossingDate = crossings[target];
+        if (crossingDate === null) continue; // polar day/night at this location/season
+        it(`${loc.name} @ ${crossingDate.toISOString()} (${target}° twilight boundary): cone edge should point at the Sun`, () => {
+          const diffDeg = nearSunEdgeDiffDeg(loc.lat, loc.lon, crossingDate);
+          // If the cone/twilight-line geometry were correct, the boundary edge nearest the
+          // Sun would coincide with the Sun's true direction (~0°). It doesn't: the cone
+          // half-angle (90 - elevationDeg) is built from the true, unprojected 3D zenith
+          // angle, while the cone's axis (displayObserverAngle) is built from
+          // computeZenithAngleFromSun's ecliptic-plane *projection* of that same angle. The
+          // two only agree exactly at solar noon/midnight.
+          expect(diffDeg).toBeLessThan(1);
+        });
+      }
+    }
+  }
 });
 
 describe("rayCircleDistance", () => {


### PR DESCRIPTION
## Summary
- Twilight cone (-6°/-12°/-18°) edges drifted away from the Sun's true direction after sunset, worst at mid-latitudes in summer. The cone's axis (`displayObserverAngle`) is built from `computeZenithAngleFromSun`'s ecliptic-plane *projection*, but the half-angle used the true unprojected `90 - elevationDeg` — the two only agreed exactly at solar noon/midnight.
- Fix: reuse the same projected zenith-angle magnitude for the half-angle, so axis and width come from one self-consistent number.

## Test plan
- [x] Added a bug-confirmation test scanning 5 locations (Denton TX, London, Sydney, Reykjavik, Quito) × 2 seasons × all 3 twilight boundaries — 20/25 cases failed against the old code, confirmed fixed against the new code.
- [x] `npm run test:coverage` — 455/455 passing, 100% coverage maintained.
- [x] `npm run check:ci` — typecheck, biome, prettier all clean.