### PR TITLE
refactor: fold offscreen-marker updates into renderSolarSystem's seam

### DIFF
--- a/src/card/card-view-state.ts
+++ b/src/card/card-view-state.ts
@@ -1,5 +1,5 @@
 import { VIEW_SIZE } from "../renderer/svg-utils.js";
-import type { ZoomLevel } from "../types.js";
+import type { PanZoomState, ZoomLevel } from "../types.js";
 
 export const DEFAULT_ZOOM_LEVEL: ZoomLevel = 1;
 export const MIN_ZOOM: ZoomLevel = 1;
@@ -11,7 +11,7 @@ export const ZOOM_LEVELS: Record<ZoomLevel, number> = { 1: 800, 2: 640, 3: 480, 
  * Encapsulates all pan and zoom state for the solar system view.
  * Keeps the SolarViewCard focused on rendering and event wiring.
  */
-export class ViewState {
+export class ViewState implements PanZoomState {
   centerX: number;
   centerY: number;
   zoomLevel: ZoomLevel;

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -1,13 +1,12 @@
 import { html, LitElement, nothing } from "lit";
 import { renderSolarSystem } from "../renderer/index.js";
-import { MARKER_GROUP_ID, renderOffscreenMarkers } from "../renderer/offscreen-markers.js";
 import type {
   CardConfig,
   Colors,
   HASSConfig,
   Hemisphere,
   LocationData,
-  ViewPosition,
+  PanZoomState,
   ZoomLevel,
 } from "../types.js";
 import { cardStyles } from "./card-styles.js";
@@ -109,7 +108,7 @@ export class SolarViewCard extends LitElement {
     return this._theme === "auto" ? null : THEME_PALETTES[this._theme];
   }
   private _heightStyle: string;
-  private _positions: ViewPosition[];
+  private _updateMarkers: ((viewState: PanZoomState) => void) | null;
   private _onVisibilityChange: (() => void) | null;
   private _gallery: GalleryController;
   _config: CardConfig | undefined;
@@ -133,7 +132,7 @@ export class SolarViewCard extends LitElement {
     this._eclipticView = false;
     this._theme = "auto";
     this._heightStyle = "";
-    this._positions = [];
+    this._updateMarkers = null;
     this._onVisibilityChange = null;
     this._gallery = new GalleryController(() => this._render());
   }
@@ -378,14 +377,14 @@ export class SolarViewCard extends LitElement {
     /* v8 ignore next */
     if (container) {
       while (container.firstChild) container.removeChild(container.firstChild);
-      const { svg, positions } = renderSolarSystem(
+      const { svg, updateMarkers } = renderSolarSystem(
         this._dateNav.currentDate,
         this._hemisphere,
         this._locationData,
         this._colors,
         this._eclipticView
       );
-      this._positions = positions;
+      this._updateMarkers = updateMarkers;
       container.appendChild(svg);
       this._bindSvgEvents(svg);
     }
@@ -484,19 +483,7 @@ export class SolarViewCard extends LitElement {
       "#solar-view svg"
     ) as SVGSVGElement | null;
     if (svg) svg.setAttribute("viewBox", this._viewState.viewBox);
-    this._updateOffscreenMarkers();
-  }
-
-  private _updateOffscreenMarkers(): void {
-    const svg = (this.shadowRoot as ShadowRoot).querySelector(
-      "#solar-view svg"
-    ) as SVGSVGElement | null;
-    if (!svg) return;
-    const old = svg.getElementById(MARKER_GROUP_ID);
-    if (old) old.remove();
-    if (this._positions && this._viewState) {
-      svg.appendChild(renderOffscreenMarkers(this._positions, this._viewState));
-    }
+    this._updateMarkers?.(this._viewState);
   }
 
   private _onPointerDown(e: PointerEvent): void {

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -5,7 +5,7 @@ import {
   calculatePlanetOrbit,
 } from "../astronomy/orbital-mechanics.js";
 import { EARTH, MOON, MOON_PIXEL_OFFSET, PLANETS, SUN } from "../astronomy/planet-data.js";
-import type { Colors, Hemisphere, LocationData, ViewPosition } from "../types.js";
+import type { Colors, Hemisphere, LocationData, PanZoomState, ViewPosition } from "../types.js";
 import {
   ORBIT_COLOR,
   renderBody,
@@ -17,6 +17,7 @@ import { computeCometVisualEllipse, renderCometBody, renderCometOrbit } from "./
 import { type LabelTarget, renderDynamicLabels } from "./labels.js";
 import { renderMoonPhaseIndicator } from "./moon-phase.js";
 import { calculateObserverAngle, renderDayNightSplit, renderObserverNeedle } from "./observer.js";
+import { MARKER_GROUP_ID, renderOffscreenMarkers } from "./offscreen-markers.js";
 import { computePlanetVisualEllipse, packOrbitRadii } from "./orbit-packing.js";
 import { renderSeasonOverlay } from "./seasons.js";
 import {
@@ -34,7 +35,11 @@ export function renderSolarSystem(
   locationData: LocationData | null = null,
   colors: Colors = {},
   eclipticView = false
-): { svg: SVGSVGElement; positions: ViewPosition[] } {
+): {
+  svg: SVGSVGElement;
+  positions: ViewPosition[];
+  updateMarkers: (viewState: PanZoomState) => void;
+} {
   const eclipticViewDirection = eclipticView ? 1 : -1;
 
   const svg = createSvgElement("svg", {
@@ -182,5 +187,15 @@ export function renderSolarSystem(
   // Moon phase indicator (rendered last so it appears on top)
   renderMoonPhaseIndicator(svg, date, hemisphere);
 
-  return { svg, positions };
+  // Re-derives which bodies' markers belong offscreen from this render's positions and the
+  // caller's current pan/zoom — cheap enough to call on every drag/zoom tick without rebuilding
+  // the rest of the SVG. Owns the marker group's DOM lifecycle (replace-by-id) so callers never
+  // need to know MARKER_GROUP_ID or reach into the SVG themselves.
+  function updateMarkers(viewState: PanZoomState): void {
+    const old = svg.getElementById(MARKER_GROUP_ID);
+    if (old) old.remove();
+    svg.appendChild(renderOffscreenMarkers(positions, viewState));
+  }
+
+  return { svg, positions, updateMarkers };
 }

--- a/test/card/card.test.ts
+++ b/test/card/card.test.ts
@@ -1107,13 +1107,6 @@ describe("SolarViewCard", () => {
       expect(() => card._applyZoom(800, 800)).not.toThrow();
     });
 
-    it("_updateOffscreenMarkers skips appending when _positions is null", () => {
-      const card = createAndMount();
-      card._positions = null;
-      expect(() => card._updateOffscreenMarkers()).not.toThrow();
-      card.remove();
-    });
-
     it("_advanceZoom is a no-op when _viewState is null", () => {
       const card = document.createElement("ha-planetary-solar-system-card-test");
       expect(() => card._advanceZoom()).not.toThrow();

--- a/test/renderer/offscreen-markers.test.ts
+++ b/test/renderer/offscreen-markers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { renderSolarSystem } from "../../src/renderer/index.js";
-import { renderOffscreenMarkers } from "../../src/renderer/offscreen-markers.js";
+import { MARKER_GROUP_ID, renderOffscreenMarkers } from "../../src/renderer/offscreen-markers.js";
 
 // Minimal viewState mock
 function makeViewState(zoomLevel, centerX = 400, centerY = 400, size = null) {
@@ -102,5 +102,33 @@ describe("renderOffscreenMarkers", () => {
     const label = group.querySelector("text");
     expect(label).not.toBeNull();
     expect(label.getAttribute("text-anchor")).toBe("end");
+  });
+});
+
+describe("renderSolarSystem().updateMarkers", () => {
+  it("appends a marker group to the returned svg for the given pan/zoom", () => {
+    const { svg, updateMarkers } = renderSolarSystem(new Date("2025-06-15"));
+    expect(svg.getElementById(MARKER_GROUP_ID)).toBeNull();
+    updateMarkers(makeViewState(4));
+    expect(svg.getElementById(MARKER_GROUP_ID)).not.toBeNull();
+  });
+
+  it("replaces the marker group on each call rather than accumulating", () => {
+    const { svg, updateMarkers } = renderSolarSystem(new Date("2025-06-15"));
+    updateMarkers(makeViewState(4));
+    const first = svg.getElementById(MARKER_GROUP_ID);
+    updateMarkers(makeViewState(4));
+    const second = svg.getElementById(MARKER_GROUP_ID);
+    expect(svg.querySelectorAll(`#${MARKER_GROUP_ID}`).length).toBe(1);
+    expect(second).not.toBe(first);
+  });
+
+  it("reflects a narrower viewport with more offscreen markers on the next call", () => {
+    const { svg, updateMarkers } = renderSolarSystem(new Date("2025-06-15"));
+    updateMarkers(makeViewState(1));
+    const wideCount = svg.getElementById(MARKER_GROUP_ID).children.length;
+    updateMarkers(makeViewState(4));
+    const narrowCount = svg.getElementById(MARKER_GROUP_ID).children.length;
+    expect(narrowCount).toBeGreaterThan(wideCount);
   });
 });


### PR DESCRIPTION
## Summary
- card.ts reached into the renderer's SVG output directly (`svg.getElementById(MARKER_GROUP_ID)`) and kept renderer output (`_positions`) as long-lived card state just to feed it back into `renderOffscreenMarkers` on every pan/zoom tick.
- `renderSolarSystem()` now returns an `updateMarkers(viewState)` closure that owns the marker group's DOM lifecycle (replace-by-id) internally — card.ts no longer imports `MARKER_GROUP_ID` or `renderOffscreenMarkers` at all, and drops the `_positions` field and `_updateOffscreenMarkers` method entirely.
- `ViewState` now `implements PanZoomState` explicitly instead of satisfying it only structurally.

## Test plan
- [x] `npm run test:coverage` — 615 tests, 100% statements/branches/functions/lines
- [x] `npm run check:ci` — typecheck + biome + prettier clean
- [x] New tests in `test/renderer/offscreen-markers.test.ts` exercise `updateMarkers` directly at the renderer seam (appends, replaces rather than accumulates, reflects viewport changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)