### PR TITLE
fix: bound EPIC/SDO fetch and image preload with a shared 15s timeout

### DIFF
--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -21,7 +21,12 @@ import {
 } from "./card-template.js";
 import { DEFAULT_ZOOM_LEVEL, MAX_ZOOM, MIN_ZOOM, ViewState } from "./card-view-state.js";
 import type { SourcedImage } from "./image-sources.js";
-import { fetchLatestEarthImageUrl, getPreviousSunSlot, getSunImageUrl } from "./image-sources.js";
+import {
+  FETCH_TIMEOUT_MS,
+  fetchLatestEarthImageUrl,
+  getPreviousSunSlot,
+  getSunImageUrl,
+} from "./image-sources.js";
 import { formatRelativeAge } from "./relative-time.js";
 import { ZoomAnimator } from "./zoom-animator.js";
 
@@ -31,24 +36,21 @@ const REPLAY_STEP_MS = REPLAY_WINDOW_MS / REPLAY_STEPS;
 const REPLAY_MAX_DURATION_MS = 5000;
 const REPLAY_INTERVAL_MS = Math.floor(REPLAY_MAX_DURATION_MS / REPLAY_STEPS);
 
-// Bounds a hung image load — decode() has no built-in timeout, so a stalled request against
-// either NASA host (Earth or Sun) would otherwise wait indefinitely with no way to fall back
-// or surface an error. Same 15s bound as the EPIC JSON fetch in image-sources.ts.
-const IMAGE_LOAD_TIMEOUT_MS = 15000;
-
 // Confirms a candidate image URL actually loads AND decodes before anything commits to
 // displaying it — so a failed or not-yet-published candidate never touches a visible <img>.
 // decode() (not the load event) is what actually guarantees this: load only means the bytes
 // downloaded, not that the browser has rasterized them yet — assigning to a live <img> right
 // after load can still stumble onto the broken-image glyph for a frame while it decodes.
 // Off-DOM: doesn't reuse the real <img> element, so a failed probe can never flash onto it.
+// Bounded by FETCH_TIMEOUT_MS (image-sources.ts) — decode() has no built-in timeout, so a
+// stalled load against either NASA host would otherwise wait indefinitely.
 function preloadImage(url: string): Promise<void> {
   const probe = new Image();
   probe.src = url;
   return Promise.race([
     probe.decode(),
     new Promise<never>((_resolve, reject) => {
-      setTimeout(() => reject(new Error("Image load timed out")), IMAGE_LOAD_TIMEOUT_MS);
+      setTimeout(() => reject(new Error("Image load timed out")), FETCH_TIMEOUT_MS);
     }),
   ]);
 }

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -31,6 +31,11 @@ const REPLAY_STEP_MS = REPLAY_WINDOW_MS / REPLAY_STEPS;
 const REPLAY_MAX_DURATION_MS = 5000;
 const REPLAY_INTERVAL_MS = Math.floor(REPLAY_MAX_DURATION_MS / REPLAY_STEPS);
 
+// Bounds a hung image load — decode() has no built-in timeout, so a stalled request against
+// either NASA host (Earth or Sun) would otherwise wait indefinitely with no way to fall back
+// or surface an error. Same 15s bound as the EPIC JSON fetch in image-sources.ts.
+const IMAGE_LOAD_TIMEOUT_MS = 15000;
+
 // Confirms a candidate image URL actually loads AND decodes before anything commits to
 // displaying it — so a failed or not-yet-published candidate never touches a visible <img>.
 // decode() (not the load event) is what actually guarantees this: load only means the bytes
@@ -40,7 +45,12 @@ const REPLAY_INTERVAL_MS = Math.floor(REPLAY_MAX_DURATION_MS / REPLAY_STEPS);
 function preloadImage(url: string): Promise<void> {
   const probe = new Image();
   probe.src = url;
-  return probe.decode();
+  return Promise.race([
+    probe.decode(),
+    new Promise<never>((_resolve, reject) => {
+      setTimeout(() => reject(new Error("Image load timed out")), IMAGE_LOAD_TIMEOUT_MS);
+    }),
+  ]);
 }
 
 // Resolves a source to a candidate that's confirmed to actually load, preloading off-DOM

--- a/src/card/image-sources.ts
+++ b/src/card/image-sources.ts
@@ -6,10 +6,11 @@ export const EPIC_BASE_URL = "https://epic.gsfc.nasa.gov";
 // 15 min, matching SUN_SLOT_MS below (polling faster than its own publish grid buys nothing).
 const GALLERY_CACHE_TTL_MS = 3600000;
 
-// Bounds a hung EPIC request — without it, a stalled fetch has no app-level ceiling and
-// blocks that gallery source indefinitely (only the browser's own network stack would
-// eventually give up, if ever).
-const EPIC_FETCH_TIMEOUT_MS = 15000;
+// Bounds a hung network request — without it, a stalled fetch or image load has no
+// app-level ceiling and blocks that gallery source indefinitely (only the browser's own
+// network stack would eventually give up, if ever). Shared by the EPIC JSON fetch here and
+// the image-decode preload in card.ts, so both NASA hosts are bounded the same way.
+export const FETCH_TIMEOUT_MS = 15000;
 
 // SDO publishes HMI Continuum (visible-light sunspot disk) quicklook frames to a dated
 // browse archive on a fixed 15-min grid (:00/:15/:30/:45 UTC), named for their real capture
@@ -85,7 +86,7 @@ export async function fetchLatestEarthImageUrl(
   }
 
   const response = await fetch(`${EPIC_BASE_URL}/api/natural`, {
-    signal: AbortSignal.timeout(EPIC_FETCH_TIMEOUT_MS),
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   });
   if (!response.ok) {
     throw new Error(`EPIC API request failed: ${response.status}`);

--- a/src/card/image-sources.ts
+++ b/src/card/image-sources.ts
@@ -6,6 +6,11 @@ export const EPIC_BASE_URL = "https://epic.gsfc.nasa.gov";
 // 15 min, matching SUN_SLOT_MS below (polling faster than its own publish grid buys nothing).
 const GALLERY_CACHE_TTL_MS = 3600000;
 
+// Bounds a hung EPIC request — without it, a stalled fetch has no app-level ceiling and
+// blocks that gallery source indefinitely (only the browser's own network stack would
+// eventually give up, if ever).
+const EPIC_FETCH_TIMEOUT_MS = 8000;
+
 // SDO publishes HMI Continuum (visible-light sunspot disk) quicklook frames to a dated
 // browse archive on a fixed 15-min grid (:00/:15/:30/:45 UTC), named for their real capture
 // time — but sdo.gsfc.nasa.gov sends no CORS header, so unlike EPIC's JSON API we can't fetch
@@ -79,7 +84,9 @@ export async function fetchLatestEarthImageUrl(
     return cached.image;
   }
 
-  const response = await fetch(`${EPIC_BASE_URL}/api/natural`);
+  const response = await fetch(`${EPIC_BASE_URL}/api/natural`, {
+    signal: AbortSignal.timeout(EPIC_FETCH_TIMEOUT_MS),
+  });
   if (!response.ok) {
     throw new Error(`EPIC API request failed: ${response.status}`);
   }

--- a/src/card/image-sources.ts
+++ b/src/card/image-sources.ts
@@ -9,7 +9,7 @@ const GALLERY_CACHE_TTL_MS = 3600000;
 // Bounds a hung EPIC request — without it, a stalled fetch has no app-level ceiling and
 // blocks that gallery source indefinitely (only the browser's own network stack would
 // eventually give up, if ever).
-const EPIC_FETCH_TIMEOUT_MS = 8000;
+const EPIC_FETCH_TIMEOUT_MS = 15000;
 
 // SDO publishes HMI Continuum (visible-light sunspot disk) quicklook frames to a dated
 // browse archive on a fixed 15-min grid (:00/:15/:30/:45 UTC), named for their real capture

--- a/test/card/card.test.ts
+++ b/test/card/card.test.ts
@@ -1949,7 +1949,7 @@ describe("SolarViewCard", () => {
       const card = createAndMount({ gallery: { mode: "earth" } });
       await vi.advanceTimersByTimeAsync(0);
       card.shadowRoot.querySelector('.gallery-thumb[data-source="earth"]').click();
-      await vi.advanceTimersByTimeAsync(15000); // IMAGE_LOAD_TIMEOUT_MS in card.ts
+      await vi.advanceTimersByTimeAsync(15000); // FETCH_TIMEOUT_MS in image-sources.ts
       const img = card.shadowRoot.querySelector("#image-view");
       expect(img.classList.contains("visible")).toBe(false);
       expect(card._imagePanelMode).toBe("none");

--- a/test/card/card.test.ts
+++ b/test/card/card.test.ts
@@ -1930,6 +1930,63 @@ describe("SolarViewCard", () => {
       card.remove();
     });
 
+    it("falls back to the solar view with a visible error when the earth image load hangs past the timeout", async () => {
+      vi.useFakeTimers();
+      stubEarthFetch();
+      vi.stubGlobal(
+        "Image",
+        class {
+          src = "";
+          decode() {
+            return new Promise(() => {}); // never settles — simulates a hung image load
+          }
+        }
+      );
+      // gallery.mode: "earth" keeps this isolated to earth's own timeout — "both" would
+      // also hang sun's preload (same stubbed Image), which retries once and so needs a
+      // second 15s wait before the shared Promise.allSettled in _refreshImageSources
+      // settles, unrelated to what this test is checking.
+      const card = createAndMount({ gallery: { mode: "earth" } });
+      await vi.advanceTimersByTimeAsync(0);
+      card.shadowRoot.querySelector('.gallery-thumb[data-source="earth"]').click();
+      await vi.advanceTimersByTimeAsync(15000); // IMAGE_LOAD_TIMEOUT_MS in card.ts
+      const img = card.shadowRoot.querySelector("#image-view");
+      expect(img.classList.contains("visible")).toBe(false);
+      expect(card._imagePanelMode).toBe("none");
+      expect(card.shadowRoot.querySelector(".status-bar").textContent).toContain(
+        "DSCOVR Earth image unavailable"
+      );
+      card.remove();
+      vi.useRealTimers();
+    });
+
+    it("falls back to the unavailable banner when the sun image load hangs on both the primary and retry attempts", async () => {
+      vi.useFakeTimers();
+      vi.stubGlobal(
+        "Image",
+        class {
+          src = "";
+          decode() {
+            return new Promise(() => {}); // never settles on either attempt
+          }
+        }
+      );
+      const card = createAndMount({ gallery: { mode: "sun" } });
+      await vi.advanceTimersByTimeAsync(0);
+      card.shadowRoot.querySelector('.gallery-thumb[data-source="sun"]').click();
+      // Primary attempt times out, then the one retry (getPreviousSunSlot) also hangs and
+      // times out — two sequential 15s bounds before the banner surfaces.
+      await vi.advanceTimersByTimeAsync(30000);
+      const img = card.shadowRoot.querySelector("#image-view");
+      expect(img.classList.contains("visible")).toBe(false);
+      expect(card._imagePanelMode).toBe("none");
+      expect(card.shadowRoot.querySelector(".status-bar").textContent).toContain(
+        "SDO HMI Continuum image unavailable"
+      );
+      card.remove();
+      vi.useRealTimers();
+    });
+
     it("auto-update ticks refresh gallery thumbnails while the gallery stays open", async () => {
       vi.useFakeTimers();
       const fetchMock = stubEarthFetch();

--- a/test/card/image-sources.test.ts
+++ b/test/card/image-sources.test.ts
@@ -144,7 +144,7 @@ describe("image-sources", () => {
 
     it("aborts and rejects a request that hangs past the timeout, bounding an otherwise-indefinite stall", async () => {
       // Stubs AbortSignal.timeout to fire immediately instead of waiting out the real
-      // 8s bound, so this test verifies the abort wiring without a real 8s sleep.
+      // FETCH_TIMEOUT_MS bound, so this test verifies the abort wiring without a real sleep.
       vi.spyOn(AbortSignal, "timeout").mockReturnValue(AbortSignal.abort(new Error("timeout")));
       vi.stubGlobal(
         "fetch",

--- a/test/card/image-sources.test.ts
+++ b/test/card/image-sources.test.ts
@@ -11,6 +11,7 @@ import {
 describe("image-sources", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
     clearImageCache();
   });
 
@@ -86,7 +87,10 @@ describe("image-sources", () => {
 
       const { url, date } = await fetchLatestEarthImageUrl();
 
-      expect(fetchMock).toHaveBeenCalledWith(`${EPIC_BASE_URL}/api/natural`);
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${EPIC_BASE_URL}/api/natural`,
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      );
       expect(url).toBe(
         `${EPIC_BASE_URL}/archive/natural/2026/08/10/jpg/epic_1b_20260810234950.jpg`
       );
@@ -131,6 +135,27 @@ describe("image-sources", () => {
     it("throws when the request fails", async () => {
       vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
       await expect(fetchLatestEarthImageUrl()).rejects.toThrow();
+    });
+
+    it("throws when the response is rate-limited (429), same as any other non-OK status", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 429 }));
+      await expect(fetchLatestEarthImageUrl()).rejects.toThrow("429");
+    });
+
+    it("aborts and rejects a request that hangs past the timeout, bounding an otherwise-indefinite stall", async () => {
+      // Stubs AbortSignal.timeout to fire immediately instead of waiting out the real
+      // 8s bound, so this test verifies the abort wiring without a real 8s sleep.
+      vi.spyOn(AbortSignal, "timeout").mockReturnValue(AbortSignal.abort(new Error("timeout")));
+      vi.stubGlobal(
+        "fetch",
+        vi.fn((_url: string, init?: { signal?: AbortSignal }) =>
+          init?.signal?.aborted
+            ? Promise.reject(init.signal.reason)
+            : Promise.reject(new Error("expected an aborted signal"))
+        )
+      );
+
+      await expect(fetchLatestEarthImageUrl()).rejects.toThrow("timeout");
     });
   });
 });


### PR DESCRIPTION
## Summary
Addresses the two audit gaps for the L1 imagery panel (pre-release readiness review):
- Neither the EPIC JSON fetch nor the image-decode preload (used by both Earth and Sun) had any timeout — a hung request had no app-level ceiling.
- No test distinguished a 429/rate-limit response from other failure modes.

- `fetchLatestEarthImageUrl` passes `AbortSignal.timeout(FETCH_TIMEOUT_MS)` to `fetch`.
- `preloadImage` (shared by Earth and Sun) races `decode()` against the same `FETCH_TIMEOUT_MS`, closing a gap that predates this PR — Sun's `<img>` load previously had no timeout at all.
- Single shared `FETCH_TIMEOUT_MS = 15000` (exported from `image-sources.ts`, imported by `card.ts`) rather than two separately-owned constants for the same bound.
- Confirmed no resource accumulation under permanent timeouts: the image cache is a fixed 2-key map (earth/sun, always overwritten), and timers are single tracked fields cleared before recreation.

## Test plan
- [x] `npm run test:coverage` — 575/575 pass, 100% coverage held
- [x] `npm run check:ci` — typecheck/biome/prettier clean
- [x] Fetch hang → `AbortSignal` fires, rejects (stubs `AbortSignal.timeout` to fire immediately, no real wait)
- [x] Earth image-load hang → falls back to the unavailable banner (scoped to `gallery.mode: "earth"` to isolate from Sun's own preload)
- [x] Sun image-load hang on both the primary and retry attempts → falls back to the unavailable banner
- [x] 429 response throws distinctly from the empty-response case

Not in scope (flagged for a separate, non-blocking PR): extracting the duplicated `ellipseFromApsides`/`polarFromFocus` orbit math into shared `svg-utils.ts` helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)