### PR TITLE
fix: replay end date, Now recenter, gray version label

### DIFF
--- a/src/card/card-styles.ts
+++ b/src/card/card-styles.ts
@@ -210,7 +210,7 @@ export const cardStyles = css`
   }
   .card-version {
     font-size: 9px;
-    color: #00e676;
+    color: #9e9e9e;
     user-select: none;
     font-family: sans-serif;
     position: absolute;

--- a/src/card/card-view-state.ts
+++ b/src/card/card-view-state.ts
@@ -95,4 +95,10 @@ export class ViewState {
   endDrag(): void {
     this.isDragging = false;
   }
+
+  /** Reset pan to center the sun in view, keeping current zoom level. */
+  recenter(): void {
+    this.centerX = VIEW_SIZE / 2;
+    this.centerY = VIEW_SIZE / 2;
+  }
 }

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -576,6 +576,7 @@ export class SolarViewCard extends LitElement {
   private _goToday(): void {
     this._isLiveMode = true;
     this._currentDate = new Date();
+    this._viewState?.recenter();
     this._render();
   }
 
@@ -614,9 +615,9 @@ export class SolarViewCard extends LitElement {
     this._replayTimer = null;
     this._isReplaying = false;
     this._isLiveMode = resumeLiveMode;
-    // If replay started from live mode, land on real "now" (time passed during the
-    // animation); otherwise return exactly to the date the user had paused on.
-    this._currentDate = resumeLiveMode ? new Date() : new Date(endTime);
+    // Always return to the date the user was viewing before replay started,
+    // regardless of live mode — replay should not jump the view forward.
+    this._currentDate = new Date(endTime);
     this._render();
   }
 

--- a/test/__snapshots__/snapshot.test.ts.snap
+++ b/test/__snapshots__/snapshot.test.ts.snap
@@ -235,7 +235,7 @@ exports[`cardStyles > matches snapshot 1`] = `
   }
   .card-version {
     font-size: 9px;
-    color: #00e676;
+    color: #9e9e9e;
     user-select: none;
     font-family: sans-serif;
     position: absolute;

--- a/test/card/card.test.ts
+++ b/test/card/card.test.ts
@@ -714,7 +714,7 @@ describe("SolarViewCard", () => {
       card.remove();
     });
 
-    it("completes within 15 seconds of wall-clock time and lands on now with live mode resumed", () => {
+    it("completes within 15 seconds of wall-clock time, resumes live mode, and returns to the pre-replay date", () => {
       const now = new Date("2026-02-15T12:00:00Z");
       vi.useFakeTimers({ now });
       const card = createAndMount();
@@ -722,10 +722,9 @@ describe("SolarViewCard", () => {
       vi.advanceTimersByTime(15000); // upper bound on real time this may take
       expect(card._isReplaying).toBe(false);
       expect(card._isLiveMode).toBe(true);
-      // Finishes before the 15s mark, so the virtual clock (and _currentDate) has
-      // advanced by less than the full 15000ms window.
-      expect(card._currentDate.getTime()).toBeGreaterThanOrEqual(now.getTime());
-      expect(card._currentDate.getTime()).toBeLessThan(now.getTime() + 15000);
+      // Live mode resumes, but the displayed date lands back on where the user
+      // was before replay started, not on real "now".
+      expect(card._currentDate.toISOString()).toBe(now.toISOString());
       card.remove();
     });
 
@@ -802,6 +801,18 @@ describe("SolarViewCard", () => {
       const after = parseViewBox(card);
       expect(after.width).toBe(zoomed.width);
       expect(card._zoomLevel).toBe(3);
+      card.remove();
+    });
+
+    it("Today button recenters the sun after panning", () => {
+      const card = createAndMount();
+      const centered = parseViewBox(card);
+      card._viewState.centerX += 150;
+      card._viewState.centerY -= 75;
+      clickButton(card, "today");
+      const after = parseViewBox(card);
+      expect(after.minX).toBe(centered.minX);
+      expect(after.minY).toBe(centered.minY);
       card.remove();
     });
   });


### PR DESCRIPTION
## Summary
- Replay finishing from live mode landed on real "now" instead of the date the user was viewing before replay started — now always returns to that date, `_isLiveMode` still resumes independently.
- "Now" button left pan offset untouched after dragging — now recenters the sun via `ViewState.recenter()`.
- Version label color changed from green (`#00e676`) to gray (`#9e9e9e`), matching ha-yahoofinance-board-card.

## Test plan
- [x] `npm run test:coverage` — 571 tests pass, 100% coverage
- [x] `npm run check:ci` — typecheck/lint/format clean