### PR TITLE
refactor: add GalleryController.viewModel() for card.ts's template

### DIFF
--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -169,18 +169,19 @@ export class SolarViewCard extends LitElement {
       this._hemisphere = lat < 0 ? "south" : "north";
     }
 
-    const statusBar = this._gallery.error
+    const gallery = this._gallery.viewModel();
+    const statusBar = gallery.error
       ? html`<div class="status-bar">
-          <span>${this._gallery.error}</span>
+          <span>${gallery.error}</span>
         </div>`
-      : this._gallery.panelMode === "none"
+      : gallery.panelSource === "none"
         ? buildStatusBar(this._locationData, this._effectiveLocationName, this._dateNav.currentDate)
         : buildImageStatusBar(
-            this._gallery.panelMode,
-            this._gallery.imageDate ? this._formatDate(this._gallery.imageDate) : "",
-            this._gallery.imageDate ?? new Date(),
+            gallery.panelSource,
+            gallery.imageDate ? this._formatDate(gallery.imageDate) : "",
+            gallery.imageDate ?? new Date(),
             new Date(),
-            this._gallery.imageLoaded
+            gallery.imageLoaded
           );
     const zoomLevel = this._zoom.displayZoomLevel;
     const theme = resolveTheme(this._theme, this._colors.background);
@@ -191,45 +192,38 @@ export class SolarViewCard extends LitElement {
           ${statusBar}
           <div
             id="solar-view"
-            class=${this._gallery.panelMode === "none" ? "" : "hidden"}
+            class=${gallery.panelSource === "none" ? "" : "hidden"}
             style=${this._heightStyle || nothing}
           ></div>
           <img
             id="image-view"
-            class="image-view ${this._gallery.panelMode === "none" ? "" : "visible"}"
+            class="image-view ${gallery.panelSource === "none" ? "" : "visible"}"
             style=${this._heightStyle || nothing}
-            src=${this._gallery.imageUrl ?? nothing}
+            src=${gallery.imageUrl ?? nothing}
             alt=""
             @click=${this._onImageClick}
             @load=${this._onImageLoad}
             @error=${this._onImageLoadError}
           />
           ${
-            this._gallery.isOpen && this._gallery.panelMode === "none"
+            gallery.showStrip
               ? html`<div class="gallery">
-                  ${this._gallery.displaySources.map(
-                    (source) => html`<button
+                  ${gallery.thumbnails.map(
+                    ({ source, url, date }) => html`<button
                       class="gallery-thumb"
                       data-source=${source}
                       title=${`Show ${GALLERY_SOURCE_LABELS[source]}`}
                       @click=${this._onGalleryClick}
                     >
                       <img
-                        src=${this._gallery.images[source]?.url ?? nothing}
+                        src=${url ?? nothing}
                         alt=""
                         @error=${source === "sun" ? this._onSunThumbError : undefined}
                       />
                       <div class="gallery-info">
                         <span class="gallery-label">${GALLERY_SOURCE_LABELS[source]}</span>
                         <span class="gallery-age"
-                          >${
-                            this._gallery.images[source]
-                              ? formatRelativeAge(
-                                  this._gallery.images[source]?.date as Date,
-                                  new Date()
-                                )
-                              : "loading…"
-                          }</span
+                          >${date ? formatRelativeAge(date, new Date()) : "loading…"}</span
                         >
                       </div>
                     </button>`
@@ -258,13 +252,13 @@ export class SolarViewCard extends LitElement {
             <button data-action="zoom-in" title="Zoom in" @click=${this._onNavClick}>+</button>
           </span>
           ${
-            this._gallery.mode !== "none"
+            gallery.navButtonVisible
               ? html`<span class="nav-spacer"></span>
                   <span class="btn-group">
                     <button
                       data-action="gallery"
                       title="Show image gallery"
-                      class=${this._gallery.isOpen ? "active" : ""}
+                      class=${gallery.navButtonActive ? "active" : ""}
                       @click=${this._onNavClick}
                     >
                       <span class="icon">☷</span>

--- a/src/card/gallery-controller.ts
+++ b/src/card/gallery-controller.ts
@@ -13,6 +13,22 @@ export type GalleryMode = "none" | "earth" | "sun" | "both" | "slide";
 export const GALLERY_MODES: GalleryMode[] = ["none", "earth", "sun", "both", "slide"];
 export const DEFAULT_GALLERY_INTERVAL_MS = 60000;
 
+// Render-ready shape for card.ts's template — raw data only (dates, urls, booleans), no
+// formatting, so formatRelativeAge/date-formatting stays in card.ts alongside its other
+// display logic. Collapses the branching card.ts's render() otherwise reconstructs from the
+// individual getters below (which stay, and remain this module's own test seam).
+export interface GalleryViewModel {
+  error: string | null;
+  panelSource: ImagePanelMode;
+  imageUrl: string | null;
+  imageDate: Date | null;
+  imageLoaded: boolean;
+  showStrip: boolean;
+  thumbnails: { source: ImageSource; url: string | null; date: Date | null }[];
+  navButtonVisible: boolean;
+  navButtonActive: boolean;
+}
+
 // Confirms a candidate image URL actually loads AND decodes before anything commits to
 // displaying it — so a failed or not-yet-published candidate never touches a visible <img>.
 // decode() (not the load event) is what actually guarantees this: load only means the bytes
@@ -117,6 +133,24 @@ export class GalleryController {
   // Sources rendered as thumbnails right now.
   get displaySources(): ImageSource[] {
     return this._mode === "slide" ? [this._autoDisplayedSource] : this._fetchSources;
+  }
+
+  viewModel(): GalleryViewModel {
+    return {
+      error: this._error,
+      panelSource: this._panelMode,
+      imageUrl: this._imageUrl,
+      imageDate: this._imageDate,
+      imageLoaded: this._imageLoaded,
+      showStrip: this._open && this._panelMode === "none",
+      thumbnails: this.displaySources.map((source) => ({
+        source,
+        url: this._images[source]?.url ?? null,
+        date: this._images[source]?.date ?? null,
+      })),
+      navButtonVisible: this._mode !== "none",
+      navButtonActive: this._open,
+    };
   }
 
   // Sources this gallery.mode needs fetched in the background — "slide" still fetches both

--- a/test/card/gallery-controller.test.ts
+++ b/test/card/gallery-controller.test.ts
@@ -232,3 +232,60 @@ describe("GalleryController slide auto-switch", () => {
     expect(gallery.displaySources).toEqual(before);
   });
 });
+
+describe("GalleryController.viewModel", () => {
+  it("reflects the error state", () => {
+    const gallery = new GalleryController(() => {});
+    gallery.configure("earth", 60000);
+    gallery.openPanel("earth");
+    (gallery as unknown as { _error: string | null })._error = "Earth image unavailable";
+    expect(gallery.viewModel().error).toBe("Earth image unavailable");
+  });
+
+  it("reflects no panel open, strip closed", () => {
+    const gallery = new GalleryController(() => {});
+    gallery.configure("earth", 60000);
+    gallery.toggle(); // configure() opens by default; close it
+    const vm = gallery.viewModel();
+    expect(vm.error).toBeNull();
+    expect(vm.panelSource).toBe("none");
+    expect(vm.navButtonVisible).toBe(true);
+    expect(vm.navButtonActive).toBe(false);
+  });
+
+  it("reflects an open strip with no panel", () => {
+    const gallery = new GalleryController(() => {});
+    gallery.configure("both", 60000);
+    const vm = gallery.viewModel();
+    expect(vm.showStrip).toBe(true);
+    expect(vm.panelSource).toBe("none");
+    expect(vm.navButtonActive).toBe(true);
+    expect(vm.thumbnails.map((t) => t.source)).toEqual(["earth", "sun"]);
+  });
+
+  it("reflects an open panel with image data, and hides the strip", async () => {
+    const gallery = new GalleryController(() => {});
+    gallery.configure("both", 60000);
+    gallery.openPanel("earth");
+    await vi.waitFor(() => expect(gallery.imageLoaded).toBe(true));
+    const vm = gallery.viewModel();
+    expect(vm.panelSource).toBe("earth");
+    expect(vm.imageUrl).toBe(gallery.imageUrl);
+    expect(vm.imageDate).toBe(gallery.imageDate);
+    expect(vm.imageLoaded).toBe(true);
+    expect(vm.showStrip).toBe(false);
+  });
+
+  it("thumbnails carry url/date from images for sources not yet fetched", () => {
+    const gallery = new GalleryController(() => {});
+    gallery.configure("sun", 60000);
+    const vm = gallery.viewModel();
+    expect(vm.thumbnails).toEqual([{ source: "sun", url: null, date: null }]);
+  });
+
+  it("navButtonVisible is false when gallery mode is none", () => {
+    const gallery = new GalleryController(() => {});
+    gallery.configure("none", 60000);
+    expect(gallery.viewModel().navButtonVisible).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- card.ts's render() pulled 8 raw getters (panelMode, imageDate, imageLoaded, error, isOpen, mode, images, displaySources) and reconstructed panel/strip/error branching inline across 3 separate ternaries plus a per-source thumbnail lookup loop
- `GalleryController.viewModel()` returns one render-ready object: raw data (dates, urls, booleans), no formatting — `formatRelativeAge`/date-formatting stays in card.ts
- Existing getters kept — they're `gallery-controller.test.ts`'s own test seam (37 assertions), unaffected
- Second Strong candidate from the architecture-improvement review; follow-up to #110

## Test plan
- [x] New GalleryController.viewModel tests cover error, closed/open strip, open panel, and unfetched-thumbnail states
- [x] npm run test:coverage — 663 passed, 100% coverage
- [x] npm run check:ci clean
- [x] ponytail-review: cut a redundant `showingPanel` field (duplicated `panelSource !== "none"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)