### PR TITLE
refactor: collapse dual-sourced location fields in card.ts

### DIFF
--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -72,6 +72,20 @@ function resolveHeightStyle(height: CardConfig["height"]): string {
   return "";
 }
 
+// HASS and config.location update independently (hass setter vs. setConfig), so each source
+// is kept as one grouped field rather than losing either one to an eager merge — _locationData
+// and _locationName below resolve them on read, override winning per-field.
+interface HassLocation {
+  lat: number | null;
+  lon: number | null;
+  timezone: string | null;
+  name: string | null;
+}
+interface LocationOverride {
+  lat: number;
+  lon: number;
+}
+
 export class SolarViewCard extends LitElement {
   static styles = cardStyles;
 
@@ -80,13 +94,9 @@ export class SolarViewCard extends LitElement {
   private _zoomAnimator: ZoomAnimator | null;
   private _defaultZoomLevel: ZoomLevel;
   private _hemisphere: Hemisphere;
-  private _lat: number | null;
-  private _lon: number | null;
-  private _timezone: string | null;
-  private _locationName: string | null;
-  private _configLat: number | null;
-  private _configLon: number | null;
-  private _configLocationName: string | null;
+  private _hassLocation: HassLocation;
+  private _locationOverride: LocationOverride | null;
+  private _locationNameOverride: string | null;
   private _autoUpdateTimer: number | null;
   private _colors: Colors;
   private _refreshMs: number;
@@ -111,13 +121,9 @@ export class SolarViewCard extends LitElement {
     this._zoomAnimator = null;
     this._defaultZoomLevel = DEFAULT_ZOOM_LEVEL;
     this._hemisphere = "north";
-    this._lat = null;
-    this._lon = null;
-    this._configLat = null;
-    this._configLon = null;
-    this._configLocationName = null;
-    this._timezone = null;
-    this._locationName = null;
+    this._hassLocation = { lat: null, lon: null, timezone: null, name: null };
+    this._locationOverride = null;
+    this._locationNameOverride = null;
     this._autoUpdateTimer = null;
     this._colors = {};
     this._refreshMs = 60000;
@@ -135,39 +141,35 @@ export class SolarViewCard extends LitElement {
   // ---------------------------------------------------------------------------
   // Proxy getters
   // ---------------------------------------------------------------------------
-  get _effectiveLat(): number | null {
-    return this._configLat ?? this._lat;
-  }
-  get _effectiveLon(): number | null {
-    return this._configLon ?? this._lon;
+  get _locationData(): LocationData | null {
+    const lat = this._locationOverride?.lat ?? this._hassLocation.lat;
+    const lon = this._locationOverride?.lon ?? this._hassLocation.lon;
+    return lat != null && lon != null
+      ? { lat, lon, timezone: this._hassLocation.timezone ?? "UTC" }
+      : null;
   }
   get _effectiveLocationName(): string | null {
-    return this._configLocationName ?? this._locationName;
-  }
-  get _locationData(): LocationData | null {
-    const lat = this._effectiveLat;
-    const lon = this._effectiveLon;
-    return lat != null && lon != null ? { lat, lon, timezone: this._timezone ?? "UTC" } : null;
+    return this._locationNameOverride ?? this._hassLocation.name;
   }
   get _zoomLevel(): ZoomLevel | null {
     return this._viewState?.zoomLevel ?? null;
   }
 
   set hass(hass: HASSConfig) {
-    const lat = hass.config?.latitude;
-    const lon = hass.config?.longitude;
-    const timezone = hass.config?.time_zone;
-    const locationName = hass.config?.location_name;
+    const next: HassLocation = {
+      lat: hass.config?.latitude ?? null,
+      lon: hass.config?.longitude ?? null,
+      timezone: hass.config?.time_zone || null,
+      name: hass.config?.location_name || null,
+    };
+    const prev = this._hassLocation;
     if (
-      lat !== this._lat ||
-      lon !== this._lon ||
-      timezone !== this._timezone ||
-      locationName !== this._locationName
+      next.lat !== prev.lat ||
+      next.lon !== prev.lon ||
+      next.timezone !== prev.timezone ||
+      next.name !== prev.name
     ) {
-      this._lat = lat != null ? lat : null;
-      this._lon = lon != null ? lon : null;
-      this._timezone = timezone || null;
-      this._locationName = locationName || null;
+      this._hassLocation = next;
       this._render();
     }
   }
@@ -204,9 +206,8 @@ export class SolarViewCard extends LitElement {
       overrideLat <= 90 &&
       overrideLon >= -180 &&
       overrideLon <= 180;
-    this._configLat = hasOverride ? overrideLat : null;
-    this._configLon = hasOverride ? overrideLon : null;
-    this._configLocationName = config.location?.name || null;
+    this._locationOverride = hasOverride ? { lat: overrideLat, lon: overrideLon } : null;
+    this._locationNameOverride = config.location?.name || null;
     this._heightStyle = resolveHeightStyle(config.height);
 
     const galleryMode = GALLERY_MODES.includes(config.gallery?.mode as GalleryMode)
@@ -251,8 +252,9 @@ export class SolarViewCard extends LitElement {
   }
 
   render() {
-    if (this._effectiveLat != null) {
-      this._hemisphere = this._effectiveLat < 0 ? "south" : "north";
+    const lat = this._locationData?.lat;
+    if (lat != null) {
+      this._hemisphere = lat < 0 ? "south" : "north";
     }
 
     const statusBar = this._gallery.error

--- a/test/card/card.test.ts
+++ b/test/card/card.test.ts
@@ -505,10 +505,12 @@ describe("SolarViewCard", () => {
           location_name: "London",
         },
       };
-      expect(card._lat).toBe(51.5);
-      expect(card._lon).toBe(-0.1);
-      expect(card._timezone).toBe("Europe/London");
-      expect(card._locationName).toBe("London");
+      expect(card._hassLocation).toEqual({
+        lat: 51.5,
+        lon: -0.1,
+        timezone: "Europe/London",
+        name: "London",
+      });
       const bar = card.shadowRoot.querySelector(".status-bar");
       expect(bar).not.toBeNull();
       card.remove();
@@ -542,12 +544,9 @@ describe("SolarViewCard", () => {
           location_name: "London",
         },
       };
-      expect(card._lat).toBe(51.5);
+      expect(card._hassLocation.lat).toBe(51.5);
       card.hass = { config: {} };
-      expect(card._lat).toBeNull();
-      expect(card._lon).toBeNull();
-      expect(card._timezone).toBeNull();
-      expect(card._locationName).toBeNull();
+      expect(card._hassLocation).toEqual({ lat: null, lon: null, timezone: null, name: null });
       card.remove();
     });
   });
@@ -565,8 +564,8 @@ describe("SolarViewCard", () => {
       };
       card.setConfig({ location: { latitude: -34.9, longitude: -56.2, name: "Montevideo" } });
       card._render();
-      expect(card._effectiveLat).toBe(-34.9);
-      expect(card._effectiveLon).toBe(-56.2);
+      expect(card._locationData?.lat).toBe(-34.9);
+      expect(card._locationData?.lon).toBe(-56.2);
       expect(card._hemisphere).toBe("south");
       expect(card._effectiveLocationName).toBe("Montevideo");
       card.remove();
@@ -577,8 +576,8 @@ describe("SolarViewCard", () => {
       card.hass = { config: { latitude: 51.5, longitude: -0.1 } };
       card.setConfig({ location: { latitude: -34.9 } });
       card._render();
-      expect(card._effectiveLat).toBe(51.5);
-      expect(card._effectiveLon).toBe(-0.1);
+      expect(card._locationData?.lat).toBe(51.5);
+      expect(card._locationData?.lon).toBe(-0.1);
       expect(card._hemisphere).toBe("north");
       card.remove();
     });
@@ -588,8 +587,8 @@ describe("SolarViewCard", () => {
       card.hass = { config: { latitude: 51.5, longitude: -0.1 } };
       card.setConfig({ location: { latitude: 200, longitude: -56.2 } });
       card._render();
-      expect(card._effectiveLat).toBe(51.5);
-      expect(card._effectiveLon).toBe(-0.1);
+      expect(card._locationData?.lat).toBe(51.5);
+      expect(card._locationData?.lon).toBe(-0.1);
       card.remove();
     });
 
@@ -598,8 +597,8 @@ describe("SolarViewCard", () => {
       card.hass = { config: { latitude: 51.5, longitude: -0.1 } };
       card.setConfig({ location: { latitude: -34.9, longitude: -200 } });
       card._render();
-      expect(card._effectiveLat).toBe(51.5);
-      expect(card._effectiveLon).toBe(-0.1);
+      expect(card._locationData?.lat).toBe(51.5);
+      expect(card._locationData?.lon).toBe(-0.1);
       card.remove();
     });
 
@@ -607,8 +606,8 @@ describe("SolarViewCard", () => {
       const card = createAndMount();
       card.hass = { config: { latitude: 51.5, longitude: -0.1, location_name: "London" } };
       card.setConfig({});
-      expect(card._effectiveLat).toBe(51.5);
-      expect(card._effectiveLon).toBe(-0.1);
+      expect(card._locationData?.lat).toBe(51.5);
+      expect(card._locationData?.lon).toBe(-0.1);
       expect(card._effectiveLocationName).toBe("London");
       card.remove();
     });
@@ -1146,8 +1145,7 @@ describe("SolarViewCard", () => {
   describe("southern hemisphere", () => {
     it("sets hemisphere to south when lat is negative", () => {
       const card = createAndMount();
-      card._lat = -33.9; // Sydney
-      card._lon = 151.2;
+      card._hassLocation = { lat: -33.9, lon: 151.2, timezone: null, name: null }; // Sydney
       card._render();
       expect(card._hemisphere).toBe("south");
       card.remove();
@@ -1356,10 +1354,7 @@ describe("SolarViewCard", () => {
       date = new Date("2026-03-05T12:00:00Z")
     ) {
       const card = document.createElement("ha-planetary-solar-system-card-test");
-      card._lat = lat;
-      card._lon = lon;
-      card._timezone = "Europe/London";
-      card._locationName = "London";
+      card._hassLocation = { lat, lon, timezone: "Europe/London", name: "London" };
       card._dateNav.currentDate = date;
       document.body.appendChild(card);
       return card;


### PR DESCRIPTION
## Summary
- HASS-provided and config-override location were 7 fields (`_lat`, `_lon`, `_timezone`, `_locationName`, `_configLat`, `_configLon`, `_configLocationName`) merged through 3 proxy getters recomputed on every access.
- Each source now groups into one field: `_hassLocation` (lat/lon/timezone/name from HASS) and `_locationOverride`/`_locationNameOverride` (config.location). Both still update independently (hass setter vs. setConfig), so neither collapses into the other — a single merged field would lose whichever source didn't just change.
- Getters collapse from 4 (`_effectiveLat`/`_effectiveLon`/`_effectiveLocationName`/`_locationData`) to 2 (`_locationData`/`_effectiveLocationName`).

## Test plan
- [x] `npm run test:coverage` — 613 tests, 100% statements/branches/functions/lines
- [x] `npm run check:ci` — typecheck + biome + prettier clean
- [x] `test/card/card.test.ts` updated to go through `card._hassLocation`/`card._locationData` instead of the removed fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)