### PR TITLE
docs: drop empty Development section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,3 @@ colors:
   orbit: "rgba(100, 200, 255, 0.2)"
   label: "#e0e0ff"
 ```
-
-## Development
-
-See [CLAUDE.md](CLAUDE.md) for build commands, design invariants, and release instructions.


### PR DESCRIPTION
Removes a two-line section that only pointed to CLAUDE.md with no content of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)