### PR TITLE
fix: move version label from top status bar to bottom nav bar

### DIFF
--- a/src/card/card-styles.ts
+++ b/src/card/card-styles.ts
@@ -214,8 +214,8 @@ export const cardStyles = css`
     user-select: none;
     font-family: sans-serif;
     position: absolute;
-    left: 50%;
+    right: 8px;
     top: 50%;
-    transform: translate(-50%, -50%);
+    transform: translateY(-50%);
   }
 `;

--- a/src/card/card-template.ts
+++ b/src/card/card-template.ts
@@ -11,8 +11,7 @@ import { formatRelativeAge } from "./relative-time.js";
 export function buildStatusBar(
   locationData: LocationData | null,
   locationName: string | null,
-  currentDate: Date,
-  showVersion?: boolean
+  currentDate: Date
 ): TemplateResult | typeof nothing {
   if (!locationData) return nothing;
 
@@ -32,7 +31,6 @@ export function buildStatusBar(
   const name = locationName || "";
   return html`<div class="status-bar">
     <span>${name} | ${mode} (${elevRounded}°)</span>
-    ${showVersion ? html`<span class="card-version">v${__CARD_VERSION__}</span>` : nothing}
     ${next && formatter ? html`<span>Next: ${next.toMode} (${formatter.format(next.time)})</span>` : nothing}
   </div>`;
 }

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -351,12 +351,7 @@ export class SolarViewCard extends LitElement {
           <span>${this._imageError}</span>
         </div>`
       : this._imagePanelMode === "none"
-        ? buildStatusBar(
-            this._locationData,
-            this._effectiveLocationName,
-            this._currentDate,
-            this._config?.show_version
-          )
+        ? buildStatusBar(this._locationData, this._effectiveLocationName, this._currentDate)
         : buildImageStatusBar(
             this._imagePanelMode,
             this._imageDate ? this._formatDate(this._imageDate) : "",
@@ -456,6 +451,7 @@ export class SolarViewCard extends LitElement {
                   </span>`
               : nothing
           }
+          ${this._config?.show_version ? html`<span class="card-version">v${__CARD_VERSION__}</span>` : nothing}
         </div>
       </div>
     `;

--- a/test/__snapshots__/snapshot.test.ts.snap
+++ b/test/__snapshots__/snapshot.test.ts.snap
@@ -3,7 +3,6 @@
 exports[`buildStatusBar snapshots > full status bar with Next transition 1`] = `
 "<!----><div class="status-bar">
     <span><!--?-->London | <!--?-->Day (<!--?-->32°)</span>
-    <!--?-->
     <!--?--><span>Next: <!--?-->Civil Twilight (<!--?-->17:25)</span>
   </div>"
 `;
@@ -11,7 +10,6 @@ exports[`buildStatusBar snapshots > full status bar with Next transition 1`] = `
 exports[`buildStatusBar snapshots > null location name (empty before pipe) 1`] = `
 "<!----><div class="status-bar">
     <span><!--?--> | <!--?-->Day (<!--?-->89°)</span>
-    <!--?-->
     <!--?--><span>Next: <!--?-->Civil Twilight (<!--?-->18:00)</span>
   </div>"
 `;
@@ -19,7 +17,6 @@ exports[`buildStatusBar snapshots > null location name (empty before pipe) 1`] =
 exports[`buildStatusBar snapshots > single span (polar night, no transition) 1`] = `
 "<!----><div class="status-bar">
     <span><!--?-->Arctic | <!--?-->Night (<!--?-->-22°)</span>
-    <!--?-->
     <!--?-->
   </div>"
 `;
@@ -239,9 +236,9 @@ exports[`cardStyles > matches snapshot 1`] = `
     user-select: none;
     font-family: sans-serif;
     position: absolute;
-    left: 50%;
+    right: 8px;
     top: 50%;
-    transform: translate(-50%, -50%);
+    transform: translateY(-50%);
   }
 "
 `;


### PR DESCRIPTION
## Summary
- Moves the `.card-version` label out of the top status bar (where it overlapped the location/mode text via absolute centering) into the bottom nav bar.
- Right-aligned, vertically centered in the nav bar — `right: 8px; top: 50%; transform: translateY(-50%)`.
- `buildStatusBar()` drops its `showVersion` parameter; the version span now renders directly in `card.ts`'s nav template, gated by `config.show_version`.

## Test plan
- [x] `npm run test:coverage` — 581/581 pass, 100% coverage held
- [x] `npm run check:ci` — typecheck/biome/prettier clean
- [x] Existing `show_version` tests in `card.test.ts` pass unchanged (source-agnostic `.card-version` queries)
- [x] Visually verified via `docs/index.html` demo harness + Playwright screenshot — label renders bottom-right, vertically centered in the nav bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)