### PR TITLE
feat: add L1 imagery panel (live NASA EPIC/SOHO Earth-Sun views)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,9 @@ colors:
 
 ### L1 Imagery
 
-Set `gallery.mode` to something other than `"none"` and the thumbnail strip with live
-[NASA SDO](https://sdo.gsfc.nasa.gov/) and [EPIC/DSCOVR](https://epic.gsfc.nasa.gov/) L1 Lagrange
-point imagery shows automatically — no click needed. A nav button (▦) lets you close and reopen the
-strip afterward. `"none"` by default (button hidden, nothing fetched).
+Set `gallery.mode` to something other than `"none"` and the thumbnail strip with live NASA Earth and
+Sun imagery shows automatically — no click needed. A nav button (▦) lets you close and reopen the
+strip afterward. `"none"` by default (button hidden, nothing fetched, nothing ever collected).
 
 | Mode    | Strip shows                                                                       |
 | ------- | --------------------------------------------------------------------------------- |
@@ -114,14 +113,26 @@ strip afterward. `"none"` by default (button hidden, nothing fetched).
 | `both`  | Earth and Sun thumbnails together                                                 |
 | `slide` | One thumbnail, flipping between Earth and Sun every `gallery.slide_interval_secs` |
 
-| Thumbnail | Source                 | Look                                | Background refresh |
-| --------- | ---------------------- | ----------------------------------- | ------------------ |
-| L1→EARTH  | NASA EPIC/DSCOVR       | Earth, natural color                | Every 1 hour       |
-| L1→SUN    | NASA SDO HMI Continuum | Sunspots, visible-light photosphere | Every 15 minutes   |
+| Thumbnail | Source                                                                                     | Look                                |
+| --------- | ------------------------------------------------------------------------------------------ | ----------------------------------- |
+| L1→EARTH  | [NASA EPIC](https://epic.gsfc.nasa.gov/), aboard DSCOVR at the Sun-Earth L1 Lagrange point | Earth, natural color                |
+| L1→SUN    | [NASA SDO](https://sdo.gsfc.nasa.gov/), in geosynchronous Earth orbit (not actually at L1) | Sunspots, visible-light photosphere |
 
-Clicking any thumbnail always opens the full-screen image view (unaffected by mode). Background
-fetching for a source only happens while its thumbnail is visible in the strip, or its full-screen
-view is open — never while `gallery.mode` is `"none"` or the strip/panel is closed.
+Both sources publish new frames on their own schedule, independent of this card:
+
+- **EPIC/DSCOVR** posts a new Earth image roughly every 1-2 hours; the card polls for a new one once
+  an hour while a thumbnail or full view is visible.
+- **SDO HMI** posts a new Sun frame every 15 minutes on the clock (`:00`/`:15`/`:30`/`:45` UTC); the
+  card polls on the same 15-minute cadence.
+
+Every thumbnail and full-screen view shows when its image was actually captured, computed from each
+source's own timestamp — EPIC's API returns one directly; SDO's dated archive encodes it in the
+filename, which the card computes from the current time and NASA's 15-minute publish grid (no extra
+request). Background fetching for a source only happens while its thumbnail is visible in the strip,
+or its full-screen view is open — never while `gallery.mode` is `"none"` or the strip/panel is
+closed.
+
+Clicking any thumbnail always opens the full-screen image view (unaffected by mode).
 
 ```yaml
 type: custom:ha-planetary-solar-system-card

--- a/README.md
+++ b/README.md
@@ -35,6 +35,32 @@ the standard astronomical twilight definitions:
 | Astronomical twilight | -12° to -18°  | Sky background glow, faint stars washed out                      |
 | Night                 | < -18°        | Full dark; the Sun no longer lights the sky                      |
 
+### L1 Imagery
+
+Set `gallery.mode` to anything but `"none"` and a thumbnail strip with live NASA Earth/Sun imagery
+appears automatically — no click needed (nav button ▦ closes/reopens it; clicking a thumbnail opens
+its full-screen view). `"none"` fetches and collects nothing.
+
+| Mode    | Strip shows                                                 |
+| ------- | ----------------------------------------------------------- |
+| `none`  | Nothing — gallery button hidden                             |
+| `earth` | Earth only                                                  |
+| `sun`   | Sun only                                                    |
+| `both`  | Earth and Sun together                                      |
+| `slide` | One thumbnail, flipping every `gallery.slide_interval_secs` |
+
+| Thumbnail | Source                                                             | Cadence                                   |
+| --------- | ------------------------------------------------------------------ | ----------------------------------------- |
+| L1→EARTH  | [NASA EPIC](https://epic.gsfc.nasa.gov/) (DSCOVR, at Sun-Earth L1) | New frame ~1-2h; polled hourly            |
+| L1→SUN    | [NASA SDO](https://sdo.gsfc.nasa.gov/) (Earth orbit, not L1)       | New frame every 15min; polled every 15min |
+
+Every image shows its real capture time — EPIC's API returns one directly; SDO's is computed from
+its 15-minute publish grid (no extra request). Background fetching only runs while a thumbnail or
+full view is actually visible.
+
+Some HA setups behind a strict reverse-proxy CSP may block `epic.gsfc.nasa.gov` /
+`sdo.gsfc.nasa.gov` requests — not fixable from the card.
+
 ## Installation
 
 ### Via HACS (recommended)
@@ -99,40 +125,7 @@ colors:
   label: "#e0e0ff"
 ```
 
-### L1 Imagery
-
-Set `gallery.mode` to something other than `"none"` and the thumbnail strip with live NASA Earth and
-Sun imagery shows automatically — no click needed. A nav button (▦) lets you close and reopen the
-strip afterward. `"none"` by default (button hidden, nothing fetched, nothing ever collected).
-
-| Mode    | Strip shows                                                                       |
-| ------- | --------------------------------------------------------------------------------- |
-| `none`  | Nothing — gallery button hidden                                                   |
-| `earth` | Earth thumbnail only                                                              |
-| `sun`   | Sun thumbnail only                                                                |
-| `both`  | Earth and Sun thumbnails together                                                 |
-| `slide` | One thumbnail, flipping between Earth and Sun every `gallery.slide_interval_secs` |
-
-| Thumbnail | Source                                                                                     | Look                                |
-| --------- | ------------------------------------------------------------------------------------------ | ----------------------------------- |
-| L1→EARTH  | [NASA EPIC](https://epic.gsfc.nasa.gov/), aboard DSCOVR at the Sun-Earth L1 Lagrange point | Earth, natural color                |
-| L1→SUN    | [NASA SDO](https://sdo.gsfc.nasa.gov/), in geosynchronous Earth orbit (not actually at L1) | Sunspots, visible-light photosphere |
-
-Both sources publish new frames on their own schedule, independent of this card:
-
-- **EPIC/DSCOVR** posts a new Earth image roughly every 1-2 hours; the card polls for a new one once
-  an hour while a thumbnail or full view is visible.
-- **SDO HMI** posts a new Sun frame every 15 minutes on the clock (`:00`/`:15`/`:30`/`:45` UTC); the
-  card polls on the same 15-minute cadence.
-
-Every thumbnail and full-screen view shows when its image was actually captured, computed from each
-source's own timestamp — EPIC's API returns one directly; SDO's dated archive encodes it in the
-filename, which the card computes from the current time and NASA's 15-minute publish grid (no extra
-request). Background fetching for a source only happens while its thumbnail is visible in the strip,
-or its full-screen view is open — never while `gallery.mode` is `"none"` or the strip/panel is
-closed.
-
-Clicking any thumbnail always opens the full-screen image view (unaffected by mode).
+See [L1 Imagery](#l1-imagery) above for what `gallery.*` does.
 
 ```yaml
 type: custom:ha-planetary-solar-system-card
@@ -140,6 +133,3 @@ gallery:
   mode: slide
   slide_interval_secs: 30
 ```
-
-Some Home Assistant setups behind a strict reverse-proxy Content-Security-Policy may block requests
-to `epic.gsfc.nasa.gov` / `sdo.gsfc.nasa.gov` — not fixable from the card itself.

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ the standard astronomical twilight definitions:
 
 ### L1 Imagery
 
-Live NASA Earth/Sun thumbnails. `gallery.mode` != `"none"` shows the strip automatically (☷ toggles
-it, a thumbnail click opens full-screen); `"none"` fetches nothing.
+Live imagery from two NASA probes: [DSCOVR](https://epic.gsfc.nasa.gov/) at the Sun-Earth L1 point
+watches Earth, [SDO](https://sdo.gsfc.nasa.gov/) in Earth orbit watches the Sun. `gallery.mode`
+picks what shows (☷ toggles the strip, a thumbnail click opens full-screen):
 
 | Mode    | Strip shows                                                 |
 | ------- | ----------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -37,9 +37,8 @@ the standard astronomical twilight definitions:
 
 ### L1 Imagery
 
-Set `gallery.mode` to anything but `"none"` and a thumbnail strip with live NASA Earth/Sun imagery
-appears automatically — no click needed (nav button ▦ closes/reopens it; clicking a thumbnail opens
-its full-screen view). `"none"` fetches and collects nothing.
+Live NASA Earth/Sun thumbnails. `gallery.mode` != `"none"` shows the strip automatically (☷ toggles
+it, a thumbnail click opens full-screen); `"none"` fetches nothing.
 
 | Mode    | Strip shows                                                 |
 | ------- | ----------------------------------------------------------- |
@@ -49,17 +48,13 @@ its full-screen view). `"none"` fetches and collects nothing.
 | `both`  | Earth and Sun together                                      |
 | `slide` | One thumbnail, flipping every `gallery.slide_interval_secs` |
 
-| Thumbnail | Source                                                             | Cadence                                   |
-| --------- | ------------------------------------------------------------------ | ----------------------------------------- |
-| L1→EARTH  | [NASA EPIC](https://epic.gsfc.nasa.gov/) (DSCOVR, at Sun-Earth L1) | New frame ~1-2h; polled hourly            |
-| L1→SUN    | [NASA SDO](https://sdo.gsfc.nasa.gov/) (Earth orbit, not L1)       | New frame every 15min; polled every 15min |
+| Thumbnail | Source                                                             | We poll     | Latest image is usually                 |
+| --------- | ------------------------------------------------------------------ | ----------- | --------------------------------------- |
+| L1→EARTH  | [NASA EPIC](https://epic.gsfc.nasa.gov/) (DSCOVR, at Sun-Earth L1) | Hourly      | ~1-2 days old (EPIC processing backlog) |
+| L1→SUN    | [NASA SDO](https://sdo.gsfc.nasa.gov/) (Earth orbit, not L1)       | Every 15min | ~15-35min old                           |
 
-Every image shows its real capture time — EPIC's API returns one directly; SDO's is computed from
-its 15-minute publish grid (no extra request). Background fetching only runs while a thumbnail or
-full view is actually visible.
-
-Some HA setups behind a strict reverse-proxy CSP may block `epic.gsfc.nasa.gov` /
-`sdo.gsfc.nasa.gov` requests — not fixable from the card.
+Strict reverse-proxy CSP may block `epic.gsfc.nasa.gov` / `sdo.gsfc.nasa.gov` — not fixable
+card-side.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ default_zoom: 2
 | `colors`               | object                 | see below | Color overrides (see Colors)                                                               |
 | `ecliptic_view`        | `"north"` \| `"south"` | `"north"` | Viewing pole: `"north"` = counter-clockwise orbits (default); `"south"` = clockwise orbits |
 | `show_version`         | boolean                | `false`   | Show card version number in the bottom-right corner of the nav bar                         |
-| `debug`                | boolean                | `false`   | Opt in to try in-progress/beta features — currently: replay button (↺, replays last 6h)    |
+| `gallery`              | boolean                | `false`   | Show the L1 Imagery gallery button (see L1 Imagery)                                        |
 
 ### Colors
 
@@ -97,3 +97,17 @@ colors:
   orbit: "rgba(100, 200, 255, 0.2)"
   label: "#e0e0ff"
 ```
+
+### L1 Imagery
+
+Set `gallery: true` to show a nav button (🖼️) that opens a thumbnail strip with live
+[NASA SDO](https://sdo.gsfc.nasa.gov/) and [EPIC/DSCOVR](https://epic.gsfc.nasa.gov/) L1 Lagrange
+point imagery. Off by default.
+
+| Thumbnail | Source                 | Look                                |
+| --------- | ---------------------- | ----------------------------------- |
+| L1→EARTH  | NASA EPIC/DSCOVR       | Earth, natural color                |
+| L1→SUN    | NASA SDO HMI Continuum | Sunspots, visible-light photosphere |
+
+Some Home Assistant setups behind a strict reverse-proxy Content-Security-Policy may block requests
+to `epic.gsfc.nasa.gov` / `sdo.gsfc.nasa.gov` — not fixable from the card itself.

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ the standard astronomical twilight definitions:
 | Astronomical twilight | -12° to -18°  | Sky background glow, faint stars washed out                      |
 | Night                 | < -18°        | Full dark; the Sun no longer lights the sky                      |
 
-### L1 Imagery
+### Live Imagery
 
 Live imagery from two NASA probes: [DSCOVR](https://epic.gsfc.nasa.gov/) at the Sun-Earth L1 point
-watches Earth, [SDO](https://sdo.gsfc.nasa.gov/) in Earth orbit watches the Sun. `gallery.mode`
-picks what shows (☷ toggles the strip, a thumbnail click opens full-screen):
+watches Earth, [SDO](https://sdo.gsfc.nasa.gov/) in geosynchronous Earth orbit watches the Sun.
+`gallery.mode` picks what shows (☷ toggles the strip, a thumbnail click opens full-screen):
 
 | Mode    | Strip shows                                                 |
 | ------- | ----------------------------------------------------------- |
@@ -49,10 +49,10 @@ picks what shows (☷ toggles the strip, a thumbnail click opens full-screen):
 | `both`  | Earth and Sun together                                      |
 | `slide` | One thumbnail, flipping every `gallery.slide_interval_secs` |
 
-| Thumbnail | Source                                                             | We poll     | Latest image is usually                 |
-| --------- | ------------------------------------------------------------------ | ----------- | --------------------------------------- |
-| L1→EARTH  | [NASA EPIC](https://epic.gsfc.nasa.gov/) (DSCOVR, at Sun-Earth L1) | Hourly      | ~1-2 days old (EPIC processing backlog) |
-| L1→SUN    | [NASA SDO](https://sdo.gsfc.nasa.gov/) (Earth orbit, not L1)       | Every 15min | ~15-35min old                           |
+| Thumbnail | Source                                                              | We poll     | Latest image is usually                 |
+| --------- | ------------------------------------------------------------------- | ----------- | --------------------------------------- |
+| L1→EARTH  | [NASA EPIC](https://epic.gsfc.nasa.gov/) (DSCOVR, at Sun-Earth L1)  | Hourly      | ~1-2 days old (EPIC processing backlog) |
+| GEO→SUN   | [NASA SDO](https://sdo.gsfc.nasa.gov/) (geosynchronous Earth orbit) | Every 15min | ~30-45min old                           |
 
 Strict reverse-proxy CSP may block `epic.gsfc.nasa.gov` / `sdo.gsfc.nasa.gov` — not fixable
 card-side.
@@ -96,7 +96,7 @@ default_zoom: 2
 | `colors`                      | object                 | see below | Color overrides (see Colors)                                                               |
 | `ecliptic_view`               | `"north"` \| `"south"` | `"north"` | Viewing pole: `"north"` = counter-clockwise orbits (default); `"south"` = clockwise orbits |
 | `show_version`                | boolean                | `false`   | Show card version number in the bottom-right corner of the nav bar                         |
-| `gallery.mode`                | see below              | `"none"`  | L1 Imagery gallery mode (see L1 Imagery)                                                   |
+| `gallery.mode`                | see below              | `"none"`  | Live Imagery gallery mode (see Live Imagery)                                               |
 | `gallery.slide_interval_secs` | number                 | `60`      | How often `slide` mode flips the displayed thumbnail between Earth and Sun                 |
 
 ### Colors
@@ -121,7 +121,7 @@ colors:
   label: "#e0e0ff"
 ```
 
-See [L1 Imagery](#l1-imagery) above for what `gallery.*` does.
+See [Live Imagery](#live-imagery) above for what `gallery.*` does.
 
 ```yaml
 type: custom:ha-planetary-solar-system-card

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ watches Earth, [SDO](https://sdo.gsfc.nasa.gov/) in geosynchronous Earth orbit w
 | `both`  | Earth and Sun together                                      |
 | `slide` | One thumbnail, flipping every `gallery.slide_interval_secs` |
 
-| Thumbnail | Source                                                              | We poll     | Latest image is usually                 |
-| --------- | ------------------------------------------------------------------- | ----------- | --------------------------------------- |
-| L1→EARTH  | [NASA EPIC](https://epic.gsfc.nasa.gov/) (DSCOVR, at Sun-Earth L1)  | Hourly      | ~1-2 days old (EPIC processing backlog) |
-| GEO→SUN   | [NASA SDO](https://sdo.gsfc.nasa.gov/) (geosynchronous Earth orbit) | Every 15min | ~30-45min old                           |
+| Thumbnail | Source                                                              | We poll     | Latest image is usually                   |
+| --------- | ------------------------------------------------------------------- | ----------- | ----------------------------------------- |
+| L1→EARTH  | [NASA EPIC](https://epic.gsfc.nasa.gov/) (DSCOVR, at Sun-Earth L1)  | Hourly      | ~1-2 days old (EPIC processing backlog)   |
+| GEO→SUN   | [NASA SDO](https://sdo.gsfc.nasa.gov/) (geosynchronous Earth orbit) | Every 15min | ~15-30min old (up to 45min if it retries) |
 
 Strict reverse-proxy CSP may block `epic.gsfc.nasa.gov` / `sdo.gsfc.nasa.gov` — not fixable
 card-side.

--- a/README.md
+++ b/README.md
@@ -64,17 +64,18 @@ default_zoom: 2
 
 ## Configuration
 
-| Option                 | Type                   | Default   | Description                                                                                |
-| ---------------------- | ---------------------- | --------- | ------------------------------------------------------------------------------------------ |
-| `refresh_mins`         | number                 | `1`       | Auto-update interval in minutes                                                            |
-| `default_zoom`         | number                 | `1`       | Starting zoom level                                                                        |
-| `zoom_animate`         | boolean                | `true`    | Animate zoom transitions                                                                   |
-| `periodic_zoom_change` | boolean                | `false`   | Cycle zoom levels on each refresh tick                                                     |
-| `periodic_zoom_max`    | number                 | `4`       | Maximum zoom level for auto-cycle (2–4)                                                    |
-| `colors`               | object                 | see below | Color overrides (see Colors)                                                               |
-| `ecliptic_view`        | `"north"` \| `"south"` | `"north"` | Viewing pole: `"north"` = counter-clockwise orbits (default); `"south"` = clockwise orbits |
-| `show_version`         | boolean                | `false`   | Show card version number in the bottom-right corner of the nav bar                         |
-| `gallery`              | boolean                | `false`   | Show the L1 Imagery gallery button (see L1 Imagery)                                        |
+| Option                        | Type                   | Default   | Description                                                                                |
+| ----------------------------- | ---------------------- | --------- | ------------------------------------------------------------------------------------------ |
+| `refresh_mins`                | number                 | `1`       | Auto-update interval in minutes                                                            |
+| `default_zoom`                | number                 | `1`       | Starting zoom level                                                                        |
+| `zoom_animate`                | boolean                | `true`    | Animate zoom transitions                                                                   |
+| `periodic_zoom_change`        | boolean                | `false`   | Cycle zoom levels on each refresh tick                                                     |
+| `periodic_zoom_max`           | number                 | `4`       | Maximum zoom level for auto-cycle (2–4)                                                    |
+| `colors`                      | object                 | see below | Color overrides (see Colors)                                                               |
+| `ecliptic_view`               | `"north"` \| `"south"` | `"north"` | Viewing pole: `"north"` = counter-clockwise orbits (default); `"south"` = clockwise orbits |
+| `show_version`                | boolean                | `false`   | Show card version number in the bottom-right corner of the nav bar                         |
+| `gallery.mode`                | see below              | `"none"`  | L1 Imagery gallery mode (see L1 Imagery)                                                   |
+| `gallery.slide_interval_secs` | number                 | `60`      | How often `slide` mode flips the displayed thumbnail between Earth and Sun                 |
 
 ### Colors
 
@@ -100,14 +101,34 @@ colors:
 
 ### L1 Imagery
 
-Set `gallery: true` to show a nav button (🖼️) that opens a thumbnail strip with live
+Set `gallery.mode` to something other than `"none"` and the thumbnail strip with live
 [NASA SDO](https://sdo.gsfc.nasa.gov/) and [EPIC/DSCOVR](https://epic.gsfc.nasa.gov/) L1 Lagrange
-point imagery. Off by default.
+point imagery shows automatically — no click needed. A nav button (▦) lets you close and reopen the
+strip afterward. `"none"` by default (button hidden, nothing fetched).
 
-| Thumbnail | Source                 | Look                                |
-| --------- | ---------------------- | ----------------------------------- |
-| L1→EARTH  | NASA EPIC/DSCOVR       | Earth, natural color                |
-| L1→SUN    | NASA SDO HMI Continuum | Sunspots, visible-light photosphere |
+| Mode    | Strip shows                                                                       |
+| ------- | --------------------------------------------------------------------------------- |
+| `none`  | Nothing — gallery button hidden                                                   |
+| `earth` | Earth thumbnail only                                                              |
+| `sun`   | Sun thumbnail only                                                                |
+| `both`  | Earth and Sun thumbnails together                                                 |
+| `slide` | One thumbnail, flipping between Earth and Sun every `gallery.slide_interval_secs` |
+
+| Thumbnail | Source                 | Look                                | Background refresh |
+| --------- | ---------------------- | ----------------------------------- | ------------------ |
+| L1→EARTH  | NASA EPIC/DSCOVR       | Earth, natural color                | Every 1 hour       |
+| L1→SUN    | NASA SDO HMI Continuum | Sunspots, visible-light photosphere | Every 15 minutes   |
+
+Clicking any thumbnail always opens the full-screen image view (unaffected by mode). Background
+fetching for a source only happens while its thumbnail is visible in the strip, or its full-screen
+view is open — never while `gallery.mode` is `"none"` or the strip/panel is closed.
+
+```yaml
+type: custom:ha-planetary-solar-system-card
+gallery:
+  mode: slide
+  slide_interval_secs: 30
+```
 
 Some Home Assistant setups behind a strict reverse-proxy Content-Security-Policy may block requests
 to `epic.gsfc.nasa.gov` / `sdo.gsfc.nasa.gov` — not fixable from the card itself.

--- a/docs/index.html
+++ b/docs/index.html
@@ -83,7 +83,7 @@
     import "./card.js";
 
     const card = document.getElementById("demo-card");
-    card.setConfig({ default_zoom: 2, debug: true });
+    card.setConfig({ default_zoom: 2 });
     card.hass = {
       config: {
         latitude: 41.8781,

--- a/src/card/card-styles.ts
+++ b/src/card/card-styles.ts
@@ -19,17 +19,20 @@ export const cardStyles = css`
     margin: 2px 2px;
   }
   .solar-view-wrapper {
-    overflow: hidden;
     position: relative;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
   }
   .status-bar {
     position: absolute;
     top: 0;
     left: 0;
     right: 0;
-    background: color-mix(in srgb, currentColor 15%, transparent);
+    background: rgba(0, 0, 0, 0.55);
     font-size: 10px;
-    color: inherit;
+    color: #fff;
+    text-shadow: 0 0 2px rgba(0, 0, 0, 0.8);
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -50,10 +53,63 @@ export const cardStyles = css`
     width: 100%;
     aspect-ratio: 1;
   }
+  #solar-view.hidden {
+    display: none;
+  }
   #solar-view svg {
     cursor: grab;
     user-select: none;
     touch-action: none;
+  }
+  .image-view {
+    display: none;
+    width: 100%;
+    aspect-ratio: 1;
+    object-fit: contain;
+    background: #000;
+    cursor: pointer;
+  }
+  .image-view.visible {
+    display: block;
+  }
+  .gallery {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    align-items: flex-end;
+    justify-content: flex-end;
+    gap: 2px;
+    padding: 2px;
+    box-sizing: border-box;
+  }
+  .gallery-thumb {
+    flex: 0 0 20%;
+    position: relative;
+    aspect-ratio: 1;
+    padding: 0;
+    border: 1px solid var(--divider-color, color-mix(in srgb, currentColor 15%, transparent));
+    border-radius: 4px;
+    background: #000;
+    overflow: hidden;
+    cursor: pointer;
+  }
+  .gallery-thumb img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+  .gallery-label {
+    position: absolute;
+    bottom: 1px;
+    right: 2px;
+    font-size: 8px;
+    color: #fff;
+    text-shadow: 0 0 2px #000;
+    font-family: sans-serif;
+    pointer-events: none;
   }
   .nav {
     display: flex;
@@ -79,6 +135,20 @@ export const cardStyles = css`
   }
   .nav button:hover {
     background: var(--secondary-background-color, color-mix(in srgb, currentColor 20%, transparent));
+  }
+  .nav button .icon {
+    filter: grayscale(1);
+    display: inline-block;
+  }
+  button[data-action="show-earth"].active {
+    background: #3b82f6;
+    border-color: #3b82f6;
+    color: #fff;
+  }
+  button[data-action="show-sun"].active {
+    background: #f97316;
+    border-color: #f97316;
+    color: #fff;
   }
   .btn-group {
     display: flex;

--- a/src/card/card-styles.ts
+++ b/src/card/card-styles.ts
@@ -15,7 +15,7 @@ export const cardStyles = css`
   }
   .date {
     font-size: 11px;
-    color: var(--secondary-text-color, color-mix(in srgb, currentColor 60%, transparent));
+    color: inherit;
     margin: 2px 2px;
   }
   .solar-view-wrapper {
@@ -29,10 +29,9 @@ export const cardStyles = css`
     top: 0;
     left: 0;
     right: 0;
-    background: rgba(0, 0, 0, 0.55);
+    background: var(--secondary-background-color, color-mix(in srgb, currentColor 10%, transparent));
     font-size: 10px;
-    color: #fff;
-    text-shadow: 0 0 2px rgba(0, 0, 0, 0.8);
+    color: inherit;
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -124,6 +123,7 @@ export const cardStyles = css`
     gap: 4px;
     margin-top: 2px;
     position: relative;
+    background: var(--secondary-background-color, color-mix(in srgb, currentColor 10%, transparent));
   }
   .nav button {
     background: color-mix(in srgb, currentColor 15%, transparent);
@@ -140,7 +140,7 @@ export const cardStyles = css`
     box-sizing: border-box;
   }
   .nav button:hover {
-    background: var(--secondary-background-color, color-mix(in srgb, currentColor 20%, transparent));
+    background: color-mix(in srgb, currentColor 25%, transparent);
   }
   .nav button .icon {
     filter: grayscale(1);

--- a/src/card/card-styles.ts
+++ b/src/card/card-styles.ts
@@ -91,7 +91,7 @@ export const cardStyles = css`
     padding: 0;
     border: 1px solid var(--divider-color, color-mix(in srgb, currentColor 15%, transparent));
     border-radius: 4px;
-    background: #000;
+    background: transparent;
     overflow: hidden;
     cursor: pointer;
   }
@@ -105,16 +105,6 @@ export const cardStyles = css`
     position: absolute;
     bottom: 1px;
     right: 2px;
-    font-size: 8px;
-    color: #fff;
-    text-shadow: 0 0 2px #000;
-    font-family: sans-serif;
-    pointer-events: none;
-  }
-  .gallery-age {
-    position: absolute;
-    top: 1px;
-    left: 2px;
     font-size: 8px;
     color: #fff;
     text-shadow: 0 0 2px #000;
@@ -172,6 +162,9 @@ export const cardStyles = css`
   }
   .btn-group button:last-child {
     border-radius: 0 6px 6px 0;
+  }
+  .btn-group button:only-child {
+    border-radius: 6px;
   }
   .nav-spacer {
     width: 8px;

--- a/src/card/card-styles.ts
+++ b/src/card/card-styles.ts
@@ -111,6 +111,16 @@ export const cardStyles = css`
     font-family: sans-serif;
     pointer-events: none;
   }
+  .gallery-age {
+    position: absolute;
+    top: 1px;
+    left: 2px;
+    font-size: 8px;
+    color: #fff;
+    text-shadow: 0 0 2px #000;
+    font-family: sans-serif;
+    pointer-events: none;
+  }
   .nav {
     display: flex;
     justify-content: center;

--- a/src/card/card-styles.ts
+++ b/src/card/card-styles.ts
@@ -101,15 +101,21 @@ export const cardStyles = css`
     object-fit: cover;
     display: block;
   }
-  .gallery-label {
+  .gallery-info {
     position: absolute;
     bottom: 1px;
+    left: 2px;
     right: 2px;
+    display: flex;
+    justify-content: space-between;
+    pointer-events: none;
+  }
+  .gallery-label,
+  .gallery-age {
     font-size: 8px;
     color: #fff;
     text-shadow: 0 0 2px #000;
     font-family: sans-serif;
-    pointer-events: none;
   }
   .nav {
     display: flex;

--- a/src/card/card-template.ts
+++ b/src/card/card-template.ts
@@ -54,9 +54,13 @@ export function buildImageStatusBar(
   mode: ImageSource,
   dateText: string,
   imageDate: Date,
-  now: Date
+  now: Date,
+  loaded: boolean
 ): TemplateResult {
+  const status = loaded
+    ? `captured ${dateText} (${formatRelativeAge(imageDate, now)})`
+    : "loading…";
   return html`<div class="status-bar">
-    <span>${IMAGE_SOURCE_LABELS[mode]} · captured ${dateText} (${formatRelativeAge(imageDate, now)})</span>
+    <span>${IMAGE_SOURCE_LABELS[mode]} · ${status}</span>
   </div>`;
 }

--- a/src/card/card-template.ts
+++ b/src/card/card-template.ts
@@ -6,6 +6,7 @@ import {
   getSkyMode,
 } from "../astronomy/solar-position.js";
 import type { LocationData } from "../types.js";
+import { formatRelativeAge } from "./relative-time.js";
 
 export function buildStatusBar(
   locationData: LocationData | null,
@@ -31,5 +32,38 @@ export function buildStatusBar(
   return html`<div class="status-bar">
     <span>${name} | ${mode} (${elevRounded}°)</span>
     ${next && formatter ? html`<span>Next: ${next.toMode} (${formatter.format(next.time)})</span>` : nothing}
+  </div>`;
+}
+
+export type ImageSource = "earth" | "sun";
+
+export const IMAGE_SOURCE_LABELS: Record<ImageSource, string> = {
+  earth: "DSCOVR Earth",
+  sun: "SDO HMI Continuum",
+};
+
+// Labels for the gallery thumbnail strip.
+export const GALLERY_SOURCE_LABELS: Record<ImageSource, string> = {
+  earth: "L1→EARTH",
+  sun: "L1→SUN",
+};
+
+export const GALLERY_SOURCES: ImageSource[] = ["earth", "sun"];
+
+// EPIC gives a real capture timestamp per image; the SDO sun image is a fixed-filename URL
+// with no timestamp, so its date only reflects when we last checked the server for it.
+const IMAGE_DATE_VERBS: Record<ImageSource, string> = {
+  earth: "captured",
+  sun: "checked",
+};
+
+export function buildImageStatusBar(
+  mode: ImageSource,
+  dateText: string,
+  imageDate: Date,
+  now: Date
+): TemplateResult {
+  return html`<div class="status-bar">
+    <span>${IMAGE_SOURCE_LABELS[mode]} · ${IMAGE_DATE_VERBS[mode]} ${dateText} (${formatRelativeAge(imageDate, now)})</span>
   </div>`;
 }

--- a/src/card/card-template.ts
+++ b/src/card/card-template.ts
@@ -50,13 +50,6 @@ export const GALLERY_SOURCE_LABELS: Record<ImageSource, string> = {
 
 export const GALLERY_SOURCES: ImageSource[] = ["earth", "sun"];
 
-// EPIC gives a real capture timestamp per image; the SDO sun image is a fixed-filename URL
-// with no timestamp, so its date only reflects when we last checked the server for it.
-const IMAGE_DATE_VERBS: Record<ImageSource, string> = {
-  earth: "captured",
-  sun: "checked",
-};
-
 export function buildImageStatusBar(
   mode: ImageSource,
   dateText: string,
@@ -64,6 +57,6 @@ export function buildImageStatusBar(
   now: Date
 ): TemplateResult {
   return html`<div class="status-bar">
-    <span>${IMAGE_SOURCE_LABELS[mode]} · ${IMAGE_DATE_VERBS[mode]} ${dateText} (${formatRelativeAge(imageDate, now)})</span>
+    <span>${IMAGE_SOURCE_LABELS[mode]} · captured ${dateText} (${formatRelativeAge(imageDate, now)})</span>
   </div>`;
 }

--- a/src/card/card-template.ts
+++ b/src/card/card-template.ts
@@ -45,7 +45,7 @@ export const IMAGE_SOURCE_LABELS: Record<ImageSource, string> = {
 // Labels for the gallery thumbnail strip.
 export const GALLERY_SOURCE_LABELS: Record<ImageSource, string> = {
   earth: "L1→EARTH",
-  sun: "L1→SUN",
+  sun: "GEO→SUN",
 };
 
 export const GALLERY_SOURCES: ImageSource[] = ["earth", "sun"];

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -262,14 +262,13 @@ export class SolarViewCard extends LitElement {
                       @click=${this._onGalleryClick}
                     >
                       <img src=${this._galleryImages[source]?.url ?? ""} alt="" />
-                      ${
-                        this._galleryImages[source]
-                          ? html`<span class="gallery-age"
-                              >${formatRelativeAge(this._galleryImages[source]?.date as Date, new Date())}</span
-                            >`
-                          : nothing
-                      }
-                      <span class="gallery-label">${GALLERY_SOURCE_LABELS[source]}</span>
+                      <span class="gallery-label"
+                        >${GALLERY_SOURCE_LABELS[source]}${
+                          this._galleryImages[source]
+                            ? html` · ${formatRelativeAge(this._galleryImages[source]?.date as Date, new Date())}`
+                            : nothing
+                        }</span
+                      >
                     </button>`
                   )}
                 </div>`
@@ -305,7 +304,7 @@ export class SolarViewCard extends LitElement {
                       class=${this._galleryOpen ? "active" : ""}
                       @click=${this._onNavClick}
                     >
-                      <span class="icon">▦</span>
+                      <span class="icon">☷</span>
                     </button>
                   </span>`
               : nothing

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -72,6 +72,7 @@ export class SolarViewCard extends LitElement {
   private _sunRetried: boolean;
   private _galleryOpen: boolean;
   private _galleryImages: Partial<Record<ImageSource, SourcedImage>>;
+  private _gallerySunRetried: boolean;
   private _galleryMode: GalleryMode;
   private _galleryAutoIntervalMs: number;
   private _autoDisplayedSource: ImageSource;
@@ -108,6 +109,7 @@ export class SolarViewCard extends LitElement {
     this._sunRetried = false;
     this._galleryOpen = false;
     this._galleryImages = {};
+    this._gallerySunRetried = false;
     this._galleryMode = "none";
     this._galleryAutoIntervalMs = DEFAULT_GALLERY_INTERVAL_MS;
     this._autoDisplayedSource = "earth";
@@ -263,7 +265,11 @@ export class SolarViewCard extends LitElement {
                       title=${`Show ${GALLERY_SOURCE_LABELS[source]}`}
                       @click=${this._onGalleryClick}
                     >
-                      <img src=${this._galleryImages[source]?.url ?? ""} alt="" />
+                      <img
+                        src=${this._galleryImages[source]?.url ?? ""}
+                        alt=""
+                        @error=${source === "sun" ? this._onSunThumbError : undefined}
+                      />
                       <div class="gallery-info">
                         <span class="gallery-label">${GALLERY_SOURCE_LABELS[source]}</span>
                         ${
@@ -709,10 +715,12 @@ export class SolarViewCard extends LitElement {
   // Fetches gallery thumbnails for the active gallery.mode — called when the gallery is
   // opened, and on each auto-update tick while it stays open and no full image is showing
   // (never while both are closed, to avoid unconditional background polling of NASA's
-  // servers for every install regardless of use). Each source is cache-guarded at a 1-hour
-  // TTL, so this only hits the network once the cache has expired.
+  // servers for every install regardless of use). Each source is cache-guarded (earth
+  // hourly, sun every 15min — matching each source's own publish cadence), so this only
+  // hits the network once the relevant cache has expired.
   private async _refreshGalleryImages(): Promise<void> {
     const sources = this._fetchGallerySources;
+    if (sources.includes("sun")) this._gallerySunRetried = false;
     const results = await Promise.allSettled(
       sources.map((source) =>
         source === "earth" ? fetchLatestEarthImageUrl() : Promise.resolve(getSunImageUrl())
@@ -724,6 +732,23 @@ export class SolarViewCard extends LitElement {
         this._galleryImages[sources[i]] = result.value;
       }
     }
+    this._render();
+  }
+
+  // Mirrors _onImageLoadError's one-step-back retry, for the gallery thumbnail instead of
+  // the full-screen view: first failure steps back one 15-min slot; a second failure drops
+  // the thumbnail (falls back to the transparent placeholder) rather than retrying forever.
+  private _onSunThumbError(): void {
+    if (this._gallerySunRetried) {
+      delete this._galleryImages.sun;
+      this._render();
+      return;
+    }
+    const current = this._galleryImages.sun;
+    /* v8 ignore next */
+    if (!current) return;
+    this._gallerySunRetried = true;
+    this._galleryImages.sun = getPreviousSunSlot(current.date);
     this._render();
   }
 

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -23,8 +23,8 @@ import { DEFAULT_ZOOM_LEVEL, MAX_ZOOM, MIN_ZOOM, ViewState } from "./card-view-s
 import type { SourcedImage } from "./image-sources.js";
 import {
   CLICK_CACHE_TTL_MS,
-  FULL_PANEL_CACHE_TTL_MS,
   fetchLatestEarthImageUrl,
+  getPreviousSunSlot,
   getSunImageUrl,
 } from "./image-sources.js";
 import { formatRelativeAge } from "./relative-time.js";
@@ -69,6 +69,7 @@ export class SolarViewCard extends LitElement {
   private _imageUrl: string | null;
   private _imageDate: Date | null;
   private _imageError: string | null;
+  private _sunRetried: boolean;
   private _galleryOpen: boolean;
   private _galleryImages: Partial<Record<ImageSource, SourcedImage>>;
   private _galleryMode: GalleryMode;
@@ -104,6 +105,7 @@ export class SolarViewCard extends LitElement {
     this._imageUrl = null;
     this._imageDate = null;
     this._imageError = null;
+    this._sunRetried = false;
     this._galleryOpen = false;
     this._galleryImages = {};
     this._galleryMode = "none";
@@ -262,13 +264,16 @@ export class SolarViewCard extends LitElement {
                       @click=${this._onGalleryClick}
                     >
                       <img src=${this._galleryImages[source]?.url ?? ""} alt="" />
-                      <span class="gallery-label"
-                        >${GALLERY_SOURCE_LABELS[source]}${
+                      <div class="gallery-info">
+                        <span class="gallery-label">${GALLERY_SOURCE_LABELS[source]}</span>
+                        ${
                           this._galleryImages[source]
-                            ? html` · ${formatRelativeAge(this._galleryImages[source]?.date as Date, new Date())}`
+                            ? html`<span class="gallery-age"
+                                >${formatRelativeAge(this._galleryImages[source]?.date as Date, new Date())}</span
+                              >`
                             : nothing
-                        }</span
-                      >
+                        }
+                      </div>
                     </button>`
                   )}
                 </div>`
@@ -612,9 +617,18 @@ export class SolarViewCard extends LitElement {
 
   // Earth's URL is validated by a real fetch before it's ever assigned, so this only ever
   // fires in practice for sun: its URL is computed (not fetch-checked) from NASA's publish
-  // cadence, so it can occasionally 404 if a slot hasn't been published yet.
+  // cadence, so it can occasionally 404 if a slot hasn't been published yet. First failure
+  // steps back one 15-min slot and retries once; only a second failure shows the banner.
   private _onImageLoadError(): void {
     if (this._imagePanelMode === "none") return;
+    if (this._imagePanelMode === "sun" && !this._sunRetried) {
+      this._sunRetried = true;
+      const { url, date } = getPreviousSunSlot(this._imageDate as Date);
+      this._imageUrl = url;
+      this._imageDate = date;
+      this._render();
+      return;
+    }
     this._imageError = `${IMAGE_SOURCE_LABELS[this._imagePanelMode]} image unavailable`;
     this._imagePanelMode = "none";
     this._imageUrl = null;
@@ -623,6 +637,7 @@ export class SolarViewCard extends LitElement {
   }
 
   private async _setImagePanel(mode: ImagePanelMode): Promise<void> {
+    this._sunRetried = false;
     if (mode === "none") {
       this._imagePanelMode = "none";
       this._imageUrl = null;
@@ -652,17 +667,15 @@ export class SolarViewCard extends LitElement {
     this._render();
   }
 
-  // Keeps the open full-screen image fresh (15-min TTL) on each auto-update tick, for as
-  // long as it stays open. Only called while _imagePanelMode !== "none" (see the tick
-  // handler). A failed refresh is silently skipped — the panel keeps showing the last
-  // good image rather than surfacing a transient background-fetch error.
+  // Keeps the open full-screen image fresh (hourly, same cadence as the gallery strip) on
+  // each auto-update tick, for as long as it stays open. Only called while
+  // _imagePanelMode !== "none" (see the tick handler). A failed refresh is silently skipped
+  // — the panel keeps showing the last good image rather than surfacing a transient
+  // background-fetch error.
   private async _refreshOpenImage(): Promise<void> {
     const mode = this._imagePanelMode;
     try {
-      const { url, date } =
-        mode === "earth"
-          ? await fetchLatestEarthImageUrl(FULL_PANEL_CACHE_TTL_MS)
-          : getSunImageUrl(FULL_PANEL_CACHE_TTL_MS);
+      const { url, date } = mode === "earth" ? await fetchLatestEarthImageUrl() : getSunImageUrl();
       this._imageUrl = url;
       this._imageDate = date;
       this._render();
@@ -696,16 +709,13 @@ export class SolarViewCard extends LitElement {
   // Fetches gallery thumbnails for the active gallery.mode — called when the gallery is
   // opened, and on each auto-update tick while it stays open and no full image is showing
   // (never while both are closed, to avoid unconditional background polling of NASA's
-  // servers for every install regardless of use). Each source is still cache-guarded (Sun:
-  // 15-min TTL, Earth: 1-hour TTL — Sun's disk image updates far more often), so this only
-  // hits the network once the relevant cache has expired.
+  // servers for every install regardless of use). Each source is cache-guarded at a 1-hour
+  // TTL, so this only hits the network once the cache has expired.
   private async _refreshGalleryImages(): Promise<void> {
     const sources = this._fetchGallerySources;
     const results = await Promise.allSettled(
       sources.map((source) =>
-        source === "earth"
-          ? fetchLatestEarthImageUrl()
-          : Promise.resolve(getSunImageUrl(FULL_PANEL_CACHE_TTL_MS))
+        source === "earth" ? fetchLatestEarthImageUrl() : Promise.resolve(getSunImageUrl())
       )
     );
     for (let i = 0; i < results.length; i++) {

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -36,6 +36,9 @@ const REPLAY_MAX_DURATION_MS = 5000;
 const REPLAY_INTERVAL_MS = Math.floor(REPLAY_MAX_DURATION_MS / REPLAY_STEPS);
 
 type ImagePanelMode = "none" | ImageSource;
+export type GalleryMode = "none" | "earth" | "sun" | "both" | "slide";
+const GALLERY_MODES: GalleryMode[] = ["none", "earth", "sun", "both", "slide"];
+const DEFAULT_GALLERY_INTERVAL_MS = 60000;
 
 export class SolarViewCard extends LitElement {
   static styles = cardStyles;
@@ -67,6 +70,10 @@ export class SolarViewCard extends LitElement {
   private _imageError: string | null;
   private _galleryOpen: boolean;
   private _galleryImages: Partial<Record<ImageSource, SourcedImage>>;
+  private _galleryMode: GalleryMode;
+  private _galleryAutoIntervalMs: number;
+  private _autoDisplayedSource: ImageSource;
+  private _autoSwitchTimer: number | null;
   _config: CardConfig | undefined;
 
   constructor() {
@@ -98,6 +105,10 @@ export class SolarViewCard extends LitElement {
     this._imageError = null;
     this._galleryOpen = false;
     this._galleryImages = {};
+    this._galleryMode = "none";
+    this._galleryAutoIntervalMs = DEFAULT_GALLERY_INTERVAL_MS;
+    this._autoDisplayedSource = "earth";
+    this._autoSwitchTimer = null;
   }
 
   // ---------------------------------------------------------------------------
@@ -153,8 +164,21 @@ export class SolarViewCard extends LitElement {
 
     this._eclipticView = config.ecliptic_view === "south";
 
+    this._galleryMode = GALLERY_MODES.includes(config.gallery?.mode as GalleryMode)
+      ? (config.gallery?.mode as GalleryMode)
+      : "none";
+    const rawInterval = Number(config.gallery?.slide_interval_secs);
+    this._galleryAutoIntervalMs =
+      Number.isFinite(rawInterval) && rawInterval >= 0.1
+        ? rawInterval * 1000
+        : DEFAULT_GALLERY_INTERVAL_MS;
+    this._galleryOpen = this._galleryMode !== "none";
+
     if (this._autoUpdateTimer != null) {
       this._startAutoUpdateTimer();
+    }
+    if (this._autoSwitchTimer != null) {
+      this._startAutoSwitchTimer();
     }
   }
 
@@ -165,6 +189,10 @@ export class SolarViewCard extends LitElement {
     // synchronous tests and delay the first frame in HA.
     this._render();
     this._startAutoUpdateTimer();
+    this._startAutoSwitchTimer();
+    if (this._galleryOpen) {
+      this._refreshGalleryImages();
+    }
     this._onVisibilityChange = () => {
       if (!document.hidden && this._isLiveMode) {
         this._currentDate = new Date();
@@ -178,6 +206,8 @@ export class SolarViewCard extends LitElement {
     super.disconnectedCallback();
     clearInterval(this._autoUpdateTimer ?? undefined);
     this._autoUpdateTimer = null;
+    clearInterval(this._autoSwitchTimer ?? undefined);
+    this._autoSwitchTimer = null;
     clearInterval(this._replayTimer ?? undefined);
     this._replayTimer = null;
     if (this._onVisibilityChange) {
@@ -222,7 +252,7 @@ export class SolarViewCard extends LitElement {
           ${
             this._galleryOpen && this._imagePanelMode === "none"
               ? html`<div class="gallery">
-                  ${GALLERY_SOURCES.map(
+                  ${this._displayGallerySources.map(
                     (source) => html`<button
                       class="gallery-thumb"
                       data-source=${source}
@@ -257,7 +287,7 @@ export class SolarViewCard extends LitElement {
             <button data-action="zoom-in" title="Zoom in" @click=${this._onNavClick}>+</button>
           </span>
           ${
-            this._config?.gallery === true
+            this._galleryMode !== "none"
               ? html`<span class="nav-spacer"></span>
                   <span class="btn-group">
                     <button
@@ -266,7 +296,7 @@ export class SolarViewCard extends LitElement {
                       class=${this._galleryOpen ? "active" : ""}
                       @click=${this._onNavClick}
                     >
-                      <span class="icon">🖼️</span>
+                      <span class="icon">▦</span>
                     </button>
                   </span>`
               : nothing
@@ -334,6 +364,21 @@ export class SolarViewCard extends LitElement {
         this._refreshGalleryImages();
       }
     }, interval) as unknown as number;
+  }
+
+  // Flips which source is shown in the "slide" gallery strip. Only relevant while
+  // gallery.mode is "slide" — otherwise cleared so no interval runs unnecessarily.
+  private _startAutoSwitchTimer(): void {
+    /* v8 ignore next */
+    clearInterval(this._autoSwitchTimer ?? undefined);
+    if (this._galleryMode !== "slide") {
+      this._autoSwitchTimer = null;
+      return;
+    }
+    this._autoSwitchTimer = setInterval(() => {
+      this._autoDisplayedSource = this._autoDisplayedSource === "earth" ? "sun" : "earth";
+      this._render();
+    }, this._galleryAutoIntervalMs) as unknown as number;
   }
 
   private _advanceZoom(): void {
@@ -606,21 +651,47 @@ export class SolarViewCard extends LitElement {
     }
   }
 
-  // Fetches all gallery thumbnails — called when the gallery is opened, and on each
-  // auto-update tick while it stays open and no full image is showing (never while both
-  // are closed, to avoid unconditional background polling of NASA's servers for every
-  // install regardless of use). Each source is still cache-guarded (1-hour TTL), so this
-  // only hits the network once the cache has expired.
+  // Sources this gallery.mode needs fetched in the background — "slide" still fetches both
+  // even though only one is displayed at a time, so flipping the displayed source never
+  // shows a stale/missing thumbnail.
+  private get _fetchGallerySources(): ImageSource[] {
+    switch (this._galleryMode) {
+      case "both":
+      case "slide":
+        return GALLERY_SOURCES;
+      case "earth":
+      case "sun":
+        return [this._galleryMode];
+      /* v8 ignore next 2 */
+      default:
+        return [];
+    }
+  }
+
+  // Sources rendered as thumbnails right now.
+  private get _displayGallerySources(): ImageSource[] {
+    return this._galleryMode === "slide" ? [this._autoDisplayedSource] : this._fetchGallerySources;
+  }
+
+  // Fetches gallery thumbnails for the active gallery.mode — called when the gallery is
+  // opened, and on each auto-update tick while it stays open and no full image is showing
+  // (never while both are closed, to avoid unconditional background polling of NASA's
+  // servers for every install regardless of use). Each source is still cache-guarded (Sun:
+  // 15-min TTL, Earth: 1-hour TTL — Sun's disk image updates far more often), so this only
+  // hits the network once the relevant cache has expired.
   private async _refreshGalleryImages(): Promise<void> {
+    const sources = this._fetchGallerySources;
     const results = await Promise.allSettled(
-      GALLERY_SOURCES.map((source) =>
-        source === "earth" ? fetchLatestEarthImageUrl() : Promise.resolve(getSunImageUrl())
+      sources.map((source) =>
+        source === "earth"
+          ? fetchLatestEarthImageUrl()
+          : Promise.resolve(getSunImageUrl(FULL_PANEL_CACHE_TTL_MS))
       )
     );
     for (let i = 0; i < results.length; i++) {
       const result = results[i];
       if (result.status === "fulfilled") {
-        this._galleryImages[GALLERY_SOURCES[i]] = result.value;
+        this._galleryImages[sources[i]] = result.value;
       }
     }
     this._render();
@@ -638,6 +709,7 @@ export class SolarViewCard extends LitElement {
       refresh_mins: 1,
       zoom_animate: true,
       colors: {},
+      gallery: { mode: "both" },
     };
   }
 }

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -27,6 +27,7 @@ import {
   fetchLatestEarthImageUrl,
   getSunImageUrl,
 } from "./image-sources.js";
+import { formatRelativeAge } from "./relative-time.js";
 import { ZoomAnimator } from "./zoom-animator.js";
 
 const REPLAY_WINDOW_MS = 6 * 60 * 60 * 1000;
@@ -248,6 +249,7 @@ export class SolarViewCard extends LitElement {
             src=${this._imageUrl ?? ""}
             alt=""
             @click=${this._onImageClick}
+            @error=${this._onImageLoadError}
           />
           ${
             this._galleryOpen && this._imagePanelMode === "none"
@@ -260,6 +262,13 @@ export class SolarViewCard extends LitElement {
                       @click=${this._onGalleryClick}
                     >
                       <img src=${this._galleryImages[source]?.url ?? ""} alt="" />
+                      ${
+                        this._galleryImages[source]
+                          ? html`<span class="gallery-age"
+                              >${formatRelativeAge(this._galleryImages[source]?.date as Date, new Date())}</span
+                            >`
+                          : nothing
+                      }
                       <span class="gallery-label">${GALLERY_SOURCE_LABELS[source]}</span>
                     </button>`
                   )}
@@ -600,6 +609,18 @@ export class SolarViewCard extends LitElement {
 
   private _onImageClick(): void {
     this._setImagePanel("none");
+  }
+
+  // Earth's URL is validated by a real fetch before it's ever assigned, so this only ever
+  // fires in practice for sun: its URL is computed (not fetch-checked) from NASA's publish
+  // cadence, so it can occasionally 404 if a slot hasn't been published yet.
+  private _onImageLoadError(): void {
+    if (this._imagePanelMode === "none") return;
+    this._imageError = `${IMAGE_SOURCE_LABELS[this._imagePanelMode]} image unavailable`;
+    this._imagePanelMode = "none";
+    this._imageUrl = null;
+    this._imageDate = null;
+    this._render();
   }
 
   private async _setImagePanel(mode: ImagePanelMode): Promise<void> {

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -11,8 +11,22 @@ import type {
   ZoomLevel,
 } from "../types.js";
 import { cardStyles } from "./card-styles.js";
-import { buildStatusBar } from "./card-template.js";
+import type { ImageSource } from "./card-template.js";
+import {
+  buildImageStatusBar,
+  buildStatusBar,
+  GALLERY_SOURCE_LABELS,
+  GALLERY_SOURCES,
+  IMAGE_SOURCE_LABELS,
+} from "./card-template.js";
 import { DEFAULT_ZOOM_LEVEL, MAX_ZOOM, MIN_ZOOM, ViewState } from "./card-view-state.js";
+import type { SourcedImage } from "./image-sources.js";
+import {
+  CLICK_CACHE_TTL_MS,
+  FULL_PANEL_CACHE_TTL_MS,
+  fetchLatestEarthImageUrl,
+  getSunImageUrl,
+} from "./image-sources.js";
 import { ZoomAnimator } from "./zoom-animator.js";
 
 const REPLAY_WINDOW_MS = 6 * 60 * 60 * 1000;
@@ -20,6 +34,8 @@ const REPLAY_STEPS = 36;
 const REPLAY_STEP_MS = REPLAY_WINDOW_MS / REPLAY_STEPS;
 const REPLAY_MAX_DURATION_MS = 5000;
 const REPLAY_INTERVAL_MS = Math.floor(REPLAY_MAX_DURATION_MS / REPLAY_STEPS);
+
+type ImagePanelMode = "none" | ImageSource;
 
 export class SolarViewCard extends LitElement {
   static styles = cardStyles;
@@ -45,6 +61,12 @@ export class SolarViewCard extends LitElement {
   private _eclipticView: boolean;
   private _positions: ViewPosition[];
   private _onVisibilityChange: (() => void) | null;
+  private _imagePanelMode: ImagePanelMode;
+  private _imageUrl: string | null;
+  private _imageDate: Date | null;
+  private _imageError: string | null;
+  private _galleryOpen: boolean;
+  private _galleryImages: Partial<Record<ImageSource, SourcedImage>>;
   _config: CardConfig | undefined;
 
   constructor() {
@@ -70,6 +92,12 @@ export class SolarViewCard extends LitElement {
     this._eclipticView = false;
     this._positions = [];
     this._onVisibilityChange = null;
+    this._imagePanelMode = "none";
+    this._imageUrl = null;
+    this._imageDate = null;
+    this._imageError = null;
+    this._galleryOpen = false;
+    this._galleryImages = {};
   }
 
   // ---------------------------------------------------------------------------
@@ -163,7 +191,18 @@ export class SolarViewCard extends LitElement {
       this._hemisphere = this._lat < 0 ? "south" : "north";
     }
 
-    const statusBar = buildStatusBar(this._locationData, this._locationName, this._currentDate);
+    const statusBar = this._imageError
+      ? html`<div class="status-bar">
+          <span>${this._imageError}</span>
+        </div>`
+      : this._imagePanelMode === "none"
+        ? buildStatusBar(this._locationData, this._locationName, this._currentDate)
+        : buildImageStatusBar(
+            this._imagePanelMode,
+            this._formatDate(this._imageDate as Date),
+            this._imageDate as Date,
+            new Date()
+          );
     const zoomLevel = this._viewState?.zoomLevel ?? this._defaultZoomLevel;
     /* v8 ignore next */
     const background = this._colors.background ?? "";
@@ -172,7 +211,31 @@ export class SolarViewCard extends LitElement {
       <div class="card" style="background: ${background}">
         <div class="solar-view-wrapper">
           ${statusBar}
-          <div id="solar-view"></div>
+          <div id="solar-view" class=${this._imagePanelMode === "none" ? "" : "hidden"}></div>
+          <img
+            id="image-view"
+            class="image-view ${this._imagePanelMode === "none" ? "" : "visible"}"
+            src=${this._imageUrl ?? ""}
+            alt=""
+            @click=${this._onImageClick}
+          />
+          ${
+            this._galleryOpen && this._imagePanelMode === "none"
+              ? html`<div class="gallery">
+                  ${GALLERY_SOURCES.map(
+                    (source) => html`<button
+                      class="gallery-thumb"
+                      data-source=${source}
+                      title=${`Show ${GALLERY_SOURCE_LABELS[source]}`}
+                      @click=${this._onGalleryClick}
+                    >
+                      <img src=${this._galleryImages[source]?.url ?? ""} alt="" />
+                      <span class="gallery-label">${GALLERY_SOURCE_LABELS[source]}</span>
+                    </button>`
+                  )}
+                </div>`
+              : nothing
+          }
         </div>
         <div class="nav">
           <span class="btn-group">
@@ -183,11 +246,7 @@ export class SolarViewCard extends LitElement {
             <button data-action="hour-forward" title="Forward 1 hour" ?disabled=${this._isReplaying} @click=${this._onNavClick}>›</button>
             <button data-action="day-forward" title="Forward 1 day" ?disabled=${this._isReplaying} @click=${this._onNavClick}>»</button>
             <button data-action="month-forward" title="Forward 1 month" ?disabled=${this._isReplaying} @click=${this._onNavClick}>⋙</button>
-            ${
-              this._config?.debug
-                ? html`<button data-action="replay" title="Replay last 6h" @click=${this._onNavClick}>↺</button>`
-                : nothing
-            }
+            <button data-action="replay" title="Replay last 6h" @click=${this._onNavClick}>↺</button>
           </span>
           <span class="nav-spacer"></span>
           <span class="date">${this._formatDate(this._currentDate)}</span>
@@ -197,6 +256,21 @@ export class SolarViewCard extends LitElement {
             <span class="zoom-level">${zoomLevel}</span>
             <button data-action="zoom-in" title="Zoom in" @click=${this._onNavClick}>+</button>
           </span>
+          ${
+            this._config?.gallery === true
+              ? html`<span class="nav-spacer"></span>
+                  <span class="btn-group">
+                    <button
+                      data-action="gallery"
+                      title="Show image gallery"
+                      class=${this._galleryOpen ? "active" : ""}
+                      @click=${this._onNavClick}
+                    >
+                      <span class="icon">🖼️</span>
+                    </button>
+                  </span>`
+              : nothing
+          }
           ${this._config?.show_version ? html`<span class="card-version">v${__CARD_VERSION__}</span>` : nothing}
         </div>
       </div>
@@ -253,6 +327,11 @@ export class SolarViewCard extends LitElement {
       }
       if (this._periodicZoomChange) {
         this._advanceZoom();
+      }
+      if (this._imagePanelMode !== "none") {
+        this._refreshOpenImage();
+      } else if (this._galleryOpen) {
+        this._refreshGalleryImages();
       }
     }, interval) as unknown as number;
   }
@@ -406,6 +485,11 @@ export class SolarViewCard extends LitElement {
     this._handleNavAction((e.currentTarget as HTMLButtonElement).dataset.action);
   }
 
+  private _onGalleryClick(e: Event): void {
+    const source = (e.currentTarget as HTMLButtonElement).dataset.source as ImageSource;
+    this._setImagePanel(source);
+  }
+
   private _bindSvgEvents(svg: SVGSVGElement): void {
     svg.addEventListener("pointerdown", (e) => this._onPointerDown(e));
     svg.addEventListener("pointermove", (e) => this._onPointerMove(e));
@@ -452,7 +536,94 @@ export class SolarViewCard extends LitElement {
       case "zoom-in":
         this._zoomIn();
         break;
+      case "gallery":
+        this._toggleGallery();
+        break;
     }
+  }
+
+  private _toggleGallery(): void {
+    this._galleryOpen = !this._galleryOpen;
+    if (!this._galleryOpen) {
+      this._setImagePanel("none");
+    } else {
+      this._imageError = null;
+      this._render();
+      this._refreshGalleryImages();
+    }
+  }
+
+  private _onImageClick(): void {
+    this._setImagePanel("none");
+  }
+
+  private async _setImagePanel(mode: ImagePanelMode): Promise<void> {
+    if (mode === "none") {
+      this._imagePanelMode = "none";
+      this._imageUrl = null;
+      this._imageDate = null;
+      this._imageError = null;
+      this._render();
+      return;
+    }
+    this._imageError = null;
+    try {
+      // Opening the full image is a click-triggered fetch: a short cache (CLICK_CACHE_TTL_MS)
+      // avoids redownloading from NASA's slow servers if you just looked at this same source
+      // moments ago. Once open, _refreshOpenImage takes over on its own (longer) cadence.
+      const { url, date } =
+        mode === "earth"
+          ? await fetchLatestEarthImageUrl(CLICK_CACHE_TTL_MS)
+          : getSunImageUrl(CLICK_CACHE_TTL_MS);
+      this._imagePanelMode = mode;
+      this._imageUrl = url;
+      this._imageDate = date;
+    } catch {
+      this._imagePanelMode = "none";
+      this._imageUrl = null;
+      this._imageDate = null;
+      this._imageError = `${IMAGE_SOURCE_LABELS[mode]} image unavailable`;
+    }
+    this._render();
+  }
+
+  // Keeps the open full-screen image fresh (15-min TTL) on each auto-update tick, for as
+  // long as it stays open. Only called while _imagePanelMode !== "none" (see the tick
+  // handler). A failed refresh is silently skipped — the panel keeps showing the last
+  // good image rather than surfacing a transient background-fetch error.
+  private async _refreshOpenImage(): Promise<void> {
+    const mode = this._imagePanelMode;
+    try {
+      const { url, date } =
+        mode === "earth"
+          ? await fetchLatestEarthImageUrl(FULL_PANEL_CACHE_TTL_MS)
+          : getSunImageUrl(FULL_PANEL_CACHE_TTL_MS);
+      this._imageUrl = url;
+      this._imageDate = date;
+      this._render();
+    } catch {
+      // Keep showing the last good image.
+    }
+  }
+
+  // Fetches all gallery thumbnails — called when the gallery is opened, and on each
+  // auto-update tick while it stays open and no full image is showing (never while both
+  // are closed, to avoid unconditional background polling of NASA's servers for every
+  // install regardless of use). Each source is still cache-guarded (1-hour TTL), so this
+  // only hits the network once the cache has expired.
+  private async _refreshGalleryImages(): Promise<void> {
+    const results = await Promise.allSettled(
+      GALLERY_SOURCES.map((source) =>
+        source === "earth" ? fetchLatestEarthImageUrl() : Promise.resolve(getSunImageUrl())
+      )
+    );
+    for (let i = 0; i < results.length; i++) {
+      const result = results[i];
+      if (result.status === "fulfilled") {
+        this._galleryImages[GALLERY_SOURCES[i]] = result.value;
+      }
+    }
+    this._render();
   }
 
   getCardSize(): number {

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -21,12 +21,7 @@ import {
 } from "./card-template.js";
 import { DEFAULT_ZOOM_LEVEL, MAX_ZOOM, MIN_ZOOM, ViewState } from "./card-view-state.js";
 import type { SourcedImage } from "./image-sources.js";
-import {
-  CLICK_CACHE_TTL_MS,
-  fetchLatestEarthImageUrl,
-  getPreviousSunSlot,
-  getSunImageUrl,
-} from "./image-sources.js";
+import { fetchLatestEarthImageUrl, getPreviousSunSlot, getSunImageUrl } from "./image-sources.js";
 import { formatRelativeAge } from "./relative-time.js";
 import { ZoomAnimator } from "./zoom-animator.js";
 
@@ -68,10 +63,12 @@ export class SolarViewCard extends LitElement {
   private _imagePanelMode: ImagePanelMode;
   private _imageUrl: string | null;
   private _imageDate: Date | null;
+  private _imageLoaded: boolean;
   private _imageError: string | null;
   private _sunRetried: boolean;
   private _galleryOpen: boolean;
   private _galleryImages: Partial<Record<ImageSource, SourcedImage>>;
+  private _galleryLoaded: Partial<Record<ImageSource, boolean>>;
   private _gallerySunRetried: boolean;
   private _galleryMode: GalleryMode;
   private _galleryAutoIntervalMs: number;
@@ -105,10 +102,12 @@ export class SolarViewCard extends LitElement {
     this._imagePanelMode = "none";
     this._imageUrl = null;
     this._imageDate = null;
+    this._imageLoaded = false;
     this._imageError = null;
     this._sunRetried = false;
     this._galleryOpen = false;
     this._galleryImages = {};
+    this._galleryLoaded = {};
     this._gallerySunRetried = false;
     this._galleryMode = "none";
     this._galleryAutoIntervalMs = DEFAULT_GALLERY_INTERVAL_MS;
@@ -236,7 +235,8 @@ export class SolarViewCard extends LitElement {
             this._imagePanelMode,
             this._formatDate(this._imageDate as Date),
             this._imageDate as Date,
-            new Date()
+            new Date(),
+            this._imageLoaded
           );
     const zoomLevel = this._viewState?.zoomLevel ?? this._defaultZoomLevel;
     /* v8 ignore next */
@@ -253,6 +253,7 @@ export class SolarViewCard extends LitElement {
             src=${this._imageUrl ?? ""}
             alt=""
             @click=${this._onImageClick}
+            @load=${this._onImageLoad}
             @error=${this._onImageLoadError}
           />
           ${
@@ -268,6 +269,7 @@ export class SolarViewCard extends LitElement {
                       <img
                         src=${this._galleryImages[source]?.url ?? ""}
                         alt=""
+                        @load=${() => this._onGalleryImageLoad(source)}
                         @error=${source === "sun" ? this._onSunThumbError : undefined}
                       />
                       <div class="gallery-info">
@@ -275,7 +277,14 @@ export class SolarViewCard extends LitElement {
                         ${
                           this._galleryImages[source]
                             ? html`<span class="gallery-age"
-                                >${formatRelativeAge(this._galleryImages[source]?.date as Date, new Date())}</span
+                                >${
+                                  this._galleryLoaded[source]
+                                    ? formatRelativeAge(
+                                        this._galleryImages[source]?.date as Date,
+                                        new Date()
+                                      )
+                                    : "loading…"
+                                }</span
                               >`
                             : nothing
                         }
@@ -630,8 +639,7 @@ export class SolarViewCard extends LitElement {
     if (this._imagePanelMode === "sun" && !this._sunRetried) {
       this._sunRetried = true;
       const { url, date } = getPreviousSunSlot(this._imageDate as Date);
-      this._imageUrl = url;
-      this._imageDate = date;
+      this._applyImage(url, date);
       this._render();
       return;
     }
@@ -639,6 +647,23 @@ export class SolarViewCard extends LitElement {
     this._imagePanelMode = "none";
     this._imageUrl = null;
     this._imageDate = null;
+    this._render();
+  }
+
+  // The date/age shown in the status bar is only as trustworthy as the image actually
+  // loading — a computed sun slot can 404 (see _onImageLoadError) before we know that.
+  // _imageLoaded gates the displayed text on the <img> load event instead of the fetch
+  // resolving, so a bad guess shows "loading…" rather than a date for a slot that turns
+  // out not to exist. Only resets when the URL actually changes, so a cache-hit refresh
+  // (same URL, already loaded) doesn't flash back to "loading…" for no reason.
+  private _applyImage(url: string, date: Date): void {
+    if (url !== this._imageUrl) this._imageLoaded = false;
+    this._imageUrl = url;
+    this._imageDate = date;
+  }
+
+  private _onImageLoad(): void {
+    this._imageLoaded = true;
     this._render();
   }
 
@@ -654,16 +679,12 @@ export class SolarViewCard extends LitElement {
     }
     this._imageError = null;
     try {
-      // Opening the full image is a click-triggered fetch: a short cache (CLICK_CACHE_TTL_MS)
-      // avoids redownloading from NASA's slow servers if you just looked at this same source
-      // moments ago. Once open, _refreshOpenImage takes over on its own (longer) cadence.
-      const { url, date } =
-        mode === "earth"
-          ? await fetchLatestEarthImageUrl(CLICK_CACHE_TTL_MS)
-          : getSunImageUrl(CLICK_CACHE_TTL_MS);
+      // Same cache TTL as the gallery thumbnail's own background fetch (earth hourly, sun
+      // every 15min) — reuses the exact image the thumbnail already has loaded instead of
+      // computing a slightly newer slot and forcing a fresh network fetch on click.
+      const { url, date } = mode === "earth" ? await fetchLatestEarthImageUrl() : getSunImageUrl();
       this._imagePanelMode = mode;
-      this._imageUrl = url;
-      this._imageDate = date;
+      this._applyImage(url, date);
     } catch {
       this._imagePanelMode = "none";
       this._imageUrl = null;
@@ -682,8 +703,7 @@ export class SolarViewCard extends LitElement {
     const mode = this._imagePanelMode;
     try {
       const { url, date } = mode === "earth" ? await fetchLatestEarthImageUrl() : getSunImageUrl();
-      this._imageUrl = url;
-      this._imageDate = date;
+      this._applyImage(url, date);
       this._render();
     } catch {
       // Keep showing the last good image.
@@ -729,9 +749,21 @@ export class SolarViewCard extends LitElement {
     for (let i = 0; i < results.length; i++) {
       const result = results[i];
       if (result.status === "fulfilled") {
-        this._galleryImages[sources[i]] = result.value;
+        this._applyGalleryImage(sources[i], result.value);
       }
     }
+    this._render();
+  }
+
+  // Same "don't trust the date until the pixels actually load" reasoning as _applyImage,
+  // for the gallery thumbnail instead of the full-screen view.
+  private _applyGalleryImage(source: ImageSource, image: SourcedImage): void {
+    if (image.url !== this._galleryImages[source]?.url) this._galleryLoaded[source] = false;
+    this._galleryImages[source] = image;
+  }
+
+  private _onGalleryImageLoad(source: ImageSource): void {
+    this._galleryLoaded[source] = true;
     this._render();
   }
 
@@ -741,6 +773,7 @@ export class SolarViewCard extends LitElement {
   private _onSunThumbError(): void {
     if (this._gallerySunRetried) {
       delete this._galleryImages.sun;
+      delete this._galleryLoaded.sun;
       this._render();
       return;
     }
@@ -748,7 +781,7 @@ export class SolarViewCard extends LitElement {
     /* v8 ignore next */
     if (!current) return;
     this._gallerySunRetried = true;
-    this._galleryImages.sun = getPreviousSunSlot(current.date);
+    this._applyGalleryImage("sun", getPreviousSunSlot(current.date));
     this._render();
   }
 

--- a/src/card/image-sources.ts
+++ b/src/card/image-sources.ts
@@ -13,12 +13,13 @@ const GALLERY_CACHE_TTL_MS = 3600000;
 // time — but sdo.gsfc.nasa.gov sends no CORS header, so unlike EPIC's JSON API we can't fetch
 // the directory listing from the browser to confirm which slot has actually been published.
 // Instead we compute the URL: floor "now minus a publish-latency buffer" to the last 15-min
-// slot. The buffer trades a small amount of freshness for a single request with no listing
-// fetch or retry — if NASA's pipeline ever lags past it, the image 404s and the UI falls back
-// to the same "unavailable" state as any other failed source.
+// slot. One buffer's worth of margin (one slot) covers the typical case; both the gallery
+// thumbnail and full-screen view retry once, a further slot back, if that guess 404s — so
+// the buffer only needs to cover the common case, not the worst case, before falling back to
+// the same "unavailable" state as any other failed source.
 export const SDO_BROWSE_BASE_URL = "https://sdo.gsfc.nasa.gov/assets/img/browse";
 export const SUN_SLOT_MS = 15 * 60000;
-const SUN_PUBLISH_BUFFER_MS = 30 * 60000;
+const SUN_PUBLISH_BUFFER_MS = 15 * 60000;
 
 export interface SourcedImage {
   url: string;

--- a/src/card/image-sources.ts
+++ b/src/card/image-sources.ts
@@ -1,12 +1,11 @@
 export const EPIC_BASE_URL = "https://epic.gsfc.nasa.gov";
-// Three cadences, from most to least frequent background traffic:
+// Two cadences:
 // - CLICK: opening a thumbnail is an explicit request for the freshest shot, but still
 //   respects a short TTL — otherwise a rapid re-click re-downloads for no new content.
-// - FULL_PANEL: while the full-screen image stays open, it keeps itself fresh on its own.
-// - GALLERY: the thumbnail strip's background ticks, much slower to avoid hammering NASA's
-//   (slow, ~1-2s per image) servers for a view that's just idling in the background.
+// - GALLERY: everything else (the idling thumbnail strip, and the full-screen view once
+//   open) ticks in the background. Earth ticks hourly; Sun ticks every 15 min — matching
+//   SUN_SLOT_MS below, since polling faster than the source's own publish grid buys nothing.
 export const CLICK_CACHE_TTL_MS = 120000;
-export const FULL_PANEL_CACHE_TTL_MS = 900000;
 const GALLERY_CACHE_TTL_MS = 3600000;
 
 // SDO publishes HMI Continuum (visible-light sunspot disk) quicklook frames to a dated
@@ -18,8 +17,8 @@ const GALLERY_CACHE_TTL_MS = 3600000;
 // fetch or retry — if NASA's pipeline ever lags past it, the image 404s and the UI falls back
 // to the same "unavailable" state as any other failed source.
 export const SDO_BROWSE_BASE_URL = "https://sdo.gsfc.nasa.gov/assets/img/browse";
-const SUN_SLOT_MS = 15 * 60000;
-const SUN_PUBLISH_BUFFER_MS = 20 * 60000;
+export const SUN_SLOT_MS = 15 * 60000;
+const SUN_PUBLISH_BUFFER_MS = 30 * 60000;
 
 export interface SourcedImage {
   url: string;
@@ -36,23 +35,33 @@ function pad(n: number): string {
   return String(n).padStart(2, "0");
 }
 
-export function getSunImageUrl(maxAgeMs = GALLERY_CACHE_TTL_MS): SourcedImage {
+function buildSunSlotImage(slot: Date): SourcedImage {
+  const year = slot.getUTCFullYear();
+  const month = pad(slot.getUTCMonth() + 1);
+  const day = pad(slot.getUTCDate());
+  const hhmmss = `${pad(slot.getUTCHours())}${pad(slot.getUTCMinutes())}00`;
+  return {
+    url: `${SDO_BROWSE_BASE_URL}/${year}/${month}/${day}/${year}${month}${day}_${hhmmss}_1024_HMIIC.jpg`,
+    date: slot,
+  };
+}
+
+export function getSunImageUrl(maxAgeMs = SUN_SLOT_MS): SourcedImage {
   const now = Date.now();
   const cached = cache.get("sun");
   if (cached && now - cached.fetchedAt < maxAgeMs) return cached.image;
 
   const slotMs = Math.floor((now - SUN_PUBLISH_BUFFER_MS) / SUN_SLOT_MS) * SUN_SLOT_MS;
-  const slot = new Date(slotMs);
-  const year = slot.getUTCFullYear();
-  const month = pad(slot.getUTCMonth() + 1);
-  const day = pad(slot.getUTCDate());
-  const hhmmss = `${pad(slot.getUTCHours())}${pad(slot.getUTCMinutes())}00`;
-  const image = {
-    url: `${SDO_BROWSE_BASE_URL}/${year}/${month}/${day}/${year}${month}${day}_${hhmmss}_1024_HMIIC.jpg`,
-    date: slot,
-  };
+  const image = buildSunSlotImage(new Date(slotMs));
   cache.set("sun", { image, fetchedAt: now });
   return image;
+}
+
+// One-step fallback for when the computed slot 404s (NASA's publish pipeline occasionally
+// lags past the buffer) — steps back exactly one 15-min slot and nothing further, so a
+// single stale request doesn't turn into an unbounded retry chain.
+export function getPreviousSunSlot(currentSlot: Date): SourcedImage {
+  return buildSunSlotImage(new Date(currentSlot.getTime() - SUN_SLOT_MS));
 }
 
 export async function fetchLatestEarthImageUrl(

--- a/src/card/image-sources.ts
+++ b/src/card/image-sources.ts
@@ -9,12 +9,17 @@ export const CLICK_CACHE_TTL_MS = 120000;
 export const FULL_PANEL_CACHE_TTL_MS = 900000;
 const GALLERY_CACHE_TTL_MS = 3600000;
 
-// SDO's fixed-filename "latest" HMI Continuum (visible-light sunspot disk) JPG.
-// sdo.gsfc.nasa.gov sends no CORS header, so unlike EPIC we can't fetch a directory
-// listing to resolve a real per-image timestamp from the browser — this URL always
-// serves the newest frame under the same name, cache-busted via a query param, and
-// dated to when we last checked rather than when it was captured.
-export const SUN_IMAGE_URL = "https://sdo.gsfc.nasa.gov/assets/img/latest/latest_1024_HMIIC.jpg";
+// SDO publishes HMI Continuum (visible-light sunspot disk) quicklook frames to a dated
+// browse archive on a fixed 15-min grid (:00/:15/:30/:45 UTC), named for their real capture
+// time — but sdo.gsfc.nasa.gov sends no CORS header, so unlike EPIC's JSON API we can't fetch
+// the directory listing from the browser to confirm which slot has actually been published.
+// Instead we compute the URL: floor "now minus a publish-latency buffer" to the last 15-min
+// slot. The buffer trades a small amount of freshness for a single request with no listing
+// fetch or retry — if NASA's pipeline ever lags past it, the image 404s and the UI falls back
+// to the same "unavailable" state as any other failed source.
+export const SDO_BROWSE_BASE_URL = "https://sdo.gsfc.nasa.gov/assets/img/browse";
+const SUN_SLOT_MS = 15 * 60000;
+const SUN_PUBLISH_BUFFER_MS = 20 * 60000;
 
 export interface SourcedImage {
   url: string;
@@ -27,11 +32,25 @@ export function clearImageCache(): void {
   cache.clear();
 }
 
+function pad(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
 export function getSunImageUrl(maxAgeMs = GALLERY_CACHE_TTL_MS): SourcedImage {
   const now = Date.now();
   const cached = cache.get("sun");
   if (cached && now - cached.fetchedAt < maxAgeMs) return cached.image;
-  const image = { url: `${SUN_IMAGE_URL}?t=${now}`, date: new Date(now) };
+
+  const slotMs = Math.floor((now - SUN_PUBLISH_BUFFER_MS) / SUN_SLOT_MS) * SUN_SLOT_MS;
+  const slot = new Date(slotMs);
+  const year = slot.getUTCFullYear();
+  const month = pad(slot.getUTCMonth() + 1);
+  const day = pad(slot.getUTCDate());
+  const hhmmss = `${pad(slot.getUTCHours())}${pad(slot.getUTCMinutes())}00`;
+  const image = {
+    url: `${SDO_BROWSE_BASE_URL}/${year}/${month}/${day}/${year}${month}${day}_${hhmmss}_1024_HMIIC.jpg`,
+    date: slot,
+  };
   cache.set("sun", { image, fetchedAt: now });
   return image;
 }

--- a/src/card/image-sources.ts
+++ b/src/card/image-sources.ts
@@ -1,11 +1,9 @@
 export const EPIC_BASE_URL = "https://epic.gsfc.nasa.gov";
-// Two cadences:
-// - CLICK: opening a thumbnail is an explicit request for the freshest shot, but still
-//   respects a short TTL — otherwise a rapid re-click re-downloads for no new content.
-// - GALLERY: everything else (the idling thumbnail strip, and the full-screen view once
-//   open) ticks in the background. Earth ticks hourly; Sun ticks every 15 min — matching
-//   SUN_SLOT_MS below, since polling faster than the source's own publish grid buys nothing.
-export const CLICK_CACHE_TTL_MS = 120000;
+// One cache TTL per source, shared by the gallery thumbnail's background poll, the
+// full-screen view's click-open fetch, and its own background refresh once open — so
+// clicking a thumbnail always reuses the exact image already loaded rather than computing
+// a slightly newer slot and forcing an extra network fetch. Earth: hourly. Sun: every
+// 15 min, matching SUN_SLOT_MS below (polling faster than its own publish grid buys nothing).
 const GALLERY_CACHE_TTL_MS = 3600000;
 
 // SDO publishes HMI Continuum (visible-light sunspot disk) quicklook frames to a dated

--- a/src/card/image-sources.ts
+++ b/src/card/image-sources.ts
@@ -1,0 +1,79 @@
+export const EPIC_BASE_URL = "https://epic.gsfc.nasa.gov";
+// Three cadences, from most to least frequent background traffic:
+// - CLICK: opening a thumbnail is an explicit request for the freshest shot, but still
+//   respects a short TTL — otherwise a rapid re-click re-downloads for no new content.
+// - FULL_PANEL: while the full-screen image stays open, it keeps itself fresh on its own.
+// - GALLERY: the thumbnail strip's background ticks, much slower to avoid hammering NASA's
+//   (slow, ~1-2s per image) servers for a view that's just idling in the background.
+export const CLICK_CACHE_TTL_MS = 120000;
+export const FULL_PANEL_CACHE_TTL_MS = 900000;
+const GALLERY_CACHE_TTL_MS = 3600000;
+
+// SDO's fixed-filename "latest" HMI Continuum (visible-light sunspot disk) JPG.
+// sdo.gsfc.nasa.gov sends no CORS header, so unlike EPIC we can't fetch a directory
+// listing to resolve a real per-image timestamp from the browser — this URL always
+// serves the newest frame under the same name, cache-busted via a query param, and
+// dated to when we last checked rather than when it was captured.
+export const SUN_IMAGE_URL = "https://sdo.gsfc.nasa.gov/assets/img/latest/latest_1024_HMIIC.jpg";
+
+export interface SourcedImage {
+  url: string;
+  date: Date;
+}
+
+const cache = new Map<string, { image: SourcedImage; fetchedAt: number }>();
+
+export function clearImageCache(): void {
+  cache.clear();
+}
+
+export function getSunImageUrl(maxAgeMs = GALLERY_CACHE_TTL_MS): SourcedImage {
+  const now = Date.now();
+  const cached = cache.get("sun");
+  if (cached && now - cached.fetchedAt < maxAgeMs) return cached.image;
+  const image = { url: `${SUN_IMAGE_URL}?t=${now}`, date: new Date(now) };
+  cache.set("sun", { image, fetchedAt: now });
+  return image;
+}
+
+export async function fetchLatestEarthImageUrl(
+  maxAgeMs = GALLERY_CACHE_TTL_MS
+): Promise<SourcedImage> {
+  const now = Date.now();
+  const cached = cache.get("earth");
+  if (cached && now - cached.fetchedAt < maxAgeMs) {
+    return cached.image;
+  }
+
+  const response = await fetch(`${EPIC_BASE_URL}/api/natural`);
+  if (!response.ok) {
+    throw new Error(`EPIC API request failed: ${response.status}`);
+  }
+  const images = (await response.json()) as Array<{ identifier: string }>;
+  const latest = images[images.length - 1];
+  if (!latest) {
+    throw new Error("EPIC API returned no images");
+  }
+  const { identifier } = latest;
+  const year = identifier.slice(0, 4);
+  const month = identifier.slice(4, 6);
+  const day = identifier.slice(6, 8);
+  const hour = identifier.slice(8, 10);
+  const minute = identifier.slice(10, 12);
+  const second = identifier.slice(12, 14);
+  const image = {
+    url: `${EPIC_BASE_URL}/archive/natural/${year}/${month}/${day}/jpg/epic_1b_${identifier}.jpg`,
+    date: new Date(
+      Date.UTC(
+        Number(year),
+        Number(month) - 1,
+        Number(day),
+        Number(hour),
+        Number(minute),
+        Number(second)
+      )
+    ),
+  };
+  cache.set("earth", { image, fetchedAt: now });
+  return image;
+}

--- a/src/card/relative-time.ts
+++ b/src/card/relative-time.ts
@@ -1,0 +1,6 @@
+export function formatRelativeAge(date: Date, now: Date): string {
+  const diffMin = Math.floor((now.getTime() - date.getTime()) / 60000);
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  return `${Math.floor(diffMin / 60)}h ago`;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,5 +106,5 @@ export interface CardConfig {
   colors?: Colors;
   ecliptic_view?: string;
   show_version?: boolean;
-  debug?: boolean;
+  gallery?: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,5 +106,5 @@ export interface CardConfig {
   colors?: Colors;
   ecliptic_view?: string;
   show_version?: boolean;
-  gallery?: boolean;
+  gallery?: { mode?: string; slide_interval_secs?: number };
 }

--- a/test/__snapshots__/snapshot.test.ts.snap
+++ b/test/__snapshots__/snapshot.test.ts.snap
@@ -123,15 +123,21 @@ exports[`cardStyles > matches snapshot 1`] = `
     object-fit: cover;
     display: block;
   }
-  .gallery-label {
+  .gallery-info {
     position: absolute;
     bottom: 1px;
+    left: 2px;
     right: 2px;
+    display: flex;
+    justify-content: space-between;
+    pointer-events: none;
+  }
+  .gallery-label,
+  .gallery-age {
     font-size: 8px;
     color: #fff;
     text-shadow: 0 0 2px #000;
     font-family: sans-serif;
-    pointer-events: none;
   }
   .nav {
     display: flex;

--- a/test/__snapshots__/snapshot.test.ts.snap
+++ b/test/__snapshots__/snapshot.test.ts.snap
@@ -113,7 +113,7 @@ exports[`cardStyles > matches snapshot 1`] = `
     padding: 0;
     border: 1px solid var(--divider-color, color-mix(in srgb, currentColor 15%, transparent));
     border-radius: 4px;
-    background: #000;
+    background: transparent;
     overflow: hidden;
     cursor: pointer;
   }
@@ -127,16 +127,6 @@ exports[`cardStyles > matches snapshot 1`] = `
     position: absolute;
     bottom: 1px;
     right: 2px;
-    font-size: 8px;
-    color: #fff;
-    text-shadow: 0 0 2px #000;
-    font-family: sans-serif;
-    pointer-events: none;
-  }
-  .gallery-age {
-    position: absolute;
-    top: 1px;
-    left: 2px;
     font-size: 8px;
     color: #fff;
     text-shadow: 0 0 2px #000;
@@ -194,6 +184,9 @@ exports[`cardStyles > matches snapshot 1`] = `
   }
   .btn-group button:last-child {
     border-radius: 0 6px 6px 0;
+  }
+  .btn-group button:only-child {
+    border-radius: 6px;
   }
   .nav-spacer {
     width: 8px;

--- a/test/__snapshots__/snapshot.test.ts.snap
+++ b/test/__snapshots__/snapshot.test.ts.snap
@@ -133,6 +133,16 @@ exports[`cardStyles > matches snapshot 1`] = `
     font-family: sans-serif;
     pointer-events: none;
   }
+  .gallery-age {
+    position: absolute;
+    top: 1px;
+    left: 2px;
+    font-size: 8px;
+    color: #fff;
+    text-shadow: 0 0 2px #000;
+    font-family: sans-serif;
+    pointer-events: none;
+  }
   .nav {
     display: flex;
     justify-content: center;

--- a/test/__snapshots__/snapshot.test.ts.snap
+++ b/test/__snapshots__/snapshot.test.ts.snap
@@ -41,17 +41,20 @@ exports[`cardStyles > matches snapshot 1`] = `
     margin: 2px 2px;
   }
   .solar-view-wrapper {
-    overflow: hidden;
     position: relative;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
   }
   .status-bar {
     position: absolute;
     top: 0;
     left: 0;
     right: 0;
-    background: color-mix(in srgb, currentColor 15%, transparent);
+    background: rgba(0, 0, 0, 0.55);
     font-size: 10px;
-    color: inherit;
+    color: #fff;
+    text-shadow: 0 0 2px rgba(0, 0, 0, 0.8);
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -72,10 +75,63 @@ exports[`cardStyles > matches snapshot 1`] = `
     width: 100%;
     aspect-ratio: 1;
   }
+  #solar-view.hidden {
+    display: none;
+  }
   #solar-view svg {
     cursor: grab;
     user-select: none;
     touch-action: none;
+  }
+  .image-view {
+    display: none;
+    width: 100%;
+    aspect-ratio: 1;
+    object-fit: contain;
+    background: #000;
+    cursor: pointer;
+  }
+  .image-view.visible {
+    display: block;
+  }
+  .gallery {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    align-items: flex-end;
+    justify-content: flex-end;
+    gap: 2px;
+    padding: 2px;
+    box-sizing: border-box;
+  }
+  .gallery-thumb {
+    flex: 0 0 20%;
+    position: relative;
+    aspect-ratio: 1;
+    padding: 0;
+    border: 1px solid var(--divider-color, color-mix(in srgb, currentColor 15%, transparent));
+    border-radius: 4px;
+    background: #000;
+    overflow: hidden;
+    cursor: pointer;
+  }
+  .gallery-thumb img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+  .gallery-label {
+    position: absolute;
+    bottom: 1px;
+    right: 2px;
+    font-size: 8px;
+    color: #fff;
+    text-shadow: 0 0 2px #000;
+    font-family: sans-serif;
+    pointer-events: none;
   }
   .nav {
     display: flex;
@@ -101,6 +157,20 @@ exports[`cardStyles > matches snapshot 1`] = `
   }
   .nav button:hover {
     background: var(--secondary-background-color, color-mix(in srgb, currentColor 20%, transparent));
+  }
+  .nav button .icon {
+    filter: grayscale(1);
+    display: inline-block;
+  }
+  button[data-action="show-earth"].active {
+    background: #3b82f6;
+    border-color: #3b82f6;
+    color: #fff;
+  }
+  button[data-action="show-sun"].active {
+    background: #f97316;
+    border-color: #f97316;
+    color: #fff;
   }
   .btn-group {
     display: flex;

--- a/test/__snapshots__/snapshot.test.ts.snap
+++ b/test/__snapshots__/snapshot.test.ts.snap
@@ -37,7 +37,7 @@ exports[`cardStyles > matches snapshot 1`] = `
   }
   .date {
     font-size: 11px;
-    color: var(--secondary-text-color, color-mix(in srgb, currentColor 60%, transparent));
+    color: inherit;
     margin: 2px 2px;
   }
   .solar-view-wrapper {
@@ -51,10 +51,9 @@ exports[`cardStyles > matches snapshot 1`] = `
     top: 0;
     left: 0;
     right: 0;
-    background: rgba(0, 0, 0, 0.55);
+    background: var(--secondary-background-color, color-mix(in srgb, currentColor 10%, transparent));
     font-size: 10px;
-    color: #fff;
-    text-shadow: 0 0 2px rgba(0, 0, 0, 0.8);
+    color: inherit;
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -146,6 +145,7 @@ exports[`cardStyles > matches snapshot 1`] = `
     gap: 4px;
     margin-top: 2px;
     position: relative;
+    background: var(--secondary-background-color, color-mix(in srgb, currentColor 10%, transparent));
   }
   .nav button {
     background: color-mix(in srgb, currentColor 15%, transparent);
@@ -162,7 +162,7 @@ exports[`cardStyles > matches snapshot 1`] = `
     box-sizing: border-box;
   }
   .nav button:hover {
-    background: var(--secondary-background-color, color-mix(in srgb, currentColor 20%, transparent));
+    background: color-mix(in srgb, currentColor 25%, transparent);
   }
   .nav button .icon {
     filter: grayscale(1);

--- a/test/card/card-template.test.ts
+++ b/test/card/card-template.test.ts
@@ -1,6 +1,6 @@
 import { nothing, render } from "lit";
 import { describe, expect, it } from "vitest";
-import { buildStatusBar } from "../../src/card/card-template.js";
+import { buildImageStatusBar, buildStatusBar } from "../../src/card/card-template.js";
 
 function renderToDOM(result) {
   const div = document.createElement("div");
@@ -89,5 +89,41 @@ describe("buildStatusBar", () => {
     const spans = root.querySelectorAll(".status-bar span");
     expect(spans.length).toBe(2);
     expect(spans[1].textContent).toMatch(/^Next: .+ \(\d{2}:\d{2}\)$/);
+  });
+});
+
+describe("buildImageStatusBar", () => {
+  const now = new Date("2026-08-12T12:00:00Z");
+
+  it("labels the earth source with DSCOVR", () => {
+    const root = renderToDOM(
+      buildImageStatusBar("earth", "26-08-10 18:49", new Date("2026-08-10T18:49:00Z"), now)
+    );
+    expect(root.querySelector(".status-bar span").textContent).toContain("DSCOVR Earth");
+  });
+
+  it("labels the sun source with SDO HMI Continuum", () => {
+    const root = renderToDOM(
+      buildImageStatusBar("sun", "26-08-12 11:55", new Date("2026-08-12T11:55:00Z"), now)
+    );
+    expect(root.querySelector(".status-bar span").textContent).toContain("SDO HMI Continuum");
+  });
+
+  it("includes the absolute date text and relative age in parentheses, verb 'captured' for earth", () => {
+    const root = renderToDOM(
+      buildImageStatusBar("earth", "26-08-11 06:00", new Date("2026-08-11T06:00:00Z"), now)
+    );
+    expect(root.querySelector(".status-bar span").textContent).toBe(
+      "DSCOVR Earth · captured 26-08-11 06:00 (30h ago)"
+    );
+  });
+
+  it("uses verb 'checked' for sun, since the fixed-URL image has no real capture timestamp", () => {
+    const root = renderToDOM(
+      buildImageStatusBar("sun", "26-08-12 11:55", new Date("2026-08-12T11:55:00Z"), now)
+    );
+    expect(root.querySelector(".status-bar span").textContent).toBe(
+      "SDO HMI Continuum · checked 26-08-12 11:55 (5m ago)"
+    );
   });
 });

--- a/test/card/card-template.test.ts
+++ b/test/card/card-template.test.ts
@@ -97,21 +97,21 @@ describe("buildImageStatusBar", () => {
 
   it("labels the earth source with DSCOVR", () => {
     const root = renderToDOM(
-      buildImageStatusBar("earth", "26-08-10 18:49", new Date("2026-08-10T18:49:00Z"), now)
+      buildImageStatusBar("earth", "26-08-10 18:49", new Date("2026-08-10T18:49:00Z"), now, true)
     );
     expect(root.querySelector(".status-bar span").textContent).toContain("DSCOVR Earth");
   });
 
   it("labels the sun source with SDO HMI Continuum", () => {
     const root = renderToDOM(
-      buildImageStatusBar("sun", "26-08-12 11:55", new Date("2026-08-12T11:55:00Z"), now)
+      buildImageStatusBar("sun", "26-08-12 11:55", new Date("2026-08-12T11:55:00Z"), now, true)
     );
     expect(root.querySelector(".status-bar span").textContent).toContain("SDO HMI Continuum");
   });
 
   it("includes the absolute date text and relative age in parentheses, verb 'captured' for earth", () => {
     const root = renderToDOM(
-      buildImageStatusBar("earth", "26-08-11 06:00", new Date("2026-08-11T06:00:00Z"), now)
+      buildImageStatusBar("earth", "26-08-11 06:00", new Date("2026-08-11T06:00:00Z"), now, true)
     );
     expect(root.querySelector(".status-bar span").textContent).toBe(
       "DSCOVR Earth · captured 26-08-11 06:00 (30h ago)"
@@ -120,10 +120,17 @@ describe("buildImageStatusBar", () => {
 
   it("uses verb 'captured' for sun too, now that its URL carries a real timestamp", () => {
     const root = renderToDOM(
-      buildImageStatusBar("sun", "26-08-12 11:55", new Date("2026-08-12T11:55:00Z"), now)
+      buildImageStatusBar("sun", "26-08-12 11:55", new Date("2026-08-12T11:55:00Z"), now, true)
     );
     expect(root.querySelector(".status-bar span").textContent).toBe(
       "SDO HMI Continuum · captured 26-08-12 11:55 (5m ago)"
     );
+  });
+
+  it("shows 'loading…' instead of the date until the image has actually loaded", () => {
+    const root = renderToDOM(
+      buildImageStatusBar("sun", "26-08-12 11:55", new Date("2026-08-12T11:55:00Z"), now, false)
+    );
+    expect(root.querySelector(".status-bar span").textContent).toBe("SDO HMI Continuum · loading…");
   });
 });

--- a/test/card/card-template.test.ts
+++ b/test/card/card-template.test.ts
@@ -118,12 +118,12 @@ describe("buildImageStatusBar", () => {
     );
   });
 
-  it("uses verb 'checked' for sun, since the fixed-URL image has no real capture timestamp", () => {
+  it("uses verb 'captured' for sun too, now that its URL carries a real timestamp", () => {
     const root = renderToDOM(
       buildImageStatusBar("sun", "26-08-12 11:55", new Date("2026-08-12T11:55:00Z"), now)
     );
     expect(root.querySelector(".status-bar span").textContent).toBe(
-      "SDO HMI Continuum · checked 26-08-12 11:55 (5m ago)"
+      "SDO HMI Continuum · captured 26-08-12 11:55 (5m ago)"
     );
   });
 });

--- a/test/card/card.test.ts
+++ b/test/card/card.test.ts
@@ -8,6 +8,15 @@ beforeAll(() => {
   }
 });
 
+// Any mounted card with gallery.mode != "none" now fetches in the background from
+// connectedCallback, even in describes that never stub fetch — leaving a real (unstubbed)
+// network result cached in image-sources.ts's module-level cache would leak into later
+// tests that expect a clean or failing cache. Clear it after every test, not just the
+// "gallery" describe's own cards.
+afterEach(() => {
+  clearImageCache();
+});
+
 describe("SolarViewCard", () => {
   it("should be a class", () => {
     expect(typeof SolarViewCard).toBe("function");
@@ -1234,7 +1243,6 @@ describe("SolarViewCard", () => {
     afterEach(() => {
       vi.unstubAllGlobals();
       vi.useRealTimers();
-      clearImageCache();
     });
 
     it("gallery button is hidden by default (no config)", () => {

--- a/test/card/card.test.ts
+++ b/test/card/card.test.ts
@@ -1291,6 +1291,30 @@ describe("SolarViewCard", () => {
       card.remove();
     });
 
+    it("a sun thumbnail load error retries the previous 15-min slot once, then drops the thumbnail", async () => {
+      const card = createAndMount();
+      await flush();
+      const sunImg = () => card.shadowRoot.querySelector('.gallery-thumb[data-source="sun"] img');
+      const firstSrc = sunImg().src;
+      const firstDate = card._galleryImages.sun.date;
+
+      sunImg().dispatchEvent(new Event("error"));
+      await flush();
+
+      // Retried once, on an earlier slot — thumbnail still shows something.
+      expect(sunImg().src).not.toBe(firstSrc);
+      expect(card._galleryImages.sun.date.getTime()).toBe(firstDate.getTime() - 15 * 60000);
+
+      // A second failure (the retried slot also 404s) drops the thumbnail.
+      sunImg().dispatchEvent(new Event("error"));
+      await flush();
+      expect(sunImg().getAttribute("src")).toBe("");
+      expect(
+        card.shadowRoot.querySelector('.gallery-thumb[data-source="sun"] .gallery-age')
+      ).toBeNull();
+      card.remove();
+    });
+
     it("fetches all thumbnails as soon as the card connects", async () => {
       const fetchMock = stubEarthFetch();
       const card = createAndMount();

--- a/test/card/card.test.ts
+++ b/test/card/card.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { SolarViewCard } from "../../src/card/card.js";
 import { clearImageCache, EPIC_BASE_URL } from "../../src/card/image-sources.js";
 
@@ -9,11 +9,16 @@ beforeAll(() => {
 });
 
 // Any mounted card with gallery.mode != "none" now fetches in the background from
-// connectedCallback, even in describes that never stub fetch — leaving a real (unstubbed)
-// network result cached in image-sources.ts's module-level cache would leak into later
-// tests that expect a clean or failing cache. Clear it after every test, not just the
-// "gallery" describe's own cards.
+// connectedCallback, even in describes that never stub fetch. Left unstubbed, that's a real
+// network call — works in CI (real internet) but not locally, and a slow one can resolve
+// after its own test ends and pollute image-sources.ts's module-level cache for a later
+// test. Default fetch to a safe rejection for every test; individual tests override it with
+// their own vi.stubGlobal("fetch", ...) when they want specific behavior.
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("fetch not stubbed for this test")));
+});
 afterEach(() => {
+  vi.unstubAllGlobals();
   clearImageCache();
 });
 

--- a/test/card/card.test.ts
+++ b/test/card/card.test.ts
@@ -56,6 +56,7 @@ describe("SolarViewCard", () => {
       refresh_mins: 1,
       zoom_animate: true,
       colors: {},
+      gallery: { mode: "both" },
     });
   });
 
@@ -173,7 +174,7 @@ describe("SolarViewCard", () => {
     });
 
     it("nav row buttons are in correct order", () => {
-      const card = createAndMount({ gallery: true });
+      const card = createAndMount({ gallery: { mode: "both" } });
       const buttons = card.shadowRoot.querySelectorAll(".nav button");
       const actions = Array.from(buttons).map((el) => el.dataset.action);
       expect(actions).toEqual([
@@ -193,7 +194,7 @@ describe("SolarViewCard", () => {
     });
 
     it("nav buttons are grouped in a .btn-group container", () => {
-      const card = createAndMount({ gallery: true });
+      const card = createAndMount({ gallery: { mode: "both" } });
       const btnGroups = card.shadowRoot.querySelectorAll(".btn-group");
       expect(btnGroups.length).toBe(3);
       // First group: nav buttons
@@ -1210,11 +1211,13 @@ describe("SolarViewCard", () => {
   describe("gallery", () => {
     const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
-    // gallery: true by default in this suite — its own on/off behavior is covered
-    // separately below, everything else here tests the gallery feature itself.
+    // gallery.mode: "both" by default in this suite — mode-specific behavior is covered
+    // separately below, everything else here tests the gallery feature itself. Any mode
+    // other than "none" auto-opens the strip on connect, so most tests here don't need to
+    // click the gallery button to open it — only to close/reopen it.
     function createAndMount(config) {
       const card = document.createElement("ha-planetary-solar-system-card-test");
-      card.setConfig({ gallery: true, ...config });
+      card.setConfig({ gallery: { mode: "both" }, ...config });
       document.body.appendChild(card);
       return card;
     }
@@ -1241,30 +1244,28 @@ describe("SolarViewCard", () => {
       card.remove();
     });
 
-    it("gallery button is hidden when gallery: false", () => {
+    it("gallery button is hidden when gallery.mode: none", () => {
       const card = document.createElement("ha-planetary-solar-system-card-test");
-      card.setConfig({ gallery: false });
+      card.setConfig({ gallery: { mode: "none" } });
       document.body.appendChild(card);
       expect(card.shadowRoot.querySelector('button[data-action="gallery"]')).toBeNull();
       card.remove();
     });
 
-    it("gallery button shows when gallery: true; strip closed by default", () => {
+    it("gallery button shows and strip is open by default when gallery.mode: both", () => {
       const card = createAndMount();
       expect(card.shadowRoot.querySelector('button[data-action="gallery"]')).toBeTruthy();
-      expect(card.shadowRoot.querySelector(".gallery")).toBeNull();
-      card.remove();
-    });
-
-    it("clicking the gallery button opens the strip with 2 thumbnails (EARTH, SUN)", async () => {
-      stubEarthFetch();
-      const card = createAndMount();
-      await flush();
-      clickButton(card, "gallery");
-      await flush();
       expect(
         card.shadowRoot.querySelector('button[data-action="gallery"]').classList.contains("active")
       ).toBe(true);
+      expect(card.shadowRoot.querySelector(".gallery")).toBeTruthy();
+      card.remove();
+    });
+
+    it("shows 2 thumbnails (EARTH, SUN) as soon as the card connects", async () => {
+      stubEarthFetch();
+      const card = createAndMount();
+      await flush();
       const thumbs = card.shadowRoot.querySelectorAll(".gallery-thumb");
       expect(thumbs.length).toBe(2);
       expect(Array.from(thumbs).map((t) => t.dataset.source)).toEqual(["earth", "sun"]);
@@ -1275,19 +1276,9 @@ describe("SolarViewCard", () => {
       card.remove();
     });
 
-    it("does not fetch any thumbnails until the gallery is opened", async () => {
+    it("fetches all thumbnails as soon as the card connects", async () => {
       const fetchMock = stubEarthFetch();
       const card = createAndMount();
-      await flush();
-      expect(fetchMock).not.toHaveBeenCalled();
-      card.remove();
-    });
-
-    it("fetches all thumbnails as soon as the gallery is opened", async () => {
-      const fetchMock = stubEarthFetch();
-      const card = createAndMount();
-      await flush();
-      clickButton(card, "gallery");
       await flush();
       expect(fetchMock).toHaveBeenCalled();
       const thumbs = card.shadowRoot.querySelectorAll(".gallery-thumb img");
@@ -1297,9 +1288,8 @@ describe("SolarViewCard", () => {
       card.remove();
     });
 
-    it("clicking the gallery button again closes the strip", async () => {
+    it("clicking the gallery button closes the strip; clicking again reopens it", async () => {
       const card = createAndMount();
-      clickButton(card, "gallery");
       await flush();
       expect(card.shadowRoot.querySelector(".gallery")).toBeTruthy();
       clickButton(card, "gallery");
@@ -1308,12 +1298,17 @@ describe("SolarViewCard", () => {
       expect(
         card.shadowRoot.querySelector('button[data-action="gallery"]').classList.contains("active")
       ).toBe(false);
+      clickButton(card, "gallery");
+      await flush();
+      expect(card.shadowRoot.querySelector(".gallery")).toBeTruthy();
+      expect(
+        card.shadowRoot.querySelector('button[data-action="gallery"]').classList.contains("active")
+      ).toBe(true);
       card.remove();
     });
 
     it("clicking a thumbnail shows the full image and hides the strip and solar view", async () => {
       const card = createAndMount();
-      clickButton(card, "gallery");
       await flush();
       card.shadowRoot.querySelector('.gallery-thumb[data-source="sun"]').click();
       await flush();
@@ -1330,7 +1325,6 @@ describe("SolarViewCard", () => {
 
     it("clicking the full image restores the solar view and the strip reappears", async () => {
       const card = createAndMount();
-      clickButton(card, "gallery");
       await flush();
       card.shadowRoot.querySelector('.gallery-thumb[data-source="sun"]').click();
       await flush();
@@ -1343,7 +1337,6 @@ describe("SolarViewCard", () => {
 
     it("clicking the gallery button while a full image is shown closes both", async () => {
       const card = createAndMount();
-      clickButton(card, "gallery");
       await flush();
       card.shadowRoot.querySelector('.gallery-thumb[data-source="sun"]').click();
       await flush();
@@ -1358,8 +1351,8 @@ describe("SolarViewCard", () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date("2026-08-12T12:00:00Z"));
       const card = createAndMount();
+      await vi.advanceTimersByTimeAsync(0);
 
-      clickButton(card, "gallery");
       const clickSun = () =>
         card.shadowRoot.querySelector('.gallery-thumb[data-source="sun"]').click();
 
@@ -1384,8 +1377,8 @@ describe("SolarViewCard", () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date("2026-08-12T12:00:00Z"));
       const card = createAndMount();
+      await vi.advanceTimersByTimeAsync(0);
 
-      clickButton(card, "gallery");
       const clickSun = () =>
         card.shadowRoot.querySelector('.gallery-thumb[data-source="sun"]').click();
 
@@ -1407,7 +1400,6 @@ describe("SolarViewCard", () => {
     it("auto-update ticks refresh the open full image every 15 minutes while it stays open", async () => {
       vi.useFakeTimers();
       const card = createAndMount({ refresh_mins: 16 });
-      clickButton(card, "gallery");
       await vi.advanceTimersByTimeAsync(0);
       card.shadowRoot.querySelector('.gallery-thumb[data-source="sun"]').click();
       await vi.advanceTimersByTimeAsync(0);
@@ -1426,7 +1418,6 @@ describe("SolarViewCard", () => {
       vi.useFakeTimers();
       const fetchMock = stubEarthFetch();
       const card = createAndMount({ refresh_mins: 16 });
-      clickButton(card, "gallery");
       await vi.advanceTimersByTimeAsync(0);
       card.shadowRoot.querySelector('.gallery-thumb[data-source="earth"]').click();
       await vi.advanceTimersByTimeAsync(0);
@@ -1442,7 +1433,6 @@ describe("SolarViewCard", () => {
     it("does not refresh the open full image before the 15-minute TTL elapses", async () => {
       vi.useFakeTimers();
       const card = createAndMount({ refresh_mins: 10 });
-      clickButton(card, "gallery");
       await vi.advanceTimersByTimeAsync(0);
       card.shadowRoot.querySelector('.gallery-thumb[data-source="sun"]').click();
       await vi.advanceTimersByTimeAsync(0);
@@ -1459,7 +1449,6 @@ describe("SolarViewCard", () => {
     it("clicking the earth thumbnail fetches the latest EPIC image and shows it", async () => {
       stubEarthFetch();
       const card = createAndMount();
-      clickButton(card, "gallery");
       await flush();
       card.shadowRoot.querySelector('.gallery-thumb[data-source="earth"]').click();
       await flush();
@@ -1475,7 +1464,6 @@ describe("SolarViewCard", () => {
     it("falls back to the solar view with a visible error when the earth image fetch fails", async () => {
       vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
       const card = createAndMount();
-      clickButton(card, "gallery");
       await flush();
       card.shadowRoot.querySelector('.gallery-thumb[data-source="earth"]').click();
       await flush();
@@ -1492,7 +1480,6 @@ describe("SolarViewCard", () => {
       vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
       const card = createAndMount();
       card.hass = { config: { latitude: 41.8781, longitude: -87.6298 } };
-      clickButton(card, "gallery");
       await flush();
       card.shadowRoot.querySelector('.gallery-thumb[data-source="earth"]').click();
       await flush();
@@ -1509,7 +1496,6 @@ describe("SolarViewCard", () => {
         vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve([]) })
       );
       const card = createAndMount();
-      clickButton(card, "gallery");
       await flush();
       card.shadowRoot.querySelector('.gallery-thumb[data-source="earth"]').click();
       await flush();
@@ -1529,7 +1515,6 @@ describe("SolarViewCard", () => {
       // advanced 61x over — many overlapping fetch/render cycles under fake timers
       // leave dangling promises that can resolve after the test tears down.
       const card = createAndMount({ refresh_mins: 61 });
-      clickButton(card, "gallery");
       await vi.advanceTimersByTimeAsync(0);
       const callsAfterOpen = fetchMock.mock.calls.length;
 
@@ -1540,10 +1525,13 @@ describe("SolarViewCard", () => {
       vi.useRealTimers();
     });
 
-    it("auto-update ticks do not fetch gallery thumbnails while the gallery is closed", async () => {
+    it("auto-update ticks do not fetch gallery thumbnails once the gallery is manually closed", async () => {
       vi.useFakeTimers();
       const fetchMock = stubEarthFetch();
       const card = createAndMount({ refresh_mins: 1 });
+      await vi.advanceTimersByTimeAsync(0);
+      fetchMock.mockClear();
+      clickButton(card, "gallery"); // close
       await vi.advanceTimersByTimeAsync(6 * 60000);
       expect(fetchMock).not.toHaveBeenCalled();
 
@@ -1554,13 +1542,98 @@ describe("SolarViewCard", () => {
     it("skips a failed source's thumbnail but still populates the others", async () => {
       vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
       const card = createAndMount();
-      clickButton(card, "gallery");
       await flush();
       const sunThumb = card.shadowRoot.querySelector('.gallery-thumb[data-source="sun"] img');
       const earthThumb = card.shadowRoot.querySelector('.gallery-thumb[data-source="earth"] img');
       expect(sunThumb.getAttribute("src")).not.toBe("");
       expect(earthThumb.getAttribute("src")).toBe(""); // earth fetch failed, thumbnail stays empty
       card.remove();
+    });
+
+    it("gallery.mode: earth shows only the earth thumbnail and fetches only earth", async () => {
+      const fetchMock = stubEarthFetch();
+      const card = createAndMount({ gallery: { mode: "earth" } });
+      await flush();
+      const thumbs = card.shadowRoot.querySelectorAll(".gallery-thumb");
+      expect(Array.from(thumbs).map((t) => t.dataset.source)).toEqual(["earth"]);
+      expect(fetchMock).toHaveBeenCalled();
+      card.remove();
+    });
+
+    it("gallery.mode: sun shows only the sun thumbnail and never calls fetch", async () => {
+      const fetchMock = stubEarthFetch();
+      const card = createAndMount({ gallery: { mode: "sun" } });
+      await flush();
+      const thumbs = card.shadowRoot.querySelectorAll(".gallery-thumb");
+      expect(Array.from(thumbs).map((t) => t.dataset.source)).toEqual(["sun"]);
+      expect(fetchMock).not.toHaveBeenCalled();
+      card.remove();
+    });
+
+    it("gallery strip refreshes the sun thumbnail every 15 minutes, not 1 hour", async () => {
+      vi.useFakeTimers();
+      const card = createAndMount({ gallery: { mode: "sun" }, refresh_mins: 16 });
+      await vi.advanceTimersByTimeAsync(0);
+      const firstSrc = card.shadowRoot.querySelector('.gallery-thumb[data-source="sun"] img').src;
+
+      await vi.advanceTimersByTimeAsync(16 * 60000);
+      const secondSrc = card.shadowRoot.querySelector('.gallery-thumb[data-source="sun"] img').src;
+
+      expect(secondSrc).not.toBe(firstSrc);
+      card.remove();
+      vi.useRealTimers();
+    });
+
+    it("gallery.mode: slide shows one thumbnail, fetches both sources, and flips on its own interval", async () => {
+      vi.useFakeTimers();
+      const fetchMock = stubEarthFetch();
+      const card = createAndMount({ gallery: { mode: "slide", slide_interval_secs: 120 } });
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(fetchMock).toHaveBeenCalled(); // both sources fetched in the background
+      let thumbs = card.shadowRoot.querySelectorAll(".gallery-thumb");
+      expect(thumbs.length).toBe(1);
+      expect(thumbs[0].dataset.source).toBe("earth");
+
+      await vi.advanceTimersByTimeAsync(120 * 1000);
+      thumbs = card.shadowRoot.querySelectorAll(".gallery-thumb");
+      expect(thumbs.length).toBe(1);
+      expect(thumbs[0].dataset.source).toBe("sun");
+
+      card.remove();
+      vi.useRealTimers();
+    });
+
+    it("reconfiguring the slide interval while slide mode stays active restarts the timer", async () => {
+      vi.useFakeTimers();
+      const card = createAndMount({ gallery: { mode: "slide", slide_interval_secs: 120 } });
+      await vi.advanceTimersByTimeAsync(0);
+
+      card.setConfig({ gallery: { mode: "slide", slide_interval_secs: 180 } });
+      await vi.advanceTimersByTimeAsync(120 * 1000); // past the old interval, before the new one
+      expect(card.shadowRoot.querySelector(".gallery-thumb").dataset.source).toBe("earth");
+
+      await vi.advanceTimersByTimeAsync(60000); // now past the new 3-min interval
+      expect(card.shadowRoot.querySelector(".gallery-thumb").dataset.source).toBe("sun");
+
+      await vi.advanceTimersByTimeAsync(180 * 1000); // flips back
+      expect(card.shadowRoot.querySelector(".gallery-thumb").dataset.source).toBe("earth");
+
+      card.remove();
+      vi.useRealTimers();
+    });
+
+    it("gallery.mode: none never shows the gallery button and never fetches", async () => {
+      vi.useFakeTimers();
+      const fetchMock = stubEarthFetch();
+      const card = document.createElement("ha-planetary-solar-system-card-test");
+      card.setConfig({ gallery: { mode: "none" }, refresh_mins: 1 });
+      document.body.appendChild(card);
+      await vi.advanceTimersByTimeAsync(6 * 60000);
+      expect(card.shadowRoot.querySelector('button[data-action="gallery"]')).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+      card.remove();
+      vi.useRealTimers();
     });
   });
 });

--- a/test/card/card.test.ts
+++ b/test/card/card.test.ts
@@ -1277,13 +1277,9 @@ describe("SolarViewCard", () => {
       const thumbs = card.shadowRoot.querySelectorAll(".gallery-thumb");
       expect(thumbs.length).toBe(2);
       expect(Array.from(thumbs).map((t) => t.dataset.source)).toEqual(["earth", "sun"]);
-      expect(Array.from(thumbs).map((t) => t.querySelector(".gallery-label").textContent)).toEqual([
-        "L1→EARTH",
-        "L1→SUN",
-      ]);
-      for (const thumb of thumbs) {
-        expect(thumb.querySelector(".gallery-age").textContent).toMatch(/ago|just now/);
-      }
+      const labels = Array.from(thumbs).map((t) => t.querySelector(".gallery-label").textContent);
+      expect(labels[0]).toMatch(/^L1→EARTH · (\d+[mh] ago|just now)$/);
+      expect(labels[1]).toMatch(/^L1→SUN · (\d+[mh] ago|just now)$/);
       card.remove();
     });
 

--- a/test/card/card.test.ts
+++ b/test/card/card.test.ts
@@ -1283,8 +1283,11 @@ describe("SolarViewCard", () => {
       expect(thumbs.length).toBe(2);
       expect(Array.from(thumbs).map((t) => t.dataset.source)).toEqual(["earth", "sun"]);
       const labels = Array.from(thumbs).map((t) => t.querySelector(".gallery-label").textContent);
-      expect(labels[0]).toMatch(/^L1→EARTH · (\d+[mh] ago|just now)$/);
-      expect(labels[1]).toMatch(/^L1→SUN · (\d+[mh] ago|just now)$/);
+      expect(labels).toEqual(["L1→EARTH", "GEO→SUN"]);
+      const ages = Array.from(thumbs).map((t) => t.querySelector(".gallery-age").textContent);
+      for (const age of ages) {
+        expect(age).toMatch(/^(\d+[mh] ago|just now)$/);
+      }
       card.remove();
     });
 
@@ -1335,16 +1338,27 @@ describe("SolarViewCard", () => {
       card.remove();
     });
 
-    it("a full-screen image load error falls back to the unavailable banner and closes the panel", async () => {
+    it("a sun image load error retries the previous 15-min slot once before giving up", async () => {
       const card = createAndMount();
       await flush();
       card.shadowRoot.querySelector('.gallery-thumb[data-source="sun"]').click();
       await flush();
       expect(card._imagePanelMode).toBe("sun");
+      const firstSrc = card.shadowRoot.querySelector("#image-view").src;
+      const firstDate = card._imageDate;
 
       card.shadowRoot.querySelector("#image-view").dispatchEvent(new Event("error"));
       await flush();
 
+      // Still open, on a different (earlier) slot — not yet the unavailable banner.
+      expect(card._imagePanelMode).toBe("sun");
+      const secondSrc = card.shadowRoot.querySelector("#image-view").src;
+      expect(secondSrc).not.toBe(firstSrc);
+      expect(card._imageDate.getTime()).toBe(firstDate.getTime() - 15 * 60000);
+
+      // A second failure (the retried slot also 404s) falls back to the banner.
+      card.shadowRoot.querySelector("#image-view").dispatchEvent(new Event("error"));
+      await flush();
       expect(card._imagePanelMode).toBe("none");
       expect(card.shadowRoot.querySelector(".status-bar").textContent).toContain(
         "SDO HMI Continuum image unavailable"
@@ -1428,7 +1442,7 @@ describe("SolarViewCard", () => {
       card.shadowRoot.querySelector("#image-view").click(); // back to gallery
       await vi.advanceTimersByTimeAsync(0);
       // Past both the 2-min click cache and into the next published 15-min slot.
-      vi.setSystemTime(new Date("2026-08-12T12:05:01Z"));
+      vi.setSystemTime(new Date("2026-08-12T12:15:01Z"));
       clickSun();
       await vi.advanceTimersByTimeAsync(0);
       const secondSrc = card.shadowRoot.querySelector("#image-view").src;
@@ -1445,7 +1459,7 @@ describe("SolarViewCard", () => {
       await vi.advanceTimersByTimeAsync(0);
       const firstSrc = card.shadowRoot.querySelector("#image-view").src;
 
-      // A single tick timed just past the 15-min full-panel TTL.
+      // A single tick timed just past the 15-min TTL.
       await vi.advanceTimersByTimeAsync(16 * 60000);
       const secondSrc = card.shadowRoot.querySelector("#image-view").src;
 
@@ -1454,16 +1468,16 @@ describe("SolarViewCard", () => {
       vi.useRealTimers();
     });
 
-    it("auto-update ticks also refresh the open earth full image every 15 minutes", async () => {
+    it("auto-update ticks also refresh the open earth full image hourly", async () => {
       vi.useFakeTimers();
       const fetchMock = stubEarthFetch();
-      const card = createAndMount({ refresh_mins: 16 });
+      const card = createAndMount({ refresh_mins: 61 });
       await vi.advanceTimersByTimeAsync(0);
       card.shadowRoot.querySelector('.gallery-thumb[data-source="earth"]').click();
       await vi.advanceTimersByTimeAsync(0);
       const callsAfterOpen = fetchMock.mock.calls.length;
 
-      await vi.advanceTimersByTimeAsync(16 * 60000);
+      await vi.advanceTimersByTimeAsync(61 * 60000);
       expect(fetchMock.mock.calls.length).toBeGreaterThan(callsAfterOpen);
 
       card.remove();

--- a/test/card/card.test.ts
+++ b/test/card/card.test.ts
@@ -1273,6 +1273,9 @@ describe("SolarViewCard", () => {
         "L1→EARTH",
         "L1→SUN",
       ]);
+      for (const thumb of thumbs) {
+        expect(thumb.querySelector(".gallery-age").textContent).toMatch(/ago|just now/);
+      }
       card.remove();
     });
 
@@ -1323,6 +1326,33 @@ describe("SolarViewCard", () => {
       card.remove();
     });
 
+    it("a full-screen image load error falls back to the unavailable banner and closes the panel", async () => {
+      const card = createAndMount();
+      await flush();
+      card.shadowRoot.querySelector('.gallery-thumb[data-source="sun"]').click();
+      await flush();
+      expect(card._imagePanelMode).toBe("sun");
+
+      card.shadowRoot.querySelector("#image-view").dispatchEvent(new Event("error"));
+      await flush();
+
+      expect(card._imagePanelMode).toBe("none");
+      expect(card.shadowRoot.querySelector(".status-bar").textContent).toContain(
+        "SDO HMI Continuum image unavailable"
+      );
+      card.remove();
+    });
+
+    it("an image load error while no panel is open is a no-op", async () => {
+      const card = createAndMount();
+      await flush();
+      card.shadowRoot.querySelector("#image-view").dispatchEvent(new Event("error"));
+      await flush();
+      expect(card._imagePanelMode).toBe("none");
+      expect(card._imageError).toBeNull();
+      card.remove();
+    });
+
     it("clicking the full image restores the solar view and the strip reappears", async () => {
       const card = createAndMount();
       await flush();
@@ -1347,7 +1377,7 @@ describe("SolarViewCard", () => {
       card.remove();
     });
 
-    it("clicking a sun thumbnail again within the short click cache reuses the same checked timestamp", async () => {
+    it("clicking a sun thumbnail again within the short click cache reuses the same slot timestamp", async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date("2026-08-12T12:00:00Z"));
       const card = createAndMount();
@@ -1373,7 +1403,7 @@ describe("SolarViewCard", () => {
       card.remove();
     });
 
-    it("clicking a sun thumbnail again once the click cache expires fetches a fresh checked timestamp", async () => {
+    it("clicking a sun thumbnail again once the click cache expires fetches a fresh slot timestamp", async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date("2026-08-12T12:00:00Z"));
       const card = createAndMount();
@@ -1388,7 +1418,8 @@ describe("SolarViewCard", () => {
 
       card.shadowRoot.querySelector("#image-view").click(); // back to gallery
       await vi.advanceTimersByTimeAsync(0);
-      vi.setSystemTime(new Date("2026-08-12T12:02:01Z")); // past the 2-min click cache
+      // Past both the 2-min click cache and into the next published 15-min slot.
+      vi.setSystemTime(new Date("2026-08-12T12:05:01Z"));
       clickSun();
       await vi.advanceTimersByTimeAsync(0);
       const secondSrc = card.shadowRoot.querySelector("#image-view").src;

--- a/test/card/card.test.ts
+++ b/test/card/card.test.ts
@@ -1284,7 +1284,18 @@ describe("SolarViewCard", () => {
       expect(Array.from(thumbs).map((t) => t.dataset.source)).toEqual(["earth", "sun"]);
       const labels = Array.from(thumbs).map((t) => t.querySelector(".gallery-label").textContent);
       expect(labels).toEqual(["L1→EARTH", "GEO→SUN"]);
-      const ages = Array.from(thumbs).map((t) => t.querySelector(".gallery-age").textContent);
+
+      // Age shows "loading…" until each thumbnail's image actually loads.
+      let ages = Array.from(thumbs).map((t) => t.querySelector(".gallery-age").textContent);
+      expect(ages).toEqual(["loading…", "loading…"]);
+
+      for (const thumb of thumbs) {
+        thumb.querySelector("img").dispatchEvent(new Event("load"));
+      }
+      await flush();
+      ages = Array.from(card.shadowRoot.querySelectorAll(".gallery-thumb")).map(
+        (t) => t.querySelector(".gallery-age").textContent
+      );
       for (const age of ages) {
         expect(age).toMatch(/^(\d+[mh] ago|just now)$/);
       }
@@ -1362,6 +1373,20 @@ describe("SolarViewCard", () => {
       card.remove();
     });
 
+    it("full-screen status bar shows 'loading…' until the image actually loads", async () => {
+      const card = createAndMount();
+      await flush();
+      card.shadowRoot.querySelector('.gallery-thumb[data-source="sun"]').click();
+      await flush();
+      expect(card.shadowRoot.querySelector(".status-bar").textContent).toContain("loading…");
+
+      card.shadowRoot.querySelector("#image-view").dispatchEvent(new Event("load"));
+      await flush();
+      expect(card.shadowRoot.querySelector(".status-bar").textContent).toContain("captured");
+      expect(card.shadowRoot.querySelector(".status-bar").textContent).not.toContain("loading…");
+      card.remove();
+    });
+
     it("a sun image load error retries the previous 15-min slot once before giving up", async () => {
       const card = createAndMount();
       await flush();
@@ -1424,7 +1449,7 @@ describe("SolarViewCard", () => {
       card.remove();
     });
 
-    it("clicking a sun thumbnail again within the short click cache reuses the same slot timestamp", async () => {
+    it("clicking a sun thumbnail again reuses the already-loaded image within the 15-min cache", async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date("2026-08-12T12:00:00Z"));
       const card = createAndMount();
@@ -1439,18 +1464,18 @@ describe("SolarViewCard", () => {
 
       card.shadowRoot.querySelector("#image-view").click(); // back to gallery
       await vi.advanceTimersByTimeAsync(0);
-      vi.setSystemTime(new Date("2026-08-12T12:00:30Z")); // 30s later, within the 2-min click cache
+      vi.setSystemTime(new Date("2026-08-12T12:00:30Z")); // 30s later, well within the 15-min cache
       clickSun();
       await vi.advanceTimersByTimeAsync(0);
       const secondSrc = card.shadowRoot.querySelector("#image-view").src;
 
-      // A short click-side cache avoids re-downloading from NASA's slow SDO server on a
-      // rapid re-click when the source hasn't posted a new frame since the last one.
+      // Same cache the thumbnail's own background fetch uses, so a click reuses the exact
+      // image already loaded instead of forcing a new network fetch on open.
       expect(secondSrc).toBe(firstSrc);
       card.remove();
     });
 
-    it("clicking a sun thumbnail again once the click cache expires fetches a fresh slot timestamp", async () => {
+    it("clicking a sun thumbnail again once the 15-min cache expires fetches a fresh slot", async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date("2026-08-12T12:00:00Z"));
       const card = createAndMount();
@@ -1465,7 +1490,7 @@ describe("SolarViewCard", () => {
 
       card.shadowRoot.querySelector("#image-view").click(); // back to gallery
       await vi.advanceTimersByTimeAsync(0);
-      // Past both the 2-min click cache and into the next published 15-min slot.
+      // Past the 15-min cache and into the next published slot.
       vi.setSystemTime(new Date("2026-08-12T12:15:01Z"));
       clickSun();
       await vi.advanceTimersByTimeAsync(0);

--- a/test/card/card.test.ts
+++ b/test/card/card.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { SolarViewCard } from "../../src/card/card.js";
+import { clearImageCache, EPIC_BASE_URL } from "../../src/card/image-sources.js";
 
 beforeAll(() => {
   if (!customElements.get("ha-planetary-solar-system-card-test")) {
@@ -172,7 +173,7 @@ describe("SolarViewCard", () => {
     });
 
     it("nav row buttons are in correct order", () => {
-      const card = createAndMount({ debug: true });
+      const card = createAndMount({ gallery: true });
       const buttons = card.shadowRoot.querySelectorAll(".nav button");
       const actions = Array.from(buttons).map((el) => el.dataset.action);
       expect(actions).toEqual([
@@ -186,14 +187,15 @@ describe("SolarViewCard", () => {
         "replay",
         "zoom-out",
         "zoom-in",
+        "gallery",
       ]);
       card.remove();
     });
 
     it("nav buttons are grouped in a .btn-group container", () => {
-      const card = createAndMount({ debug: true });
+      const card = createAndMount({ gallery: true });
       const btnGroups = card.shadowRoot.querySelectorAll(".btn-group");
-      expect(btnGroups.length).toBe(2);
+      expect(btnGroups.length).toBe(3);
       // First group: nav buttons
       const navGroup = btnGroups[0];
       const navButtons = navGroup.querySelectorAll("button");
@@ -208,12 +210,17 @@ describe("SolarViewCard", () => {
       expect(zoomButtons[1].dataset.action).toBe("zoom-in");
       const levelSpan = zoomGroup.querySelector(".zoom-level");
       expect(levelSpan).toBeTruthy();
+      // Third group: gallery button
+      const imageGroup = btnGroups[2];
+      const imageButtons = imageGroup.querySelectorAll("button");
+      expect(imageButtons.length).toBe(1);
+      expect(imageButtons[0].dataset.action).toBe("gallery");
       card.remove();
     });
 
-    it("replay button is hidden unless debug is enabled", () => {
+    it("replay button is visible by default", () => {
       const card = createAndMount();
-      expect(card.shadowRoot.querySelector('button[data-action="replay"]')).toBeNull();
+      expect(card.shadowRoot.querySelector('button[data-action="replay"]')).not.toBeNull();
       card.remove();
     });
 
@@ -431,7 +438,7 @@ describe("SolarViewCard", () => {
     ];
 
     it("replay button uses a circular arrow glyph", () => {
-      const card = createAndMount({ debug: true });
+      const card = createAndMount();
       const btn = card.shadowRoot.querySelector('button[data-action="replay"]');
       expect(btn.textContent).toBe("↺");
       card.remove();
@@ -439,7 +446,7 @@ describe("SolarViewCard", () => {
 
     it("clicking replay jumps to 6h before now and exits live mode", () => {
       vi.useFakeTimers({ now: new Date("2026-02-15T12:00:00Z") });
-      const card = createAndMount({ debug: true });
+      const card = createAndMount();
       clickButton(card, "replay");
       expect(card._currentDate.toISOString()).toBe(new Date("2026-02-15T06:00:00Z").toISOString());
       expect(card._isLiveMode).toBe(false);
@@ -448,7 +455,7 @@ describe("SolarViewCard", () => {
 
     it("steps forward in 10-minute increments", () => {
       vi.useFakeTimers({ now: new Date("2026-02-15T12:00:00Z") });
-      const card = createAndMount({ debug: true });
+      const card = createAndMount();
       clickButton(card, "replay");
       vi.advanceTimersByTime(138); // one interval tick
       expect(card._currentDate.toISOString()).toBe(new Date("2026-02-15T06:10:00Z").toISOString());
@@ -457,7 +464,7 @@ describe("SolarViewCard", () => {
 
     it("disables time-navigation buttons while replaying, re-enables when done", () => {
       vi.useFakeTimers({ now: new Date("2026-02-15T12:00:00Z") });
-      const card = createAndMount({ debug: true });
+      const card = createAndMount();
       clickButton(card, "replay");
       for (const action of timeNavActions) {
         const btn = card.shadowRoot.querySelector(`button[data-action="${action}"]`);
@@ -477,7 +484,7 @@ describe("SolarViewCard", () => {
     it("completes within 15 seconds of wall-clock time and lands on now with live mode resumed", () => {
       const now = new Date("2026-02-15T12:00:00Z");
       vi.useFakeTimers({ now });
-      const card = createAndMount({ debug: true });
+      const card = createAndMount();
       clickButton(card, "replay");
       vi.advanceTimersByTime(15000); // upper bound on real time this may take
       expect(card._isReplaying).toBe(false);
@@ -492,7 +499,7 @@ describe("SolarViewCard", () => {
     it("replays the 6h ending at the currently displayed date, not real now", () => {
       // Real "now" is Feb 15, but the user has navigated to a past date and paused there.
       vi.useFakeTimers({ now: new Date("2026-02-15T12:00:00Z") });
-      const card = createAndMount({ debug: true });
+      const card = createAndMount();
       card._currentDate = new Date("2026-01-01T06:00:00Z");
       card._isLiveMode = false;
       card._render();
@@ -509,7 +516,7 @@ describe("SolarViewCard", () => {
 
     it("clicking replay again cancels it mid-flight", () => {
       vi.useFakeTimers({ now: new Date("2026-02-15T12:00:00Z") });
-      const card = createAndMount({ debug: true });
+      const card = createAndMount();
       clickButton(card, "replay");
       vi.advanceTimersByTime(138 * 10);
       const midDate = card._currentDate.toISOString();
@@ -522,7 +529,7 @@ describe("SolarViewCard", () => {
 
     it("cleans up the replay timer on disconnect", () => {
       vi.useFakeTimers({ now: new Date("2026-02-15T12:00:00Z") });
-      const card = createAndMount({ debug: true });
+      const card = createAndMount();
       clickButton(card, "replay");
       expect(card._replayTimer).not.toBeNull();
       card.remove();
@@ -1196,6 +1203,363 @@ describe("SolarViewCard", () => {
       vi.advanceTimersByTime(60000);
       // Zoom level display should update immediately to target
       expect(card.shadowRoot.querySelector(".zoom-level").textContent).toBe("2");
+      card.remove();
+    });
+  });
+
+  describe("gallery", () => {
+    const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+    // gallery: true by default in this suite — its own on/off behavior is covered
+    // separately below, everything else here tests the gallery feature itself.
+    function createAndMount(config) {
+      const card = document.createElement("ha-planetary-solar-system-card-test");
+      card.setConfig({ gallery: true, ...config });
+      document.body.appendChild(card);
+      return card;
+    }
+
+    function stubEarthFetch(identifier = "20260810234950") {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([{ identifier }]),
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      return fetchMock;
+    }
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      vi.useRealTimers();
+      clearImageCache();
+    });
+
+    it("gallery button is hidden by default (no config)", () => {
+      const card = document.createElement("ha-planetary-solar-system-card-test");
+      document.body.appendChild(card);
+      expect(card.shadowRoot.querySelector('button[data-action="gallery"]')).toBeNull();
+      card.remove();
+    });
+
+    it("gallery button is hidden when gallery: false", () => {
+      const card = document.createElement("ha-planetary-solar-system-card-test");
+      card.setConfig({ gallery: false });
+      document.body.appendChild(card);
+      expect(card.shadowRoot.querySelector('button[data-action="gallery"]')).toBeNull();
+      card.remove();
+    });
+
+    it("gallery button shows when gallery: true; strip closed by default", () => {
+      const card = createAndMount();
+      expect(card.shadowRoot.querySelector('button[data-action="gallery"]')).toBeTruthy();
+      expect(card.shadowRoot.querySelector(".gallery")).toBeNull();
+      card.remove();
+    });
+
+    it("clicking the gallery button opens the strip with 2 thumbnails (EARTH, SUN)", async () => {
+      stubEarthFetch();
+      const card = createAndMount();
+      await flush();
+      clickButton(card, "gallery");
+      await flush();
+      expect(
+        card.shadowRoot.querySelector('button[data-action="gallery"]').classList.contains("active")
+      ).toBe(true);
+      const thumbs = card.shadowRoot.querySelectorAll(".gallery-thumb");
+      expect(thumbs.length).toBe(2);
+      expect(Array.from(thumbs).map((t) => t.dataset.source)).toEqual(["earth", "sun"]);
+      expect(Array.from(thumbs).map((t) => t.querySelector(".gallery-label").textContent)).toEqual([
+        "L1→EARTH",
+        "L1→SUN",
+      ]);
+      card.remove();
+    });
+
+    it("does not fetch any thumbnails until the gallery is opened", async () => {
+      const fetchMock = stubEarthFetch();
+      const card = createAndMount();
+      await flush();
+      expect(fetchMock).not.toHaveBeenCalled();
+      card.remove();
+    });
+
+    it("fetches all thumbnails as soon as the gallery is opened", async () => {
+      const fetchMock = stubEarthFetch();
+      const card = createAndMount();
+      await flush();
+      clickButton(card, "gallery");
+      await flush();
+      expect(fetchMock).toHaveBeenCalled();
+      const thumbs = card.shadowRoot.querySelectorAll(".gallery-thumb img");
+      for (const img of thumbs) {
+        expect(img.src).not.toBe("");
+      }
+      card.remove();
+    });
+
+    it("clicking the gallery button again closes the strip", async () => {
+      const card = createAndMount();
+      clickButton(card, "gallery");
+      await flush();
+      expect(card.shadowRoot.querySelector(".gallery")).toBeTruthy();
+      clickButton(card, "gallery");
+      await flush();
+      expect(card.shadowRoot.querySelector(".gallery")).toBeNull();
+      expect(
+        card.shadowRoot.querySelector('button[data-action="gallery"]').classList.contains("active")
+      ).toBe(false);
+      card.remove();
+    });
+
+    it("clicking a thumbnail shows the full image and hides the strip and solar view", async () => {
+      const card = createAndMount();
+      clickButton(card, "gallery");
+      await flush();
+      card.shadowRoot.querySelector('.gallery-thumb[data-source="sun"]').click();
+      await flush();
+      expect(card._imagePanelMode).toBe("sun");
+      expect(card.shadowRoot.querySelector(".status-bar").textContent).toContain(
+        "SDO HMI Continuum"
+      );
+      const img = card.shadowRoot.querySelector("#image-view");
+      expect(img.classList.contains("visible")).toBe(true);
+      expect(card.shadowRoot.querySelector(".gallery")).toBeNull();
+      expect(card.shadowRoot.querySelector("#solar-view").classList.contains("hidden")).toBe(true);
+      card.remove();
+    });
+
+    it("clicking the full image restores the solar view and the strip reappears", async () => {
+      const card = createAndMount();
+      clickButton(card, "gallery");
+      await flush();
+      card.shadowRoot.querySelector('.gallery-thumb[data-source="sun"]').click();
+      await flush();
+      card.shadowRoot.querySelector("#image-view").click();
+      await flush();
+      expect(card._imagePanelMode).toBe("none");
+      expect(card.shadowRoot.querySelector(".gallery")).toBeTruthy();
+      card.remove();
+    });
+
+    it("clicking the gallery button while a full image is shown closes both", async () => {
+      const card = createAndMount();
+      clickButton(card, "gallery");
+      await flush();
+      card.shadowRoot.querySelector('.gallery-thumb[data-source="sun"]').click();
+      await flush();
+      clickButton(card, "gallery");
+      await flush();
+      expect(card._imagePanelMode).toBe("none");
+      expect(card.shadowRoot.querySelector(".gallery")).toBeNull();
+      card.remove();
+    });
+
+    it("clicking a sun thumbnail again within the short click cache reuses the same checked timestamp", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-08-12T12:00:00Z"));
+      const card = createAndMount();
+
+      clickButton(card, "gallery");
+      const clickSun = () =>
+        card.shadowRoot.querySelector('.gallery-thumb[data-source="sun"]').click();
+
+      clickSun();
+      await vi.advanceTimersByTimeAsync(0);
+      const firstSrc = card.shadowRoot.querySelector("#image-view").src;
+
+      card.shadowRoot.querySelector("#image-view").click(); // back to gallery
+      await vi.advanceTimersByTimeAsync(0);
+      vi.setSystemTime(new Date("2026-08-12T12:00:30Z")); // 30s later, within the 2-min click cache
+      clickSun();
+      await vi.advanceTimersByTimeAsync(0);
+      const secondSrc = card.shadowRoot.querySelector("#image-view").src;
+
+      // A short click-side cache avoids re-downloading from NASA's slow SDO server on a
+      // rapid re-click when the source hasn't posted a new frame since the last one.
+      expect(secondSrc).toBe(firstSrc);
+      card.remove();
+    });
+
+    it("clicking a sun thumbnail again once the click cache expires fetches a fresh checked timestamp", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-08-12T12:00:00Z"));
+      const card = createAndMount();
+
+      clickButton(card, "gallery");
+      const clickSun = () =>
+        card.shadowRoot.querySelector('.gallery-thumb[data-source="sun"]').click();
+
+      clickSun();
+      await vi.advanceTimersByTimeAsync(0);
+      const firstSrc = card.shadowRoot.querySelector("#image-view").src;
+
+      card.shadowRoot.querySelector("#image-view").click(); // back to gallery
+      await vi.advanceTimersByTimeAsync(0);
+      vi.setSystemTime(new Date("2026-08-12T12:02:01Z")); // past the 2-min click cache
+      clickSun();
+      await vi.advanceTimersByTimeAsync(0);
+      const secondSrc = card.shadowRoot.querySelector("#image-view").src;
+
+      expect(secondSrc).not.toBe(firstSrc);
+      card.remove();
+    });
+
+    it("auto-update ticks refresh the open full image every 15 minutes while it stays open", async () => {
+      vi.useFakeTimers();
+      const card = createAndMount({ refresh_mins: 16 });
+      clickButton(card, "gallery");
+      await vi.advanceTimersByTimeAsync(0);
+      card.shadowRoot.querySelector('.gallery-thumb[data-source="sun"]').click();
+      await vi.advanceTimersByTimeAsync(0);
+      const firstSrc = card.shadowRoot.querySelector("#image-view").src;
+
+      // A single tick timed just past the 15-min full-panel TTL.
+      await vi.advanceTimersByTimeAsync(16 * 60000);
+      const secondSrc = card.shadowRoot.querySelector("#image-view").src;
+
+      expect(secondSrc).not.toBe(firstSrc);
+      card.remove();
+      vi.useRealTimers();
+    });
+
+    it("auto-update ticks also refresh the open earth full image every 15 minutes", async () => {
+      vi.useFakeTimers();
+      const fetchMock = stubEarthFetch();
+      const card = createAndMount({ refresh_mins: 16 });
+      clickButton(card, "gallery");
+      await vi.advanceTimersByTimeAsync(0);
+      card.shadowRoot.querySelector('.gallery-thumb[data-source="earth"]').click();
+      await vi.advanceTimersByTimeAsync(0);
+      const callsAfterOpen = fetchMock.mock.calls.length;
+
+      await vi.advanceTimersByTimeAsync(16 * 60000);
+      expect(fetchMock.mock.calls.length).toBeGreaterThan(callsAfterOpen);
+
+      card.remove();
+      vi.useRealTimers();
+    });
+
+    it("does not refresh the open full image before the 15-minute TTL elapses", async () => {
+      vi.useFakeTimers();
+      const card = createAndMount({ refresh_mins: 10 });
+      clickButton(card, "gallery");
+      await vi.advanceTimersByTimeAsync(0);
+      card.shadowRoot.querySelector('.gallery-thumb[data-source="sun"]').click();
+      await vi.advanceTimersByTimeAsync(0);
+      const firstSrc = card.shadowRoot.querySelector("#image-view").src;
+
+      await vi.advanceTimersByTimeAsync(10 * 60000); // one tick, still within the 15-min TTL
+      const secondSrc = card.shadowRoot.querySelector("#image-view").src;
+
+      expect(secondSrc).toBe(firstSrc);
+      card.remove();
+      vi.useRealTimers();
+    });
+
+    it("clicking the earth thumbnail fetches the latest EPIC image and shows it", async () => {
+      stubEarthFetch();
+      const card = createAndMount();
+      clickButton(card, "gallery");
+      await flush();
+      card.shadowRoot.querySelector('.gallery-thumb[data-source="earth"]').click();
+      await flush();
+      const img = card.shadowRoot.querySelector("#image-view");
+      expect(img.classList.contains("visible")).toBe(true);
+      expect(img.src).toBe(
+        `${EPIC_BASE_URL}/archive/natural/2026/08/10/jpg/epic_1b_20260810234950.jpg`
+      );
+      expect(card.shadowRoot.querySelector(".status-bar").textContent).toContain("DSCOVR Earth");
+      card.remove();
+    });
+
+    it("falls back to the solar view with a visible error when the earth image fetch fails", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+      const card = createAndMount();
+      clickButton(card, "gallery");
+      await flush();
+      card.shadowRoot.querySelector('.gallery-thumb[data-source="earth"]').click();
+      await flush();
+      const img = card.shadowRoot.querySelector("#image-view");
+      expect(img.classList.contains("visible")).toBe(false);
+      expect(card._imagePanelMode).toBe("none");
+      expect(card.shadowRoot.querySelector(".status-bar").textContent).toContain(
+        "DSCOVR Earth image unavailable"
+      );
+      card.remove();
+    });
+
+    it("clears the error banner when the gallery is reopened", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+      const card = createAndMount();
+      card.hass = { config: { latitude: 41.8781, longitude: -87.6298 } };
+      clickButton(card, "gallery");
+      await flush();
+      card.shadowRoot.querySelector('.gallery-thumb[data-source="earth"]').click();
+      await flush();
+      expect(card.shadowRoot.querySelector(".status-bar").textContent).toContain("unavailable");
+      clickButton(card, "gallery"); // close
+      clickButton(card, "gallery"); // reopen
+      expect(card.shadowRoot.querySelector(".status-bar").textContent).not.toContain("unavailable");
+      card.remove();
+    });
+
+    it("falls back to the solar view with a visible error when the earth image response is empty", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve([]) })
+      );
+      const card = createAndMount();
+      clickButton(card, "gallery");
+      await flush();
+      card.shadowRoot.querySelector('.gallery-thumb[data-source="earth"]').click();
+      await flush();
+      const img = card.shadowRoot.querySelector("#image-view");
+      expect(img.classList.contains("visible")).toBe(false);
+      expect(card._imagePanelMode).toBe("none");
+      expect(card.shadowRoot.querySelector(".status-bar").textContent).toContain(
+        "DSCOVR Earth image unavailable"
+      );
+      card.remove();
+    });
+
+    it("auto-update ticks refresh gallery thumbnails while the gallery stays open", async () => {
+      vi.useFakeTimers();
+      const fetchMock = stubEarthFetch();
+      // A single tick timed just past the 1-hour cache TTL, rather than 1-min ticks
+      // advanced 61x over — many overlapping fetch/render cycles under fake timers
+      // leave dangling promises that can resolve after the test tears down.
+      const card = createAndMount({ refresh_mins: 61 });
+      clickButton(card, "gallery");
+      await vi.advanceTimersByTimeAsync(0);
+      const callsAfterOpen = fetchMock.mock.calls.length;
+
+      await vi.advanceTimersByTimeAsync(61 * 60000);
+      expect(fetchMock.mock.calls.length).toBeGreaterThan(callsAfterOpen);
+
+      card.remove();
+      vi.useRealTimers();
+    });
+
+    it("auto-update ticks do not fetch gallery thumbnails while the gallery is closed", async () => {
+      vi.useFakeTimers();
+      const fetchMock = stubEarthFetch();
+      const card = createAndMount({ refresh_mins: 1 });
+      await vi.advanceTimersByTimeAsync(6 * 60000);
+      expect(fetchMock).not.toHaveBeenCalled();
+
+      card.remove();
+      vi.useRealTimers();
+    });
+
+    it("skips a failed source's thumbnail but still populates the others", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+      const card = createAndMount();
+      clickButton(card, "gallery");
+      await flush();
+      const sunThumb = card.shadowRoot.querySelector('.gallery-thumb[data-source="sun"] img');
+      const earthThumb = card.shadowRoot.querySelector('.gallery-thumb[data-source="earth"] img');
+      expect(sunThumb.getAttribute("src")).not.toBe("");
+      expect(earthThumb.getAttribute("src")).toBe(""); // earth fetch failed, thumbnail stays empty
       card.remove();
     });
   });

--- a/test/card/image-sources.test.ts
+++ b/test/card/image-sources.test.ts
@@ -14,15 +14,15 @@ describe("image-sources", () => {
   });
 
   describe("getSunImageUrl", () => {
-    // now = 2026-08-15T22:42:30Z; minus the 20-min publish buffer = 22:22:30;
-    // floored to the last 15-min slot = 22:15:00.
+    // now = 2026-08-15T22:42:30Z; minus the 30-min publish buffer = 22:12:30;
+    // floored to the last 15-min slot = 22:00:00.
     const NOW = Date.UTC(2026, 7, 15, 22, 42, 30);
 
     it("computes the SDO browse-archive URL for the last published 15-min slot, buffered for publish latency", () => {
       vi.spyOn(Date, "now").mockReturnValue(NOW);
       const { url, date } = getSunImageUrl();
-      expect(url).toBe(`${SDO_BROWSE_BASE_URL}/2026/08/15/20260815_221500_1024_HMIIC.jpg`);
-      expect(date.toISOString()).toBe("2026-08-15T22:15:00.000Z");
+      expect(url).toBe(`${SDO_BROWSE_BASE_URL}/2026/08/15/20260815_220000_1024_HMIIC.jpg`);
+      expect(date.toISOString()).toBe("2026-08-15T22:00:00.000Z");
     });
 
     it("returns the cached result within the TTL instead of a fresh slot", () => {
@@ -33,10 +33,10 @@ describe("image-sources", () => {
       expect(second).toEqual(first);
     });
 
-    it("recomputes with a fresh slot once the 1-hour TTL has elapsed", () => {
+    it("recomputes with a fresh slot once the 15-min default TTL has elapsed", () => {
       vi.spyOn(Date, "now").mockReturnValue(NOW);
       const first = getSunImageUrl();
-      vi.spyOn(Date, "now").mockReturnValue(NOW + 3600001);
+      vi.spyOn(Date, "now").mockReturnValue(NOW + 15 * 60000 + 1);
       const second = getSunImageUrl();
       expect(second).not.toEqual(first);
     });

--- a/test/card/image-sources.test.ts
+++ b/test/card/image-sources.test.ts
@@ -4,7 +4,7 @@ import {
   EPIC_BASE_URL,
   fetchLatestEarthImageUrl,
   getSunImageUrl,
-  SUN_IMAGE_URL,
+  SDO_BROWSE_BASE_URL,
 } from "../../src/card/image-sources.js";
 
 describe("image-sources", () => {
@@ -14,33 +14,38 @@ describe("image-sources", () => {
   });
 
   describe("getSunImageUrl", () => {
-    it("returns the fixed SDO HMI Continuum URL with a cache-busting param, and the current date", () => {
-      vi.spyOn(Date, "now").mockReturnValue(1700000000000);
+    // now = 2026-08-15T22:42:30Z; minus the 20-min publish buffer = 22:22:30;
+    // floored to the last 15-min slot = 22:15:00.
+    const NOW = Date.UTC(2026, 7, 15, 22, 42, 30);
+
+    it("computes the SDO browse-archive URL for the last published 15-min slot, buffered for publish latency", () => {
+      vi.spyOn(Date, "now").mockReturnValue(NOW);
       const { url, date } = getSunImageUrl();
-      expect(url).toBe(`${SUN_IMAGE_URL}?t=1700000000000`);
-      expect(date.getTime()).toBe(1700000000000);
+      expect(url).toBe(`${SDO_BROWSE_BASE_URL}/2026/08/15/20260815_221500_1024_HMIIC.jpg`);
+      expect(date.toISOString()).toBe("2026-08-15T22:15:00.000Z");
     });
 
-    it("returns the cached result within the TTL instead of a fresh timestamp", () => {
-      vi.spyOn(Date, "now").mockReturnValue(1700000000000);
+    it("returns the cached result within the TTL instead of a fresh slot", () => {
+      vi.spyOn(Date, "now").mockReturnValue(NOW);
       const first = getSunImageUrl();
-      vi.spyOn(Date, "now").mockReturnValue(1700000000000 + 60000);
+      vi.spyOn(Date, "now").mockReturnValue(NOW + 60000);
       const second = getSunImageUrl();
       expect(second).toEqual(first);
     });
 
-    it("refetches with a new timestamp once the 1-hour TTL has elapsed", () => {
-      vi.spyOn(Date, "now").mockReturnValue(1700000000000);
+    it("recomputes with a fresh slot once the 1-hour TTL has elapsed", () => {
+      vi.spyOn(Date, "now").mockReturnValue(NOW);
       const first = getSunImageUrl();
-      vi.spyOn(Date, "now").mockReturnValue(1700000000000 + 3600001);
+      vi.spyOn(Date, "now").mockReturnValue(NOW + 3600001);
       const second = getSunImageUrl();
       expect(second).not.toEqual(first);
     });
 
     it("a shorter maxAgeMs expires the cache sooner", () => {
-      vi.spyOn(Date, "now").mockReturnValue(1700000000000);
+      vi.spyOn(Date, "now").mockReturnValue(NOW);
       const first = getSunImageUrl();
-      vi.spyOn(Date, "now").mockReturnValue(1700000000000 + 60000);
+      // 16 min later, guaranteed to cross into the next published 15-min slot.
+      vi.spyOn(Date, "now").mockReturnValue(NOW + 16 * 60000);
       const second = getSunImageUrl(1000);
       expect(second).not.toEqual(first);
     });

--- a/test/card/image-sources.test.ts
+++ b/test/card/image-sources.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  clearImageCache,
+  EPIC_BASE_URL,
+  fetchLatestEarthImageUrl,
+  getSunImageUrl,
+  SUN_IMAGE_URL,
+} from "../../src/card/image-sources.js";
+
+describe("image-sources", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    clearImageCache();
+  });
+
+  describe("getSunImageUrl", () => {
+    it("returns the fixed SDO HMI Continuum URL with a cache-busting param, and the current date", () => {
+      vi.spyOn(Date, "now").mockReturnValue(1700000000000);
+      const { url, date } = getSunImageUrl();
+      expect(url).toBe(`${SUN_IMAGE_URL}?t=1700000000000`);
+      expect(date.getTime()).toBe(1700000000000);
+    });
+
+    it("returns the cached result within the TTL instead of a fresh timestamp", () => {
+      vi.spyOn(Date, "now").mockReturnValue(1700000000000);
+      const first = getSunImageUrl();
+      vi.spyOn(Date, "now").mockReturnValue(1700000000000 + 60000);
+      const second = getSunImageUrl();
+      expect(second).toEqual(first);
+    });
+
+    it("refetches with a new timestamp once the 1-hour TTL has elapsed", () => {
+      vi.spyOn(Date, "now").mockReturnValue(1700000000000);
+      const first = getSunImageUrl();
+      vi.spyOn(Date, "now").mockReturnValue(1700000000000 + 3600001);
+      const second = getSunImageUrl();
+      expect(second).not.toEqual(first);
+    });
+
+    it("a shorter maxAgeMs expires the cache sooner", () => {
+      vi.spyOn(Date, "now").mockReturnValue(1700000000000);
+      const first = getSunImageUrl();
+      vi.spyOn(Date, "now").mockReturnValue(1700000000000 + 60000);
+      const second = getSunImageUrl(1000);
+      expect(second).not.toEqual(first);
+    });
+  });
+
+  describe("fetchLatestEarthImageUrl", () => {
+    it("builds the archive URL and UTC capture date from the last (most recent) entry", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve([{ identifier: "20260810005516" }, { identifier: "20260810234950" }]),
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const { url, date } = await fetchLatestEarthImageUrl();
+
+      expect(fetchMock).toHaveBeenCalledWith(`${EPIC_BASE_URL}/api/natural`);
+      expect(url).toBe(
+        `${EPIC_BASE_URL}/archive/natural/2026/08/10/jpg/epic_1b_20260810234950.jpg`
+      );
+      expect(date.toISOString()).toBe("2026-08-10T23:49:50.000Z");
+    });
+
+    it("returns the cached result within the TTL without calling fetch again", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([{ identifier: "20260810234950" }]),
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const first = await fetchLatestEarthImageUrl();
+      const second = await fetchLatestEarthImageUrl();
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(second).toEqual(first);
+    });
+
+    it("a shorter maxAgeMs expires the cache sooner and calls fetch again", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([{ identifier: "20260810234950" }]),
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      await fetchLatestEarthImageUrl();
+      await fetchLatestEarthImageUrl(0);
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("throws when the response is empty", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve([]) })
+      );
+      await expect(fetchLatestEarthImageUrl()).rejects.toThrow();
+    });
+
+    it("throws when the request fails", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+      await expect(fetchLatestEarthImageUrl()).rejects.toThrow();
+    });
+  });
+});

--- a/test/card/image-sources.test.ts
+++ b/test/card/image-sources.test.ts
@@ -14,15 +14,15 @@ describe("image-sources", () => {
   });
 
   describe("getSunImageUrl", () => {
-    // now = 2026-08-15T22:42:30Z; minus the 30-min publish buffer = 22:12:30;
-    // floored to the last 15-min slot = 22:00:00.
+    // now = 2026-08-15T22:42:30Z; minus the 15-min publish buffer = 22:27:30;
+    // floored to the last 15-min slot = 22:15:00.
     const NOW = Date.UTC(2026, 7, 15, 22, 42, 30);
 
     it("computes the SDO browse-archive URL for the last published 15-min slot, buffered for publish latency", () => {
       vi.spyOn(Date, "now").mockReturnValue(NOW);
       const { url, date } = getSunImageUrl();
-      expect(url).toBe(`${SDO_BROWSE_BASE_URL}/2026/08/15/20260815_220000_1024_HMIIC.jpg`);
-      expect(date.toISOString()).toBe("2026-08-15T22:00:00.000Z");
+      expect(url).toBe(`${SDO_BROWSE_BASE_URL}/2026/08/15/20260815_221500_1024_HMIIC.jpg`);
+      expect(date.toISOString()).toBe("2026-08-15T22:15:00.000Z");
     });
 
     it("returns the cached result within the TTL instead of a fresh slot", () => {

--- a/test/card/relative-time.test.ts
+++ b/test/card/relative-time.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { formatRelativeAge } from "../../src/card/relative-time.js";
+
+describe("formatRelativeAge", () => {
+  const now = new Date("2026-08-12T12:00:00Z");
+
+  it("returns 'just now' for under a minute", () => {
+    expect(formatRelativeAge(new Date("2026-08-12T11:59:30Z"), now)).toBe("just now");
+  });
+
+  it("formats minutes", () => {
+    expect(formatRelativeAge(new Date("2026-08-12T11:55:00Z"), now)).toBe("5m ago");
+  });
+
+  it("formats hours", () => {
+    expect(formatRelativeAge(new Date("2026-08-12T06:00:00Z"), now)).toBe("6h ago");
+  });
+
+  it("floors partial hours instead of rounding", () => {
+    expect(formatRelativeAge(new Date("2026-08-12T06:30:00Z"), now)).toBe("5h ago");
+  });
+
+  it("keeps counting hours past a day rather than switching to days", () => {
+    expect(formatRelativeAge(new Date("2026-08-11T06:00:00Z"), now)).toBe("30h ago");
+  });
+
+  it("treats a future date as 'just now'", () => {
+    expect(formatRelativeAge(new Date("2026-08-12T12:05:00Z"), now)).toBe("just now");
+  });
+});


### PR DESCRIPTION
## Summary
- New `l1_imagery` view: fetches live Earth (NASA EPIC) and Sun (SOHO) images, no HA entity required
- Auto-cycles between images on a configurable interval/duration (whole seconds)
- Caches fetches for 5 minutes; manual button clicks bypass the cache
- Per-view status bar with distinct icons and relative image age
- Gallery thumbnail strip (Earth + 4 SOHO views) for quick source switching

## Test plan
- [x] `npm run test:coverage`
- [x] `npm run check:ci`