### PR TITLE
refactor: extract config parsing and theme resolution from card.ts

### DIFF
--- a/src/card/card-config.ts
+++ b/src/card/card-config.ts
@@ -1,0 +1,101 @@
+import type { CardConfig, Colors, ZoomLevel } from "../types.js";
+import { DEFAULT_ZOOM_LEVEL, MAX_ZOOM, MIN_ZOOM } from "./card-view-state.js";
+import type { GalleryMode } from "./gallery-controller.js";
+import { DEFAULT_GALLERY_INTERVAL_MS, GALLERY_MODES } from "./gallery-controller.js";
+
+export interface ParsedCardConfig {
+  zoomLevel: ZoomLevel;
+  refreshMs: number;
+  periodicZoomChange: boolean;
+  periodicZoomMax: number;
+  zoomAnimate: boolean;
+  colors: Colors;
+  theme: "auto" | "dark" | "light";
+  eclipticView: boolean;
+  locationOverride: { lat: number; lon: number } | null;
+  locationNameOverride: string | null;
+  heightStyle: string;
+  galleryMode: GalleryMode;
+  galleryIntervalMs: number;
+}
+
+// Resolves config.height into an inline style for #solar-view/.image-view. A px value caps
+// the height and lets the square SVG/image letterbox-shrink to fit (preserveAspectRatio
+// "meet" — nothing crops). A percent reshapes the aspect-ratio itself (e.g. "50%" = half as
+// tall as wide) since CSS max-height can't resolve against an auto-height parent.
+function resolveHeightStyle(height: CardConfig["height"]): string {
+  if (typeof height === "number") {
+    return height > 0 ? `max-height: ${height}px` : "";
+  }
+  if (typeof height === "string") {
+    const px = /^(\d+(?:\.\d+)?)px$/.exec(height);
+    if (px) return `max-height: ${px[1]}px`;
+    const pct = /^(\d+(?:\.\d+)?)%$/.exec(height);
+    if (pct) {
+      const n = Number(pct[1]);
+      return n > 0 ? `aspect-ratio: ${100 / n}` : "";
+    }
+  }
+  return "";
+}
+
+// Pure validate/default pass over CardConfig — the single place each field's fallback and
+// range-check rule lives. card.ts's setConfig hands the result straight to _zoom.configure()/
+// _gallery.configure() and its own remaining fields, instead of parsing inline.
+export function parseCardConfig(config: CardConfig): ParsedCardConfig {
+  const zoomLevel =
+    config.default_zoom == null || config.default_zoom < MIN_ZOOM || config.default_zoom > MAX_ZOOM
+      ? DEFAULT_ZOOM_LEVEL
+      : (config.default_zoom as ZoomLevel);
+
+  const rawRefresh = Number(config.refresh_mins);
+  const refreshMs = Number.isFinite(rawRefresh) && rawRefresh >= 0.1 ? rawRefresh * 60000 : 60000;
+
+  const periodicZoomChange = config.periodic_zoom_change === true;
+  const rawMax = Number(config.periodic_zoom_max);
+  const periodicZoomMax =
+    Number.isInteger(rawMax) && rawMax >= 2 && rawMax <= MAX_ZOOM ? rawMax : MAX_ZOOM;
+  const zoomAnimate = config.zoom_animate !== false;
+
+  const theme = config.theme === "dark" || config.theme === "light" ? config.theme : "auto";
+  const eclipticView = config.ecliptic_view === "south";
+
+  const overrideLat = config.location?.latitude;
+  const overrideLon = config.location?.longitude;
+  const hasOverride =
+    typeof overrideLat === "number" &&
+    typeof overrideLon === "number" &&
+    overrideLat >= -90 &&
+    overrideLat <= 90 &&
+    overrideLon >= -180 &&
+    overrideLon <= 180;
+  const locationOverride = hasOverride ? { lat: overrideLat, lon: overrideLon } : null;
+  const locationNameOverride = config.location?.name || null;
+
+  const heightStyle = resolveHeightStyle(config.height);
+
+  const galleryMode = GALLERY_MODES.includes(config.gallery?.mode as GalleryMode)
+    ? (config.gallery?.mode as GalleryMode)
+    : "none";
+  const rawInterval = Number(config.gallery?.slide_interval_secs);
+  const galleryIntervalMs =
+    Number.isFinite(rawInterval) && rawInterval >= 0.1
+      ? rawInterval * 1000
+      : DEFAULT_GALLERY_INTERVAL_MS;
+
+  return {
+    zoomLevel,
+    refreshMs,
+    periodicZoomChange,
+    periodicZoomMax,
+    zoomAnimate,
+    colors: config.colors ?? {},
+    theme,
+    eclipticView,
+    locationOverride,
+    locationNameOverride,
+    heightStyle,
+    galleryMode,
+    galleryIntervalMs,
+  };
+}

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -9,67 +9,18 @@ import type {
   PanZoomState,
   ZoomLevel,
 } from "../types.js";
+import { parseCardConfig } from "./card-config.js";
 import { cardStyles } from "./card-styles.js";
 import type { ImageSource } from "./card-template.js";
 import { buildImageStatusBar, buildStatusBar, GALLERY_SOURCE_LABELS } from "./card-template.js";
-import { DEFAULT_ZOOM_LEVEL, MAX_ZOOM, MIN_ZOOM } from "./card-view-state.js";
 import { DateNav } from "./date-nav.js";
 import type { GalleryMode } from "./gallery-controller.js";
-import {
-  DEFAULT_GALLERY_INTERVAL_MS,
-  GALLERY_MODES,
-  GalleryController,
-} from "./gallery-controller.js";
+import { GalleryController } from "./gallery-controller.js";
 import { formatRelativeAge } from "./relative-time.js";
+import { resolveTheme, THEME_OVERRIDE_VARS } from "./theme.js";
 import { ZoomController } from "./zoom-controller.js";
 
 export type { GalleryMode };
-
-// Built-in background+text pairs for `theme: "dark" | "light"` — forces every currentColor-
-// derived accent (orbit, labels, twilight cones, needle, ...) to a consistent palette
-// regardless of the HA theme actually installed. `colors.background` still overrides the
-// background half, matching how colors.* already layers on top elsewhere.
-const THEME_PALETTES: Record<"dark" | "light", { background: string; color: string }> = {
-  dark: { background: "#1c1c1c", color: "#e1e1e1" },
-  light: { background: "#ffffff", color: "#212121" },
-};
-
-// card-styles.ts leans on these HA custom properties (status-bar/nav backgrounds, borders)
-// with a currentColor-based fallback for when HA doesn't define them. But HA always defines
-// them — from whichever theme is actually installed — and custom properties pierce the shadow
-// boundary, so a forced dark/light `theme:` only overriding :host's plain background/color
-// still left every var(--secondary-background-color, ...) etc. resolving to the real (possibly
-// mismatched) HA theme's value instead of the intended fallback. Setting each to the CSS-wide
-// keyword "initial" makes it the custom property's guaranteed-invalid value, which is exactly
-// what makes var()'s fallback kick in.
-const THEME_OVERRIDE_VARS = [
-  "--ha-card-background",
-  "--card-background-color",
-  "--primary-background-color",
-  "--primary-text-color",
-  "--secondary-background-color",
-  "--divider-color",
-];
-
-// Resolves config.height into an inline style for #solar-view/.image-view. A px value caps
-// the height and lets the square SVG/image letterbox-shrink to fit (preserveAspectRatio
-// "meet" — nothing crops). A percent reshapes the aspect-ratio itself (e.g. "50%" = half as
-// tall as wide) since CSS max-height can't resolve against an auto-height parent.
-function resolveHeightStyle(height: CardConfig["height"]): string {
-  if (typeof height === "number") {
-    return height > 0 ? `max-height: ${height}px` : "";
-  }
-  if (typeof height === "string") {
-    const px = /^(\d+(?:\.\d+)?)px$/.exec(height);
-    if (px) return `max-height: ${px[1]}px`;
-    const pct = /^(\d+(?:\.\d+)?)%$/.exec(height);
-    if (pct) {
-      const n = Number(pct[1]);
-      return n > 0 ? `aspect-ratio: ${100 / n}` : "";
-    }
-  }
-  return "";
-}
 
 // HASS and config.location update independently (hass setter vs. setConfig), so each source
 // is kept as one grouped field rather than losing either one to an eager merge — _locationData
@@ -99,9 +50,6 @@ export class SolarViewCard extends LitElement {
   private _refreshMs: number;
   private _eclipticView: boolean;
   private _theme: "auto" | "dark" | "light";
-  private get _themePalette(): { background: string; color: string } | null {
-    return this._theme === "auto" ? null : THEME_PALETTES[this._theme];
-  }
   private _heightStyle: string;
   private _updateMarkers: ((viewState: PanZoomState) => void) | null;
   private _onVisibilityChange: (() => void) | null;
@@ -168,50 +116,22 @@ export class SolarViewCard extends LitElement {
 
   setConfig(config: CardConfig): void {
     this._config = config;
-    const defaultZoomLevel =
-      config.default_zoom == null ||
-      config.default_zoom < MIN_ZOOM ||
-      config.default_zoom > MAX_ZOOM
-        ? DEFAULT_ZOOM_LEVEL
-        : (config.default_zoom as ZoomLevel);
+    const parsed = parseCardConfig(config);
 
-    const rawRefresh = Number(config.refresh_mins);
-    this._refreshMs = Number.isFinite(rawRefresh) && rawRefresh >= 0.1 ? rawRefresh * 60000 : 60000;
-
-    const periodicZoomChange = config.periodic_zoom_change === true;
-    const rawMax = Number(config.periodic_zoom_max);
-    const periodicZoomMax =
-      Number.isInteger(rawMax) && rawMax >= 2 && rawMax <= MAX_ZOOM ? rawMax : MAX_ZOOM;
-    const zoomAnimate = config.zoom_animate !== false;
-    this._zoom.configure(defaultZoomLevel, periodicZoomChange, periodicZoomMax, zoomAnimate);
-
-    this._colors = config.colors ?? {};
-    this._theme = config.theme === "dark" || config.theme === "light" ? config.theme : "auto";
-
-    this._eclipticView = config.ecliptic_view === "south";
-
-    const overrideLat = config.location?.latitude;
-    const overrideLon = config.location?.longitude;
-    const hasOverride =
-      typeof overrideLat === "number" &&
-      typeof overrideLon === "number" &&
-      overrideLat >= -90 &&
-      overrideLat <= 90 &&
-      overrideLon >= -180 &&
-      overrideLon <= 180;
-    this._locationOverride = hasOverride ? { lat: overrideLat, lon: overrideLon } : null;
-    this._locationNameOverride = config.location?.name || null;
-    this._heightStyle = resolveHeightStyle(config.height);
-
-    const galleryMode = GALLERY_MODES.includes(config.gallery?.mode as GalleryMode)
-      ? (config.gallery?.mode as GalleryMode)
-      : "none";
-    const rawInterval = Number(config.gallery?.slide_interval_secs);
-    const galleryAutoIntervalMs =
-      Number.isFinite(rawInterval) && rawInterval >= 0.1
-        ? rawInterval * 1000
-        : DEFAULT_GALLERY_INTERVAL_MS;
-    this._gallery.configure(galleryMode, galleryAutoIntervalMs);
+    this._zoom.configure(
+      parsed.zoomLevel,
+      parsed.periodicZoomChange,
+      parsed.periodicZoomMax,
+      parsed.zoomAnimate
+    );
+    this._refreshMs = parsed.refreshMs;
+    this._colors = parsed.colors;
+    this._theme = parsed.theme;
+    this._eclipticView = parsed.eclipticView;
+    this._locationOverride = parsed.locationOverride;
+    this._locationNameOverride = parsed.locationNameOverride;
+    this._heightStyle = parsed.heightStyle;
+    this._gallery.configure(parsed.galleryMode, parsed.galleryIntervalMs);
 
     if (this._autoUpdateTimer != null) {
       this._startAutoUpdateTimer();
@@ -264,12 +184,10 @@ export class SolarViewCard extends LitElement {
             this._gallery.imageLoaded
           );
     const zoomLevel = this._zoom.displayZoomLevel;
-    /* v8 ignore next */
-    const background = this._colors.background ?? this._themePalette?.background ?? "";
-    const color = this._themePalette?.color ?? "";
+    const theme = resolveTheme(this._theme, this._colors.background);
 
     return html`
-      <div class="card" style="background: ${background}; color: ${color}">
+      <div class="card" style="background: ${theme.background}; color: ${theme.color}">
         <div class="solar-view-wrapper">
           ${statusBar}
           <div
@@ -381,14 +299,14 @@ export class SolarViewCard extends LitElement {
     }
 
     this._updateViewBox();
-    /* v8 ignore next */
-    this.style.background = this._colors.background ?? this._themePalette?.background ?? "";
-    this.style.color = this._themePalette?.color ?? "";
+    const theme = resolveTheme(this._theme, this._colors.background);
+    this.style.background = theme.background;
+    this.style.color = theme.color;
     for (const varName of THEME_OVERRIDE_VARS) {
-      if (this._themePalette) {
-        this.style.setProperty(varName, "initial");
-      } else {
+      if (theme.vars[varName] === null) {
         this.style.removeProperty(varName);
+      } else {
+        this.style.setProperty(varName, theme.vars[varName]);
       }
     }
   }

--- a/src/card/theme.ts
+++ b/src/card/theme.ts
@@ -1,0 +1,51 @@
+// Built-in background+text pairs for `theme: "dark" | "light"` — forces every currentColor-
+// derived accent (orbit, labels, twilight cones, needle, ...) to a consistent palette
+// regardless of the HA theme actually installed. `colors.background` still overrides the
+// background half, matching how colors.* already layers on top elsewhere.
+const THEME_PALETTES: Record<"dark" | "light", { background: string; color: string }> = {
+  dark: { background: "#1c1c1c", color: "#e1e1e1" },
+  light: { background: "#ffffff", color: "#212121" },
+};
+
+// card-styles.ts leans on these HA custom properties (status-bar/nav backgrounds, borders)
+// with a currentColor-based fallback for when HA doesn't define them. But HA always defines
+// them — from whichever theme is actually installed — and custom properties pierce the shadow
+// boundary, so a forced dark/light `theme:` only overriding :host's plain background/color
+// still left every var(--secondary-background-color, ...) etc. resolving to the real (possibly
+// mismatched) HA theme's value instead of the intended fallback. Setting each to the CSS-wide
+// keyword "initial" makes it the custom property's guaranteed-invalid value, which is exactly
+// what makes var()'s fallback kick in.
+export const THEME_OVERRIDE_VARS = [
+  "--ha-card-background",
+  "--card-background-color",
+  "--primary-background-color",
+  "--primary-text-color",
+  "--secondary-background-color",
+  "--divider-color",
+];
+
+export interface ResolvedTheme {
+  background: string;
+  color: string;
+  // null = clear the property (auto theme); "initial" = force it, per THEME_OVERRIDE_VARS above.
+  vars: Record<string, string | null>;
+}
+
+// Pure mapping from a card's theme + colors.background override to what should actually be
+// painted — computed once and shared by render() (inline style attribute) and updated()
+// (this.style.* + custom properties), instead of re-deriving the same palette in both places.
+export function resolveTheme(
+  theme: "auto" | "dark" | "light",
+  colorsBackground: string | undefined
+): ResolvedTheme {
+  const palette = theme === "auto" ? null : THEME_PALETTES[theme];
+  const vars: Record<string, string | null> = {};
+  for (const name of THEME_OVERRIDE_VARS) {
+    vars[name] = palette ? "initial" : null;
+  }
+  return {
+    background: colorsBackground ?? palette?.background ?? "",
+    color: palette?.color ?? "",
+    vars,
+  };
+}

--- a/test/card/card-config.test.ts
+++ b/test/card/card-config.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import { parseCardConfig } from "../../src/card/card-config.js";
+
+describe("parseCardConfig", () => {
+  it("applies all defaults for an empty config", () => {
+    const parsed = parseCardConfig({});
+    expect(parsed).toEqual({
+      zoomLevel: 1,
+      refreshMs: 60000,
+      periodicZoomChange: false,
+      periodicZoomMax: 4,
+      zoomAnimate: true,
+      colors: {},
+      theme: "auto",
+      eclipticView: false,
+      locationOverride: null,
+      locationNameOverride: null,
+      heightStyle: "",
+      galleryMode: "none",
+      galleryIntervalMs: 60000,
+    });
+  });
+
+  describe("zoomLevel", () => {
+    it("uses default_zoom when within range", () => {
+      expect(parseCardConfig({ default_zoom: 3 }).zoomLevel).toBe(3);
+    });
+    it("falls back to default when out of range", () => {
+      expect(parseCardConfig({ default_zoom: 0 }).zoomLevel).toBe(1);
+      expect(parseCardConfig({ default_zoom: 5 }).zoomLevel).toBe(1);
+    });
+  });
+
+  describe("refreshMs", () => {
+    it("converts refresh_mins to milliseconds", () => {
+      expect(parseCardConfig({ refresh_mins: 2 }).refreshMs).toBe(120000);
+    });
+    it("falls back to 60000 when invalid or too small", () => {
+      expect(parseCardConfig({ refresh_mins: 0 }).refreshMs).toBe(60000);
+      expect(parseCardConfig({ refresh_mins: Number.NaN }).refreshMs).toBe(60000);
+    });
+  });
+
+  describe("periodicZoomMax", () => {
+    it("uses periodic_zoom_max when a valid integer in range", () => {
+      expect(parseCardConfig({ periodic_zoom_max: 3 }).periodicZoomMax).toBe(3);
+    });
+    it("falls back to MAX_ZOOM when non-integer or out of range", () => {
+      expect(parseCardConfig({ periodic_zoom_max: 1.5 }).periodicZoomMax).toBe(4);
+      expect(parseCardConfig({ periodic_zoom_max: 1 }).periodicZoomMax).toBe(4);
+      expect(parseCardConfig({ periodic_zoom_max: 5 }).periodicZoomMax).toBe(4);
+    });
+  });
+
+  describe("periodicZoomChange / zoomAnimate", () => {
+    it("periodic_zoom_change defaults false, true only when === true", () => {
+      expect(
+        parseCardConfig({ periodic_zoom_change: "yes" as unknown as boolean }).periodicZoomChange
+      ).toBe(false);
+      expect(parseCardConfig({ periodic_zoom_change: true }).periodicZoomChange).toBe(true);
+    });
+    it("zoom_animate defaults true, false only when === false", () => {
+      expect(parseCardConfig({ zoom_animate: false }).zoomAnimate).toBe(false);
+      expect(parseCardConfig({}).zoomAnimate).toBe(true);
+    });
+  });
+
+  describe("theme", () => {
+    it("passes through dark/light, falls back to auto", () => {
+      expect(parseCardConfig({ theme: "dark" }).theme).toBe("dark");
+      expect(parseCardConfig({ theme: "light" }).theme).toBe("light");
+      expect(parseCardConfig({ theme: "purple" as unknown as "dark" }).theme).toBe("auto");
+    });
+  });
+
+  describe("eclipticView", () => {
+    it("true only when ecliptic_view === 'south'", () => {
+      expect(parseCardConfig({ ecliptic_view: "south" }).eclipticView).toBe(true);
+      expect(parseCardConfig({ ecliptic_view: "north" }).eclipticView).toBe(false);
+    });
+  });
+
+  describe("locationOverride", () => {
+    it("accepts a valid lat/lon pair", () => {
+      expect(
+        parseCardConfig({ location: { latitude: 10, longitude: 20 } }).locationOverride
+      ).toEqual({
+        lat: 10,
+        lon: 20,
+      });
+    });
+    it("rejects out-of-range or missing values", () => {
+      expect(
+        parseCardConfig({ location: { latitude: 91, longitude: 20 } }).locationOverride
+      ).toBeNull();
+      expect(
+        parseCardConfig({ location: { latitude: 10, longitude: 181 } }).locationOverride
+      ).toBeNull();
+      expect(parseCardConfig({ location: { latitude: 10 } }).locationOverride).toBeNull();
+    });
+    it("parses locationNameOverride independently", () => {
+      expect(parseCardConfig({ location: { name: "Home" } }).locationNameOverride).toBe("Home");
+    });
+  });
+
+  describe("heightStyle", () => {
+    it("resolves a px height", () => {
+      expect(parseCardConfig({ height: 400 }).heightStyle).toBe("max-height: 400px");
+    });
+    it("resolves a percent height", () => {
+      expect(parseCardConfig({ height: "50%" }).heightStyle).toBe("aspect-ratio: 2");
+    });
+  });
+
+  describe("gallery", () => {
+    it("uses a recognised gallery mode", () => {
+      expect(parseCardConfig({ gallery: { mode: "sun" } }).galleryMode).toBe("sun");
+    });
+    it("falls back to 'none' for an unrecognised mode", () => {
+      expect(parseCardConfig({ gallery: { mode: "bogus" } }).galleryMode).toBe("none");
+    });
+    it("converts slide_interval_secs to milliseconds", () => {
+      expect(parseCardConfig({ gallery: { slide_interval_secs: 5 } }).galleryIntervalMs).toBe(5000);
+    });
+    it("falls back to the default interval when invalid", () => {
+      expect(parseCardConfig({ gallery: { slide_interval_secs: 0 } }).galleryIntervalMs).toBe(
+        60000
+      );
+    });
+  });
+});

--- a/test/card/theme.test.ts
+++ b/test/card/theme.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { resolveTheme, THEME_OVERRIDE_VARS } from "../../src/card/theme.js";
+
+describe("resolveTheme", () => {
+  it("auto leaves background/color empty and clears override vars", () => {
+    const t = resolveTheme("auto", undefined);
+    expect(t.background).toBe("");
+    expect(t.color).toBe("");
+    for (const name of THEME_OVERRIDE_VARS) {
+      expect(t.vars[name]).toBeNull();
+    }
+  });
+
+  it("dark forces a dark background/text pair and sets override vars to 'initial'", () => {
+    const t = resolveTheme("dark", undefined);
+    expect(t.background).toBe("#1c1c1c");
+    expect(t.color).toBe("#e1e1e1");
+    for (const name of THEME_OVERRIDE_VARS) {
+      expect(t.vars[name]).toBe("initial");
+    }
+  });
+
+  it("light forces a light background/text pair", () => {
+    const t = resolveTheme("light", undefined);
+    expect(t.background).toBe("#ffffff");
+    expect(t.color).toBe("#212121");
+  });
+
+  it("colors.background overrides the forced theme's background but not color", () => {
+    const t = resolveTheme("dark", "#ff00ff");
+    expect(t.background).toBe("#ff00ff");
+    expect(t.color).toBe("#e1e1e1");
+  });
+});


### PR DESCRIPTION
## Summary
- Extract `setConfig`'s 6 independent validation rules into a pure `parseCardConfig()` in `src/card/card-config.ts` (mirrors the existing `resolveHeightStyle` treatment).
- Extract the theme background/color/CSS-var computation — previously duplicated between `render()` and `updated()` — into a pure `resolveTheme()` in `src/card/theme.ts`.
- `card.ts` net -82 lines; `setConfig` shrinks to parse + assign.

## Test plan
- [x] `npm run test:coverage` — 650/650 pass, 100% coverage
- [x] `npm run check:ci` — typecheck + biome + prettier clean
- [x] New unit tests for `parseCardConfig` and `resolveTheme` exercise logic without mounting the full card

🤖 Generated with [Claude Code](https://claude.com/claude-code)