### PR TITLE
refactor: extract shared ellipseFromApsides/polarFromFocus helpers

### DIFF
--- a/src/renderer/comets.ts
+++ b/src/renderer/comets.ts
@@ -5,6 +5,7 @@ import {
   BODY_LABEL_ATTRS,
   createSvgElement,
   DEFAULT_LABEL_COLOR,
+  ellipseFromApsides,
   orbitTransformMatrix,
 } from "./svg-utils.js";
 
@@ -27,11 +28,10 @@ export function computeCometVisualEllipse(comet: Comet): CometVisualEllipse {
     aphelionPx = neptunePx + excess * 4;
   }
 
-  const aPx = (perihelionPx + aphelionPx) / 2;
-  const cPx = (aphelionPx - perihelionPx) / 2;
-  const bPx = Math.sqrt(aPx * aPx - cPx * cPx);
-  const ePx = cPx / aPx;
-  return { aPx, bPx, cPx, ePx, rotationDeg: comet.longitudeOfPerihelion };
+  return {
+    ...ellipseFromApsides(perihelionPx, aphelionPx),
+    rotationDeg: comet.longitudeOfPerihelion,
+  };
 }
 
 /**

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -24,6 +24,7 @@ import {
   CENTER,
   createSvgElement,
   DEFAULT_LABEL_COLOR,
+  polarFromFocus,
   VIEW_SIZE,
 } from "./svg-utils.js";
 
@@ -98,9 +99,7 @@ export function renderSolarSystem(
   PLANETS.forEach((planet, i) => {
     const { angle, trueAnomaly } = calculatePlanetOrbit(planet, date);
     const { aPx, ePx } = planetEllipses[i];
-    const radius = (aPx * (1 - ePx * ePx)) / (1 + ePx * Math.cos(trueAnomaly));
-    const x = CENTER + radius * Math.cos(angle);
-    const y = CENTER + eclipticViewDirection * radius * Math.sin(angle);
+    const { x, y } = polarFromFocus(aPx, ePx, trueAnomaly, angle, eclipticViewDirection);
     if (planet.name === EARTH.name) {
       earthX = x;
       earthY = y;
@@ -124,9 +123,7 @@ export function renderSolarSystem(
   for (const comet of COMETS) {
     const { angle, radius, trueAnomaly } = calculateCometPosition(comet, date);
     const { aPx, ePx } = computeCometVisualEllipse(comet);
-    const rPx = (aPx * (1 - ePx * ePx)) / (1 + ePx * Math.cos(trueAnomaly));
-    const cx = CENTER + rPx * Math.cos(angle);
-    const cy = CENTER + eclipticViewDirection * rPx * Math.sin(angle);
+    const { x: cx, y: cy } = polarFromFocus(aPx, ePx, trueAnomaly, angle, eclipticViewDirection);
     // Tail scales inversely with distance from Sun
     const perihelion = comet.semiMajorAxis * (1 - comet.eccentricity);
     const tailScale = Math.min(1, perihelion / radius);

--- a/src/renderer/orbit-packing.ts
+++ b/src/renderer/orbit-packing.ts
@@ -1,7 +1,7 @@
 import { MOON, MOON_PIXEL_OFFSET } from "../astronomy/planet-data.js";
 import type { CometVisualEllipse, Planet } from "../types.js";
 import { SATURN_RING_OUTER_RADIUS } from "./bodies.js";
-import { auToRadius } from "./svg-utils.js";
+import { auToRadius, ellipseFromApsides } from "./svg-utils.js";
 
 // ponytail: fixed heuristic margin, revisit if a future body needs a wider gap.
 const MIN_GAP = 8;
@@ -54,9 +54,8 @@ export function computePlanetVisualEllipse(
   const perihelionPx = auToRadius(au * (1 - e)) + packedOffset;
   const aphelionPx = auToRadius(au * (1 + e)) + packedOffset;
 
-  const aPx = (perihelionPx + aphelionPx) / 2;
-  const cPx = (aphelionPx - perihelionPx) / 2;
-  const bPx = Math.sqrt(aPx * aPx - cPx * cPx);
-  const ePx = cPx / aPx;
-  return { aPx, bPx, cPx, ePx, rotationDeg: planet.longitudeOfPerihelion };
+  return {
+    ...ellipseFromApsides(perihelionPx, aphelionPx),
+    rotationDeg: planet.longitudeOfPerihelion,
+  };
 }

--- a/src/renderer/svg-utils.ts
+++ b/src/renderer/svg-utils.ts
@@ -1,4 +1,5 @@
 import { PLANETS } from "../astronomy/planet-data.js";
+import type { CometVisualEllipse } from "../types.js";
 
 export const SVG_NS = "http://www.w3.org/2000/svg";
 export const DEFAULT_LABEL_COLOR = "currentColor";
@@ -27,6 +28,43 @@ export function auToRadius(au: number): number {
 export function radiusFromAU(radius: number): number {
   const t = (radius - MIN_RADIUS) / (MAX_RADIUS - MIN_RADIUS);
   return Math.exp(_logMinAU + t * (_logMaxAU - _logMinAU));
+}
+
+/**
+ * Ellipse parameters in pixel space from a body's perihelion/aphelion distances (both
+ * already converted to px via auToRadius). Shared by every orbiting body — planet, comet —
+ * so this math lives in exactly one place rather than being re-derived per body type.
+ */
+export function ellipseFromApsides(
+  perihelionPx: number,
+  aphelionPx: number
+): Omit<CometVisualEllipse, "rotationDeg"> {
+  const aPx = (perihelionPx + aphelionPx) / 2;
+  const cPx = (aphelionPx - perihelionPx) / 2;
+  const bPx = Math.sqrt(aPx * aPx - cPx * cPx);
+  const ePx = cPx / aPx;
+  return { aPx, bPx, cPx, ePx };
+}
+
+/**
+ * A body's pixel position on its ellipse at the given true anomaly/angle — the polar
+ * equation of an ellipse with the Sun at the focus, r = a(1-e²)/(1+e·cosθ), rotated into
+ * screen space. Must stay derived identically for every body type: this is the same
+ * formula orbitTransformComponents's matrix is built to agree with (see its docstring,
+ * #94) — a marker computed any other way can drift off the drawn orbit ring.
+ */
+export function polarFromFocus(
+  aPx: number,
+  ePx: number,
+  trueAnomaly: number,
+  angle: number,
+  eclipticViewDirection: number
+): { x: number; y: number } {
+  const radius = (aPx * (1 - ePx * ePx)) / (1 + ePx * Math.cos(trueAnomaly));
+  return {
+    x: CENTER + radius * Math.cos(angle),
+    y: CENTER + eclipticViewDirection * radius * Math.sin(angle),
+  };
 }
 
 export interface OrbitTransformComponents {

--- a/test/renderer/svg-utils.test.ts
+++ b/test/renderer/svg-utils.test.ts
@@ -4,8 +4,10 @@ import {
   auToRadius,
   CENTER,
   createSvgElement,
+  ellipseFromApsides,
   MAX_RADIUS,
   MIN_RADIUS,
+  polarFromFocus,
   SVG_NS,
   VIEW_SIZE,
 } from "../../src/renderer/svg-utils.js";
@@ -71,5 +73,48 @@ describe("auToRadius", () => {
     const jupiterRadius = auToRadius(5.2);
     // Jupiter should be noticeably past the midpoint (> 50% of MAX_RADIUS)
     expect(jupiterRadius).toBeGreaterThan(MIN_RADIUS + (MAX_RADIUS - MIN_RADIUS) * 0.4);
+  });
+});
+
+describe("ellipseFromApsides", () => {
+  it("computes aPx as the midpoint and cPx as the half-difference of the apsides", () => {
+    const { aPx, cPx } = ellipseFromApsides(80, 120);
+    expect(aPx).toBe(100);
+    expect(cPx).toBe(20);
+  });
+
+  it("degenerates to a circle (bPx === aPx, ePx === 0) when apsides are equal", () => {
+    const { aPx, bPx, ePx } = ellipseFromApsides(100, 100);
+    expect(bPx).toBeCloseTo(aPx, 8);
+    expect(ePx).toBeCloseTo(0, 8);
+  });
+
+  it("matches the shared formula's own aPx/bPx/cPx/ePx relationship", () => {
+    const { aPx, bPx, cPx, ePx } = ellipseFromApsides(50, 150);
+    expect(bPx).toBeCloseTo(Math.sqrt(aPx * aPx - cPx * cPx), 8);
+    expect(ePx).toBeCloseTo(cPx / aPx, 8);
+  });
+});
+
+describe("polarFromFocus", () => {
+  it("places a circular orbit (ePx=0) at radius aPx regardless of angle", () => {
+    const { x, y } = polarFromFocus(100, 0, 0, Math.PI / 2, -1);
+    expect(x).toBeCloseTo(CENTER, 8);
+    expect(y).toBeCloseTo(CENTER - 100, 8);
+  });
+
+  it("puts a body at its perihelion distance when trueAnomaly is 0", () => {
+    const aPx = 100;
+    const ePx = 0.5;
+    const perihelionPx = aPx * (1 - ePx);
+    const { x } = polarFromFocus(aPx, ePx, 0, 0, -1);
+    expect(x).toBeCloseTo(CENTER + perihelionPx, 8);
+  });
+
+  it("negates the y-offset when eclipticViewDirection flips sign", () => {
+    const north = polarFromFocus(100, 0.3, 1, Math.PI / 3, -1);
+    const south = polarFromFocus(100, 0.3, 1, Math.PI / 3, 1);
+    expect(south.y - CENTER).toBeCloseTo(-(north.y - CENTER), 8);
+    expect(south.x).toBeCloseTo(north.x, 8);
   });
 });


### PR DESCRIPTION
## Summary
Fixes a duplication gap flagged in the pre-release readiness audit: two identical math blocks were copy-pasted rather than shared.

- `ellipseFromApsides(perihelionPx, aphelionPx)` — the apsides-to-ellipse formula, previously duplicated between `computePlanetVisualEllipse` (`orbit-packing.ts`) and `computeCometVisualEllipse` (`comets.ts`).
- `polarFromFocus(aPx, ePx, trueAnomaly, angle, eclipticViewDirection)` — the polar-from-focus position formula, previously duplicated between the planet and comet position loops in `renderer/index.ts`.

Both now live once in `svg-utils.ts`. Notable because `orbitTransformComponents`'s own docstring already warns this exact formula must never diverge between the marker and the drawn orbit ring (#94 regression) — it was still living in two copies. Now both routes go through the same function, so they can't drift apart again.

No behavior change — pure extraction, same formulas.

## Test plan
- [x] `npm run test:coverage` — 577/577 pass, 100% coverage held
- [x] `npm run check:ci` — typecheck/biome/prettier clean
- [x] Added direct unit tests for both new exported helpers in `svg-utils.test.ts`, matching the file's existing convention of testing each exported function directly (`auToRadius` etc.)
- [x] Existing `computePlanetVisualEllipse`/`computeCometVisualEllipse` tests pass unchanged, confirming the extraction preserves behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)