### PR TITLE
refactor: extract SolarView to own the SVG seam in card.ts

### DIFF
--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -1,12 +1,10 @@
 import { html, LitElement, nothing } from "lit";
-import { renderSolarSystem } from "../renderer/index.js";
 import type {
   CardConfig,
   Colors,
   HASSConfig,
   Hemisphere,
   LocationData,
-  PanZoomState,
   ZoomLevel,
 } from "../types.js";
 import { parseCardConfig } from "./card-config.js";
@@ -17,6 +15,7 @@ import { DateNav } from "./date-nav.js";
 import type { GalleryMode } from "./gallery-controller.js";
 import { GalleryController } from "./gallery-controller.js";
 import { formatRelativeAge } from "./relative-time.js";
+import { SolarView } from "./solar-view.js";
 import { resolveTheme, THEME_OVERRIDE_VARS } from "./theme.js";
 import { ZoomController } from "./zoom-controller.js";
 
@@ -51,7 +50,7 @@ export class SolarViewCard extends LitElement {
   private _eclipticView: boolean;
   private _theme: "auto" | "dark" | "light";
   private _heightStyle: string;
-  private _updateMarkers: ((viewState: PanZoomState) => void) | null;
+  private _solarView: SolarView;
   private _onVisibilityChange: (() => void) | null;
   private _gallery: GalleryController;
   _config: CardConfig | undefined;
@@ -61,7 +60,7 @@ export class SolarViewCard extends LitElement {
     this._dateNav = new DateNav(() => this._render());
     this._zoom = new ZoomController(
       () => this._render(),
-      () => this._updateViewBox()
+      () => this._solarView.applyViewState()
     );
     this._hemisphere = "north";
     this._hassLocation = { lat: null, lon: null, timezone: null, name: null };
@@ -73,7 +72,7 @@ export class SolarViewCard extends LitElement {
     this._eclipticView = false;
     this._theme = "auto";
     this._heightStyle = "";
-    this._updateMarkers = null;
+    this._solarView = new SolarView(this._zoom);
     this._onVisibilityChange = null;
     this._gallery = new GalleryController(() => this._render());
   }
@@ -285,20 +284,17 @@ export class SolarViewCard extends LitElement {
     const container = (this.shadowRoot as ShadowRoot).getElementById("solar-view");
     /* v8 ignore next */
     if (container) {
-      while (container.firstChild) container.removeChild(container.firstChild);
-      const { svg, updateMarkers } = renderSolarSystem(
+      this._solarView.mount(
+        container,
         this._dateNav.currentDate,
         this._hemisphere,
         this._locationData,
         this._colors,
         this._eclipticView
       );
-      this._updateMarkers = updateMarkers;
-      container.appendChild(svg);
-      this._bindSvgEvents(svg);
     }
 
-    this._updateViewBox();
+    this._solarView.applyViewState();
     const theme = resolveTheme(this._theme, this._colors.background);
     this.style.background = theme.background;
     this.style.color = theme.color;
@@ -353,38 +349,6 @@ export class SolarViewCard extends LitElement {
     this._dateNav.goLive();
   }
 
-  private _updateViewBox(): void {
-    const panZoomState = this._zoom.panZoomState;
-    if (!panZoomState) return;
-    const svg = (this.shadowRoot as ShadowRoot).querySelector(
-      "#solar-view svg"
-    ) as SVGSVGElement | null;
-    if (svg) svg.setAttribute("viewBox", this._zoom.viewBox as string);
-    this._updateMarkers?.(panZoomState);
-  }
-
-  private _onPointerDown(e: PointerEvent): void {
-    const svg = e.currentTarget as SVGSVGElement;
-    svg.setPointerCapture(e.pointerId);
-    this._zoom.startDrag(e.clientX, e.clientY);
-    svg.style.cursor = "grabbing";
-  }
-
-  private _onPointerMove(e: PointerEvent): void {
-    if (!this._zoom.isDragging) return;
-    const svg = e.currentTarget as SVGSVGElement;
-    const rect = svg.getBoundingClientRect();
-    this._zoom.updateDrag(e.clientX, e.clientY, rect);
-  }
-
-  private _onPointerUp(e: PointerEvent): void {
-    if (!this._zoom.isDragging) return;
-    this._zoom.endDrag();
-    const svg = e.currentTarget as SVGSVGElement;
-    svg.releasePointerCapture(e.pointerId);
-    svg.style.cursor = "grab";
-  }
-
   private _onNavClick(e: Event): void {
     this._handleNavAction((e.currentTarget as HTMLButtonElement).dataset.action);
   }
@@ -392,12 +356,6 @@ export class SolarViewCard extends LitElement {
   private _onGalleryClick(e: Event): void {
     const source = (e.currentTarget as HTMLButtonElement).dataset.source as ImageSource;
     this._gallery.openPanel(source);
-  }
-
-  private _bindSvgEvents(svg: SVGSVGElement): void {
-    svg.addEventListener("pointerdown", (e) => this._onPointerDown(e));
-    svg.addEventListener("pointermove", (e) => this._onPointerMove(e));
-    svg.addEventListener("pointerup", (e) => this._onPointerUp(e));
   }
 
   private _handleNavAction(action: string | undefined): void {

--- a/src/card/solar-view.ts
+++ b/src/card/solar-view.ts
@@ -1,0 +1,77 @@
+import { renderSolarSystem } from "../renderer/index.js";
+import type { Colors, Hemisphere, LocationData, PanZoomState } from "../types.js";
+import type { ZoomController } from "./zoom-controller.js";
+
+/**
+ * Owns the #solar-view SVG end to end: mounting a freshly rendered scene, applying pan/zoom
+ * state (viewBox + offscreen markers), and driving drag via the given ZoomController. Callers
+ * never touch the SVG's DOM shape directly — see the leaked-seam finding this replaces.
+ */
+export class SolarView {
+  private _zoom: ZoomController;
+  private _svg: SVGSVGElement | null;
+  private _updateMarkers: ((viewState: PanZoomState) => void) | null;
+
+  constructor(zoom: ZoomController) {
+    this._zoom = zoom;
+    this._svg = null;
+    this._updateMarkers = null;
+  }
+
+  mount(
+    container: HTMLElement,
+    date: Date,
+    hemisphere: Hemisphere,
+    locationData: LocationData | null,
+    colors: Colors,
+    eclipticView: boolean
+  ): void {
+    while (container.firstChild) container.removeChild(container.firstChild);
+    const { svg, updateMarkers } = renderSolarSystem(
+      date,
+      hemisphere,
+      locationData,
+      colors,
+      eclipticView
+    );
+    this._svg = svg;
+    this._updateMarkers = updateMarkers;
+    container.appendChild(svg);
+    this._bindPointerEvents(svg);
+  }
+
+  applyViewState(): void {
+    const panZoomState = this._zoom.panZoomState;
+    if (!panZoomState) return;
+    if (this._svg) this._svg.setAttribute("viewBox", this._zoom.viewBox as string);
+    this._updateMarkers?.(panZoomState);
+  }
+
+  private _bindPointerEvents(svg: SVGSVGElement): void {
+    svg.addEventListener("pointerdown", (e) => this._onPointerDown(e));
+    svg.addEventListener("pointermove", (e) => this._onPointerMove(e));
+    svg.addEventListener("pointerup", (e) => this._onPointerUp(e));
+  }
+
+  private _onPointerDown(e: PointerEvent): void {
+    const svg = e.currentTarget as SVGSVGElement;
+    svg.setPointerCapture(e.pointerId);
+    this._zoom.startDrag(e.clientX, e.clientY);
+    svg.style.cursor = "grabbing";
+  }
+
+  private _onPointerMove(e: PointerEvent): void {
+    if (!this._zoom.isDragging) return;
+    const svg = e.currentTarget as SVGSVGElement;
+    const rect = svg.getBoundingClientRect();
+    this._zoom.updateDrag(e.clientX, e.clientY, rect);
+  }
+
+  private _onPointerUp(e: PointerEvent): void {
+    if (!this._zoom.isDragging) return;
+    this._zoom.endDrag();
+    const svg = e.currentTarget as SVGSVGElement;
+    svg.releasePointerCapture(e.pointerId);
+    svg.style.cursor = "grab";
+  }
+}

--- a/test/card/card.test.ts
+++ b/test/card/card.test.ts
@@ -1097,11 +1097,6 @@ describe("SolarViewCard", () => {
   });
 
   describe("internal method null guards", () => {
-    it("_updateViewBox is a no-op when shadow DOM has no SVG", () => {
-      const card = document.createElement("ha-planetary-solar-system-card-test");
-      expect(() => card._updateViewBox()).not.toThrow();
-    });
-
     it("_zoom.advancePeriodic is a no-op before the view is initialized", () => {
       const card = document.createElement("ha-planetary-solar-system-card-test");
       expect(() => card._zoom.advancePeriodic()).not.toThrow();
@@ -1120,13 +1115,6 @@ describe("SolarViewCard", () => {
     it("disconnectedCallback is safe before connectedCallback", () => {
       const card = document.createElement("ha-planetary-solar-system-card-test");
       expect(() => card.disconnectedCallback()).not.toThrow();
-    });
-
-    it("_updateViewBox skips setAttribute when #solar-view has no SVG child", () => {
-      const card = createAndMount();
-      card.shadowRoot.querySelector("#solar-view").innerHTML = "";
-      expect(() => card._updateViewBox()).not.toThrow();
-      card.remove();
     });
   });
 

--- a/test/card/solar-view.test.ts
+++ b/test/card/solar-view.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { SolarView } from "../../src/card/solar-view.js";
+import { ZoomController } from "../../src/card/zoom-controller.js";
+
+function mountedView(): { view: SolarView; zoom: ZoomController; container: HTMLElement } {
+  const zoom = new ZoomController(
+    () => {},
+    () => {}
+  );
+  zoom.configure(2, false, 4, false);
+  zoom.ensureInitialized();
+  const view = new SolarView(zoom);
+  const container = document.createElement("div");
+  view.mount(container, new Date("2026-08-16T12:00:00Z"), "north", null, {}, false);
+  return { view, zoom, container };
+}
+
+describe("SolarView.mount", () => {
+  it("appends a single svg to the container", () => {
+    const { container } = mountedView();
+    expect(container.children.length).toBe(1);
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+
+  it("clears any previous content before mounting again", () => {
+    const { view, container } = mountedView();
+    view.mount(container, new Date("2026-08-17T12:00:00Z"), "north", null, {}, false);
+    expect(container.children.length).toBe(1);
+  });
+});
+
+describe("SolarView.applyViewState", () => {
+  it("is a no-op when nothing has been mounted", () => {
+    const zoom = new ZoomController(
+      () => {},
+      () => {}
+    );
+    const view = new SolarView(zoom);
+    expect(() => view.applyViewState()).not.toThrow();
+  });
+
+  it("skips the svg write when the zoom view initializes before mount() runs", () => {
+    const zoom = new ZoomController(
+      () => {},
+      () => {}
+    );
+    zoom.configure(2, false, 4, false);
+    zoom.ensureInitialized();
+    const view = new SolarView(zoom);
+    expect(() => view.applyViewState()).not.toThrow();
+  });
+
+  it("sets the svg viewBox from the zoom controller", () => {
+    const { view, zoom, container } = mountedView();
+    const svg = container.querySelector("svg") as SVGSVGElement;
+    svg.setAttribute("viewBox", "0 0 1 1");
+    view.applyViewState();
+    expect(svg.getAttribute("viewBox")).toBe(zoom.viewBox);
+  });
+});
+
+describe("SolarView pointer drag", () => {
+  it("pointermove before pointerdown is a no-op", () => {
+    const { zoom, container } = mountedView();
+    const svg = container.querySelector("svg") as SVGSVGElement;
+    const centerBefore = zoom.panZoomState?.centerX;
+    svg.dispatchEvent(new PointerEvent("pointermove", { clientX: 300, clientY: 300 }));
+    expect(zoom.panZoomState?.centerX).toBe(centerBefore);
+  });
+
+  it("pointerup before pointerdown is a no-op", () => {
+    const { zoom, container } = mountedView();
+    const svg = container.querySelector("svg") as SVGSVGElement;
+    svg.releasePointerCapture = () => {};
+    svg.dispatchEvent(new PointerEvent("pointerup", { clientX: 300, clientY: 300 }));
+    expect(zoom.isDragging).toBe(false);
+  });
+
+  it("pointerdown starts a drag, sets capture and grabbing cursor", () => {
+    const { zoom, container } = mountedView();
+    const svg = container.querySelector("svg") as SVGSVGElement;
+    svg.setPointerCapture = () => {};
+    svg.releasePointerCapture = () => {};
+    svg.dispatchEvent(
+      new PointerEvent("pointerdown", { clientX: 100, clientY: 100, pointerId: 1 })
+    );
+    expect(zoom.isDragging).toBe(true);
+    expect(svg.style.cursor).toBe("grabbing");
+  });
+
+  it("pointermove while dragging updates pan center, pointerup ends drag and resets cursor", () => {
+    const { zoom, container } = mountedView();
+    const svg = container.querySelector("svg") as SVGSVGElement;
+    svg.setPointerCapture = () => {};
+    svg.releasePointerCapture = () => {};
+    svg.getBoundingClientRect = () =>
+      ({ width: 400, height: 400, x: 0, y: 0, top: 0, left: 0 }) as DOMRect;
+
+    const centerBefore = zoom.panZoomState?.centerX;
+    svg.dispatchEvent(
+      new PointerEvent("pointerdown", { clientX: 200, clientY: 200, pointerId: 1 })
+    );
+    svg.dispatchEvent(
+      new PointerEvent("pointermove", { clientX: 250, clientY: 200, pointerId: 1 })
+    );
+    expect(zoom.panZoomState?.centerX).toBeLessThan(centerBefore as number);
+
+    svg.dispatchEvent(new PointerEvent("pointerup", { clientX: 250, clientY: 200, pointerId: 1 }));
+    expect(zoom.isDragging).toBe(false);
+    expect(svg.style.cursor).toBe("grab");
+  });
+});


### PR DESCRIPTION
## Summary
- card.ts leaked #solar-view's DOM shape across 4 call sites: viewBox querySelector, marker-update closure held as instance state, and pointer capture/cursor writes interleaved with ZoomController calls
- New `SolarView` (src/card/solar-view.ts) owns the SVG end to end — mount, applyViewState (viewBox + offscreen markers), and pointer drag lifecycle
- card.ts drops to two calls (`mount`, `applyViewState`); renderer/index.ts untouched
- From the architecture-improvement review's top recommendation — this was the direct cause of card.test.ts running 2164 lines (3x the file it tests), the only extracted collaborator with no isolated unit test until now

## Test plan
- [x] New test/card/solar-view.test.ts covers mount, applyViewState, and full pointer-drag lifecycle in isolation
- [x] npm run test:coverage — 657 passed, 100% coverage
- [x] npm run check:ci clean
- [x] ponytail-review: lean, nothing to cut

🤖 Generated with [Claude Code](https://claude.com/claude-code)