### PR TITLE
refactor: extract ZoomController from card.ts

### DIFF
--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -12,7 +12,7 @@ import type {
 import { cardStyles } from "./card-styles.js";
 import type { ImageSource } from "./card-template.js";
 import { buildImageStatusBar, buildStatusBar, GALLERY_SOURCE_LABELS } from "./card-template.js";
-import { DEFAULT_ZOOM_LEVEL, MAX_ZOOM, MIN_ZOOM, ViewState } from "./card-view-state.js";
+import { DEFAULT_ZOOM_LEVEL, MAX_ZOOM, MIN_ZOOM } from "./card-view-state.js";
 import { DateNav } from "./date-nav.js";
 import type { GalleryMode } from "./gallery-controller.js";
 import {
@@ -21,7 +21,7 @@ import {
   GalleryController,
 } from "./gallery-controller.js";
 import { formatRelativeAge } from "./relative-time.js";
-import { ZoomAnimator } from "./zoom-animator.js";
+import { ZoomController } from "./zoom-controller.js";
 
 export type { GalleryMode };
 
@@ -89,9 +89,7 @@ export class SolarViewCard extends LitElement {
   static styles = cardStyles;
 
   private _dateNav: DateNav;
-  private _viewState: ViewState | null;
-  private _zoomAnimator: ZoomAnimator | null;
-  private _defaultZoomLevel: ZoomLevel;
+  private _zoom: ZoomController;
   private _hemisphere: Hemisphere;
   private _hassLocation: HassLocation;
   private _locationOverride: LocationOverride | null;
@@ -99,9 +97,6 @@ export class SolarViewCard extends LitElement {
   private _autoUpdateTimer: number | null;
   private _colors: Colors;
   private _refreshMs: number;
-  private _periodicZoomChange: boolean;
-  private _periodicZoomMax: number;
-  private _zoomAnimate: boolean;
   private _eclipticView: boolean;
   private _theme: "auto" | "dark" | "light";
   private get _themePalette(): { background: string; color: string } | null {
@@ -116,9 +111,10 @@ export class SolarViewCard extends LitElement {
   constructor() {
     super();
     this._dateNav = new DateNav(() => this._render());
-    this._viewState = null;
-    this._zoomAnimator = null;
-    this._defaultZoomLevel = DEFAULT_ZOOM_LEVEL;
+    this._zoom = new ZoomController(
+      () => this._render(),
+      () => this._updateViewBox()
+    );
     this._hemisphere = "north";
     this._hassLocation = { lat: null, lon: null, timezone: null, name: null };
     this._locationOverride = null;
@@ -126,9 +122,6 @@ export class SolarViewCard extends LitElement {
     this._autoUpdateTimer = null;
     this._colors = {};
     this._refreshMs = 60000;
-    this._periodicZoomChange = false;
-    this._periodicZoomMax = MAX_ZOOM;
-    this._zoomAnimate = false;
     this._eclipticView = false;
     this._theme = "auto";
     this._heightStyle = "";
@@ -151,7 +144,7 @@ export class SolarViewCard extends LitElement {
     return this._locationNameOverride ?? this._hassLocation.name;
   }
   get _zoomLevel(): ZoomLevel | null {
-    return this._viewState?.zoomLevel ?? null;
+    return this._zoom.zoomLevel;
   }
 
   set hass(hass: HASSConfig) {
@@ -175,7 +168,7 @@ export class SolarViewCard extends LitElement {
 
   setConfig(config: CardConfig): void {
     this._config = config;
-    this._defaultZoomLevel =
+    const defaultZoomLevel =
       config.default_zoom == null ||
       config.default_zoom < MIN_ZOOM ||
       config.default_zoom > MAX_ZOOM
@@ -185,11 +178,12 @@ export class SolarViewCard extends LitElement {
     const rawRefresh = Number(config.refresh_mins);
     this._refreshMs = Number.isFinite(rawRefresh) && rawRefresh >= 0.1 ? rawRefresh * 60000 : 60000;
 
-    this._periodicZoomChange = config.periodic_zoom_change === true;
+    const periodicZoomChange = config.periodic_zoom_change === true;
     const rawMax = Number(config.periodic_zoom_max);
-    this._periodicZoomMax =
+    const periodicZoomMax =
       Number.isInteger(rawMax) && rawMax >= 2 && rawMax <= MAX_ZOOM ? rawMax : MAX_ZOOM;
-    this._zoomAnimate = config.zoom_animate !== false;
+    const zoomAnimate = config.zoom_animate !== false;
+    this._zoom.configure(defaultZoomLevel, periodicZoomChange, periodicZoomMax, zoomAnimate);
 
     this._colors = config.colors ?? {};
     this._theme = config.theme === "dark" || config.theme === "light" ? config.theme : "auto";
@@ -269,7 +263,7 @@ export class SolarViewCard extends LitElement {
             new Date(),
             this._gallery.imageLoaded
           );
-    const zoomLevel = this._viewState?.zoomLevel ?? this._defaultZoomLevel;
+    const zoomLevel = this._zoom.displayZoomLevel;
     /* v8 ignore next */
     const background = this._colors.background ?? this._themePalette?.background ?? "";
     const color = this._themePalette?.color ?? "";
@@ -368,10 +362,7 @@ export class SolarViewCard extends LitElement {
   }
 
   updated(): void {
-    if (!this._viewState) {
-      this._viewState = new ViewState(this._defaultZoomLevel);
-      this._zoomAnimator = new ZoomAnimator(this._viewState, () => this._updateViewBox());
-    }
+    this._zoom.ensureInitialized();
 
     const container = (this.shadowRoot as ShadowRoot).getElementById("solar-view");
     /* v8 ignore next */
@@ -420,20 +411,9 @@ export class SolarViewCard extends LitElement {
     const interval = this._refreshMs;
     this._autoUpdateTimer = setInterval(() => {
       this._dateNav.tick();
-      if (this._periodicZoomChange) {
-        this._advanceZoom();
-      }
+      this._zoom.tick();
       this._gallery.tick();
     }, interval) as unknown as number;
-  }
-
-  private _advanceZoom(): void {
-    if (!this._viewState) return;
-    const prevWidth = this._viewState.width;
-    const next =
-      this._viewState.zoomLevel >= this._periodicZoomMax ? MIN_ZOOM : this._viewState.zoomLevel + 1;
-    this._viewState.setZoomLevel(next);
-    this._applyZoom(prevWidth);
   }
 
   private _formatDate(date: Date): string {
@@ -451,59 +431,37 @@ export class SolarViewCard extends LitElement {
 
   private _goToday(): void {
     // Recenter before goLive() so its render picks up the recentered viewState.
-    this._viewState?.recenter();
+    this._zoom.recenter();
     this._dateNav.goLive();
   }
 
-  private _zoomIn(): void {
-    if (!this._viewState) return;
-    const prevWidth = this._viewState.width;
-    if (this._viewState.zoomIn()) this._applyZoom(prevWidth);
-  }
-
-  private _zoomOut(): void {
-    if (!this._viewState) return;
-    const prevWidth = this._viewState.width;
-    if (this._viewState.zoomOut()) this._applyZoom(prevWidth);
-  }
-
-  private _applyZoom(fromWidth: number): void {
-    if (!this._viewState) return;
-    if (this._zoomAnimate && this._zoomAnimator) {
-      this._render();
-      this._zoomAnimator.animateTo(this._viewState.zoomLevel, fromWidth, () => this._render());
-    } else {
-      this._render();
-    }
-  }
-
   private _updateViewBox(): void {
-    if (!this._viewState) return;
+    const panZoomState = this._zoom.panZoomState;
+    if (!panZoomState) return;
     const svg = (this.shadowRoot as ShadowRoot).querySelector(
       "#solar-view svg"
     ) as SVGSVGElement | null;
-    if (svg) svg.setAttribute("viewBox", this._viewState.viewBox);
-    this._updateMarkers?.(this._viewState);
+    if (svg) svg.setAttribute("viewBox", this._zoom.viewBox as string);
+    this._updateMarkers?.(panZoomState);
   }
 
   private _onPointerDown(e: PointerEvent): void {
     const svg = e.currentTarget as SVGSVGElement;
     svg.setPointerCapture(e.pointerId);
-    this._viewState?.startDrag(e.clientX, e.clientY);
+    this._zoom.startDrag(e.clientX, e.clientY);
     svg.style.cursor = "grabbing";
   }
 
   private _onPointerMove(e: PointerEvent): void {
-    if (!this._viewState?.isDragging) return;
+    if (!this._zoom.isDragging) return;
     const svg = e.currentTarget as SVGSVGElement;
     const rect = svg.getBoundingClientRect();
-    this._viewState.updateDrag(e.clientX, e.clientY, rect);
-    this._updateViewBox();
+    this._zoom.updateDrag(e.clientX, e.clientY, rect);
   }
 
   private _onPointerUp(e: PointerEvent): void {
-    if (!this._viewState?.isDragging) return;
-    this._viewState.endDrag();
+    if (!this._zoom.isDragging) return;
+    this._zoom.endDrag();
     const svg = e.currentTarget as SVGSVGElement;
     svg.releasePointerCapture(e.pointerId);
     svg.style.cursor = "grab";
@@ -530,7 +488,7 @@ export class SolarViewCard extends LitElement {
         this._dateNav.toggleReplay();
         break;
       case "zoom-out":
-        this._zoomOut();
+        this._zoom.zoomOut();
         break;
       case "month-back":
         this._dateNav.navigateMonths(-1);
@@ -554,7 +512,7 @@ export class SolarViewCard extends LitElement {
         this._dateNav.navigateMonths(1);
         break;
       case "zoom-in":
-        this._zoomIn();
+        this._zoom.zoomIn();
         break;
       case "gallery":
         this._gallery.toggle();

--- a/src/card/zoom-controller.ts
+++ b/src/card/zoom-controller.ts
@@ -1,0 +1,142 @@
+import type { PanZoomState, ZoomLevel } from "../types.js";
+import { DEFAULT_ZOOM_LEVEL, MAX_ZOOM, MIN_ZOOM, ViewState } from "./card-view-state.js";
+import { ZoomAnimator } from "./zoom-animator.js";
+
+/**
+ * Owns pan/zoom: the ViewState + ZoomAnimator pair, periodic auto-cycle config, and drag
+ * math. card.ts keeps the DOM-touching half (querying #solar-view svg, setting the viewBox
+ * attribute, triggering offscreen-marker updates) since that's shared with Lit's render
+ * lifecycle — this controller only ever hands back plain state and fires callbacks.
+ *
+ * Two callbacks, matching the two different costs: onChange requests a full Lit re-render
+ * (zoom level changed — nav bar text/buttons need it), onViewBoxChange is cheap and fires on
+ * every drag/animation frame (only the SVG viewBox + offscreen markers need updating).
+ */
+export class ZoomController {
+  private _viewState: ViewState | null;
+  private _zoomAnimator: ZoomAnimator | null;
+  private _defaultZoomLevel: ZoomLevel;
+  private _periodicZoomChange: boolean;
+  private _periodicZoomMax: number;
+  private _animate: boolean;
+  private _onChange: () => void;
+  private _onViewBoxChange: () => void;
+
+  constructor(onChange: () => void, onViewBoxChange: () => void) {
+    this._viewState = null;
+    this._zoomAnimator = null;
+    this._defaultZoomLevel = DEFAULT_ZOOM_LEVEL;
+    this._periodicZoomChange = false;
+    this._periodicZoomMax = MAX_ZOOM;
+    this._animate = false;
+    this._onChange = onChange;
+    this._onViewBoxChange = onViewBoxChange;
+  }
+
+  get zoomLevel(): ZoomLevel | null {
+    return this._viewState?.zoomLevel ?? null;
+  }
+  // Falls back to the configured default before the view initializes on first render.
+  get displayZoomLevel(): ZoomLevel {
+    return this._viewState?.zoomLevel ?? this._defaultZoomLevel;
+  }
+  get panZoomState(): PanZoomState | null {
+    return this._viewState;
+  }
+  get viewBox(): string | null {
+    return this._viewState?.viewBox ?? null;
+  }
+  get isDragging(): boolean {
+    return this._viewState?.isDragging ?? false;
+  }
+  get periodicZoomChange(): boolean {
+    return this._periodicZoomChange;
+  }
+  get periodicZoomMax(): number {
+    return this._periodicZoomMax;
+  }
+  get animate(): boolean {
+    return this._animate;
+  }
+
+  configure(
+    defaultZoomLevel: ZoomLevel,
+    periodicZoomChange: boolean,
+    periodicZoomMax: number,
+    animate: boolean
+  ): void {
+    this._defaultZoomLevel = defaultZoomLevel;
+    this._periodicZoomChange = periodicZoomChange;
+    this._periodicZoomMax = periodicZoomMax;
+    this._animate = animate;
+  }
+
+  ensureInitialized(): void {
+    if (this._viewState) return;
+    this._viewState = new ViewState(this._defaultZoomLevel);
+    this._zoomAnimator = new ZoomAnimator(this._viewState, () => this._onViewBoxChange());
+  }
+
+  // ponytail: test-seeding only — forces the next ensureInitialized() to build a fresh
+  // ViewState (e.g. to verify a new default_zoom takes effect), which no production call
+  // site needs since the real view is only ever initialized once per connection.
+  reset(): void {
+    this._viewState = null;
+    this._zoomAnimator = null;
+  }
+
+  recenter(): void {
+    this._viewState?.recenter();
+  }
+
+  zoomIn(): void {
+    const viewState = this._viewState;
+    if (!viewState) return;
+    const prevWidth = viewState.width;
+    if (viewState.zoomIn()) this._apply(viewState, prevWidth);
+  }
+
+  zoomOut(): void {
+    const viewState = this._viewState;
+    if (!viewState) return;
+    const prevWidth = viewState.width;
+    if (viewState.zoomOut()) this._apply(viewState, prevWidth);
+  }
+
+  // Auto-update tick: advances the periodic auto-cycle only while it's enabled.
+  tick(): void {
+    if (this._periodicZoomChange) this.advancePeriodic();
+  }
+
+  advancePeriodic(): void {
+    const viewState = this._viewState;
+    if (!viewState) return;
+    const prevWidth = viewState.width;
+    const next = viewState.zoomLevel >= this._periodicZoomMax ? MIN_ZOOM : viewState.zoomLevel + 1;
+    viewState.setZoomLevel(next);
+    this._apply(viewState, prevWidth);
+  }
+
+  startDrag(clientX: number, clientY: number): void {
+    this._viewState?.startDrag(clientX, clientY);
+  }
+
+  updateDrag(clientX: number, clientY: number, rect: DOMRect): void {
+    if (!this._viewState?.isDragging) return;
+    this._viewState.updateDrag(clientX, clientY, rect);
+    this._onViewBoxChange();
+  }
+
+  endDrag(): void {
+    this._viewState?.endDrag();
+  }
+
+  private _apply(viewState: ViewState, fromWidth: number): void {
+    if (this._animate && this._zoomAnimator) {
+      this._onChange();
+      this._zoomAnimator.animateTo(viewState.zoomLevel, fromWidth, () => this._onChange());
+    } else {
+      this._onChange();
+    }
+  }
+}

--- a/test/card/card.test.ts
+++ b/test/card/card.test.ts
@@ -815,8 +815,8 @@ describe("SolarViewCard", () => {
     it("Today button recenters the sun after panning", () => {
       const card = createAndMount();
       const centered = parseViewBox(card);
-      card._viewState.centerX += 150;
-      card._viewState.centerY -= 75;
+      card._zoom.panZoomState.centerX += 150;
+      card._zoom.panZoomState.centerY -= 75;
       clickButton(card, "today");
       const after = parseViewBox(card);
       expect(after.minX).toBe(centered.minX);
@@ -922,13 +922,13 @@ describe("SolarViewCard", () => {
     it("defaults to false when not set", () => {
       const card = document.createElement("ha-planetary-solar-system-card-test");
       card.setConfig({});
-      expect(card._periodicZoomChange).toBe(false);
+      expect(card._zoom.periodicZoomChange).toBe(false);
     });
 
     it("is true when configured as true", () => {
       const card = document.createElement("ha-planetary-solar-system-card-test");
       card.setConfig({ periodic_zoom_change: true });
-      expect(card._periodicZoomChange).toBe(true);
+      expect(card._zoom.periodicZoomChange).toBe(true);
     });
   });
 
@@ -1050,13 +1050,13 @@ describe("SolarViewCard", () => {
     it("defaults to MAX_ZOOM for invalid periodic_zoom_max values", () => {
       const card = document.createElement("ha-planetary-solar-system-card-test");
       card.setConfig({ periodic_zoom_max: "abc" });
-      expect(card._periodicZoomMax).toBe(4);
+      expect(card._zoom.periodicZoomMax).toBe(4);
       card.setConfig({ periodic_zoom_max: 2.5 });
-      expect(card._periodicZoomMax).toBe(4);
+      expect(card._zoom.periodicZoomMax).toBe(4);
       card.setConfig({ periodic_zoom_max: 1 });
-      expect(card._periodicZoomMax).toBe(4);
+      expect(card._zoom.periodicZoomMax).toBe(4);
       card.setConfig({ periodic_zoom_max: 5 });
-      expect(card._periodicZoomMax).toBe(4);
+      expect(card._zoom.periodicZoomMax).toBe(4);
     });
 
     it("has no effect when periodic_zoom_change is false", () => {
@@ -1102,24 +1102,19 @@ describe("SolarViewCard", () => {
       expect(() => card._updateViewBox()).not.toThrow();
     });
 
-    it("_applyZoom is safe when shadow DOM has no .zoom-level element", () => {
+    it("_zoom.advancePeriodic is a no-op before the view is initialized", () => {
       const card = document.createElement("ha-planetary-solar-system-card-test");
-      expect(() => card._applyZoom(800, 800)).not.toThrow();
+      expect(() => card._zoom.advancePeriodic()).not.toThrow();
     });
 
-    it("_advanceZoom is a no-op when _viewState is null", () => {
+    it("_zoom.zoomIn is a no-op before the view is initialized", () => {
       const card = document.createElement("ha-planetary-solar-system-card-test");
-      expect(() => card._advanceZoom()).not.toThrow();
+      expect(() => card._zoom.zoomIn()).not.toThrow();
     });
 
-    it("_zoomIn is a no-op when _viewState is null", () => {
+    it("_zoom.zoomOut is a no-op before the view is initialized", () => {
       const card = document.createElement("ha-planetary-solar-system-card-test");
-      expect(() => card._zoomIn()).not.toThrow();
-    });
-
-    it("_zoomOut is a no-op when _viewState is null", () => {
-      const card = document.createElement("ha-planetary-solar-system-card-test");
-      expect(() => card._zoomOut()).not.toThrow();
+      expect(() => card._zoom.zoomOut()).not.toThrow();
     });
 
     it("disconnectedCallback is safe before connectedCallback", () => {
@@ -1149,9 +1144,9 @@ describe("SolarViewCard", () => {
     it("pointermove before pointerdown is a no-op", () => {
       const card = createAndMount();
       const svg = card.shadowRoot.querySelector("#solar-view svg");
-      const centerBefore = card._viewState.centerX;
+      const centerBefore = card._zoom.panZoomState.centerX;
       svg.dispatchEvent(new PointerEvent("pointermove", { clientX: 300, clientY: 300 }));
-      expect(card._viewState.centerX).toBe(centerBefore);
+      expect(card._zoom.panZoomState.centerX).toBe(centerBefore);
       card.remove();
     });
 
@@ -1161,7 +1156,7 @@ describe("SolarViewCard", () => {
       svg.releasePointerCapture = () => {};
       // Should not throw and dragging flag stays false
       svg.dispatchEvent(new PointerEvent("pointerup", { clientX: 300, clientY: 300 }));
-      expect(card._viewState.isDragging).toBe(false);
+      expect(card._zoom.isDragging).toBe(false);
       card.remove();
     });
   });
@@ -1194,7 +1189,7 @@ describe("SolarViewCard", () => {
       svg.setPointerCapture = () => {};
       svg.releasePointerCapture = () => {};
       svg.dispatchEvent(downEvent);
-      expect(card._viewState.isDragging).toBe(true);
+      expect(card._zoom.isDragging).toBe(true);
 
       // Simulate pointerup — should end drag
       const upEvent = new PointerEvent("pointerup", {
@@ -1203,7 +1198,7 @@ describe("SolarViewCard", () => {
         pointerId: 1,
       });
       svg.dispatchEvent(upEvent);
-      expect(card._viewState.isDragging).toBe(false);
+      expect(card._zoom.isDragging).toBe(false);
       card.remove();
     });
 
@@ -1215,7 +1210,10 @@ describe("SolarViewCard", () => {
       // Mock getBoundingClientRect
       svg.getBoundingClientRect = () => ({ width: 400, height: 400, x: 0, y: 0, top: 0, left: 0 });
 
-      const centerBefore = { x: card._viewState.centerX, y: card._viewState.centerY };
+      const centerBefore = {
+        x: card._zoom.panZoomState.centerX,
+        y: card._zoom.panZoomState.centerY,
+      };
 
       svg.dispatchEvent(
         new PointerEvent("pointerdown", { clientX: 200, clientY: 200, pointerId: 1 })
@@ -1225,7 +1223,7 @@ describe("SolarViewCard", () => {
       );
 
       // Dragging right should decrease centerX (content moves right)
-      expect(card._viewState.centerX).toBeLessThan(centerBefore.x);
+      expect(card._zoom.panZoomState.centerX).toBeLessThan(centerBefore.x);
 
       svg.dispatchEvent(
         new PointerEvent("pointerup", { clientX: 250, clientY: 200, pointerId: 1 })
@@ -1391,13 +1389,13 @@ describe("SolarViewCard", () => {
     it("defaults to true when not set", () => {
       const card = document.createElement("ha-planetary-solar-system-card-test");
       card.setConfig({});
-      expect(card._zoomAnimate).toBe(true);
+      expect(card._zoom.animate).toBe(true);
     });
 
     it("is false when configured as false", () => {
       const card = document.createElement("ha-planetary-solar-system-card-test");
       card.setConfig({ zoom_animate: false });
-      expect(card._zoomAnimate).toBe(false);
+      expect(card._zoom.animate).toBe(false);
     });
 
     it("zoom is instant when zoom_animate is false", () => {
@@ -1434,7 +1432,7 @@ describe("SolarViewCard", () => {
       document.body.appendChild(card);
       expect(parseViewBox(card).width).toBe(800);
       // Reconfigure with new default zoom — should re-render instantly
-      card._viewState = null; // force fresh ViewState on next render
+      card._zoom.reset(); // force fresh ViewState on next render
       card.setConfig({ zoom_animate: true, default_zoom: 3 });
       card._render();
       expect(parseViewBox(card).width).toBe(480);

--- a/test/card/zoom-controller.test.ts
+++ b/test/card/zoom-controller.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from "vitest";
+import { ZoomController } from "../../src/card/zoom-controller.js";
+
+describe("ZoomController before initialization", () => {
+  it("reports safe defaults", () => {
+    const zoom = new ZoomController(
+      () => {},
+      () => {}
+    );
+    expect(zoom.zoomLevel).toBeNull();
+    expect(zoom.panZoomState).toBeNull();
+    expect(zoom.viewBox).toBeNull();
+    expect(zoom.isDragging).toBe(false);
+  });
+
+  it("displayZoomLevel falls back to the configured default", () => {
+    const zoom = new ZoomController(
+      () => {},
+      () => {}
+    );
+    zoom.configure(3, false, 4, false);
+    expect(zoom.displayZoomLevel).toBe(3);
+  });
+
+  it("zoomIn/zoomOut/advancePeriodic/recenter/startDrag/endDrag are no-ops", () => {
+    const onChange = vi.fn();
+    const onViewBoxChange = vi.fn();
+    const zoom = new ZoomController(onChange, onViewBoxChange);
+    expect(() => {
+      zoom.zoomIn();
+      zoom.zoomOut();
+      zoom.advancePeriodic();
+      zoom.recenter();
+      zoom.startDrag(0, 0);
+      zoom.endDrag();
+    }).not.toThrow();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("updateDrag is a no-op when never dragging", () => {
+    const onViewBoxChange = vi.fn();
+    const zoom = new ZoomController(() => {}, onViewBoxChange);
+    zoom.updateDrag(10, 10, { width: 400 } as DOMRect);
+    expect(onViewBoxChange).not.toHaveBeenCalled();
+  });
+});
+
+describe("ZoomController.ensureInitialized", () => {
+  it("builds the view at the configured default zoom, once", () => {
+    const zoom = new ZoomController(
+      () => {},
+      () => {}
+    );
+    zoom.configure(2, false, 4, false);
+    zoom.ensureInitialized();
+    expect(zoom.zoomLevel).toBe(2);
+    zoom.configure(4, false, 4, false); // shouldn't rebuild an already-initialized view
+    zoom.ensureInitialized();
+    expect(zoom.zoomLevel).toBe(2);
+  });
+
+  it("reset() forces the next ensureInitialized() to rebuild at the current default", () => {
+    const zoom = new ZoomController(
+      () => {},
+      () => {}
+    );
+    zoom.configure(1, false, 4, false);
+    zoom.ensureInitialized();
+    expect(zoom.zoomLevel).toBe(1);
+    zoom.configure(3, false, 4, false);
+    zoom.reset();
+    zoom.ensureInitialized();
+    expect(zoom.zoomLevel).toBe(3);
+  });
+});
+
+describe("ZoomController zoom actions", () => {
+  it("zoomIn/zoomOut change level and notify onChange, clamped at the bounds", () => {
+    const onChange = vi.fn();
+    const zoom = new ZoomController(onChange, () => {});
+    zoom.configure(1, false, 4, false);
+    zoom.ensureInitialized();
+
+    zoom.zoomIn();
+    expect(zoom.zoomLevel).toBe(2);
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    zoom.zoomOut();
+    expect(zoom.zoomLevel).toBe(1);
+    zoom.zoomOut(); // already at the minimum
+    expect(zoom.zoomLevel).toBe(1);
+    expect(onChange).toHaveBeenCalledTimes(2); // the no-op zoomOut doesn't notify
+  });
+
+  it("advancePeriodic cycles up to periodicZoomMax then wraps to the minimum", () => {
+    const zoom = new ZoomController(
+      () => {},
+      () => {}
+    );
+    zoom.configure(1, true, 3, false);
+    zoom.ensureInitialized();
+
+    zoom.advancePeriodic();
+    expect(zoom.zoomLevel).toBe(2);
+    zoom.advancePeriodic();
+    expect(zoom.zoomLevel).toBe(3);
+    zoom.advancePeriodic();
+    expect(zoom.zoomLevel).toBe(1);
+  });
+
+  it("tick advances only when periodicZoomChange is enabled", () => {
+    const zoom = new ZoomController(
+      () => {},
+      () => {}
+    );
+    zoom.configure(1, false, 4, false);
+    zoom.ensureInitialized();
+    zoom.tick();
+    expect(zoom.zoomLevel).toBe(1);
+
+    zoom.configure(1, true, 4, false);
+    zoom.tick();
+    expect(zoom.zoomLevel).toBe(2);
+  });
+
+  it("animates via requestAnimationFrame when animate is enabled", () => {
+    const rafSpy = vi.spyOn(globalThis, "requestAnimationFrame").mockReturnValue(1);
+    const zoom = new ZoomController(
+      () => {},
+      () => {}
+    );
+    zoom.configure(1, false, 4, true);
+    zoom.ensureInitialized();
+    zoom.zoomIn();
+    expect(rafSpy).toHaveBeenCalled();
+    rafSpy.mockRestore();
+  });
+});
+
+describe("ZoomController drag lifecycle", () => {
+  it("startDrag/updateDrag/endDrag update panZoomState and notify onViewBoxChange", () => {
+    const onViewBoxChange = vi.fn();
+    const zoom = new ZoomController(() => {}, onViewBoxChange);
+    zoom.ensureInitialized();
+    const before = { x: zoom.panZoomState?.centerX, y: zoom.panZoomState?.centerY };
+
+    zoom.startDrag(200, 200);
+    zoom.updateDrag(250, 200, { width: 400, height: 400, x: 0, y: 0 } as DOMRect);
+    expect(onViewBoxChange).toHaveBeenCalledTimes(1);
+    expect(zoom.panZoomState?.centerX).not.toBe(before.x);
+
+    zoom.endDrag();
+    expect(zoom.isDragging).toBe(false);
+  });
+
+  it("recenter resets pan without changing zoom level", () => {
+    const zoom = new ZoomController(
+      () => {},
+      () => {}
+    );
+    zoom.ensureInitialized();
+    zoom.startDrag(0, 0);
+    zoom.updateDrag(100, 0, { width: 400, height: 400, x: 0, y: 0 } as DOMRect);
+    zoom.endDrag();
+    const zoomLevelBefore = zoom.zoomLevel;
+    zoom.recenter();
+    expect(zoom.zoomLevel).toBe(zoomLevelBefore);
+  });
+});


### PR DESCRIPTION
## Summary
- Pan/zoom (the `ViewState`+`ZoomAnimator` pair, periodic auto-cycle config, drag math) was 6 fields and 5 methods spread through card.ts.
- New `ZoomController` (`src/card/zoom-controller.ts`) owns all of it behind `zoomIn`/`zoomOut`/`advancePeriodic`/`tick`/`recenter`/`startDrag`/`updateDrag`/`endDrag`.
- card.ts keeps only the DOM-touching half — querying `#solar-view svg` and setting the `viewBox` attribute — since that's tied to Lit's render lifecycle, same split as `GalleryController` before it.
- Two callbacks passed to the controller, matching two different costs: `onChange` requests a full Lit re-render (zoom level changed), `onViewBoxChange` is cheap and fires on every drag/animation frame.

## Test plan
- [x] `npm run test:coverage` — 626 tests, 100% statements/branches/functions/lines
- [x] `npm run check:ci` — typecheck + biome + prettier clean
- [x] New `test/card/zoom-controller.test.ts` exercises the controller standalone (no DOM)
- [x] `test/card/card.test.ts` updated to go through `card._zoom` instead of the removed private fields/methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)