### PR TITLE
refactor: extract computeTwilightBand from renderDayNightSplit

### DIFF
--- a/src/renderer/observer.ts
+++ b/src/renderer/observer.ts
@@ -100,6 +100,38 @@ export function calculateObserverAngle(
   return earthOrbitalAngle + localTimeAngle;
 }
 
+// Elevation/zenith angle -> which twilight band the visibility cone should show, and how wide
+// it should be. Pure so the band boundaries and half-angle geometry are testable without a
+// DOM — renderDayNightSplit only calls this and hands the result to renderVisibilityCone.
+export function computeTwilightBand(
+  elevationDeg: number,
+  zenithAngleFromSun: number | null,
+  colors: Colors
+): { color: string; halfAngle: number } {
+  let color: string;
+  if (elevationDeg >= 0) color = colors.cone_day ?? CONE_DAY;
+  else if (elevationDeg >= -6) color = colors.cone_twilight_civil ?? CONE_CIVIL;
+  else if (elevationDeg >= -12) color = colors.cone_twilight_nautical ?? CONE_NAUTICAL;
+  else if (elevationDeg >= -18) color = colors.cone_twilight_astronomical ?? CONE_ASTRONOMICAL;
+  else color = colors.cone_night ?? CONE_NIGHT;
+
+  // Twilight half-angle must expand in the SAME frame as displayObserverAngle (the cone's
+  // axis), or the two disagree away from solar noon/midnight. zenithAngleFromSun is an
+  // ecliptic-PLANE PROJECTION of the true 3D zenith angle — so reuse that same projected
+  // magnitude here instead of the true unprojected (90 - elevationDeg), which was silently
+  // assumed to be interchangeable with it. Using the mismatched true-angle magnitude on a
+  // projected axis is exactly what pushed the -6/-12/-18 cone edges away from the Sun's
+  // actual direction after sunset (worst at mid latitudes).
+  const halfAngle =
+    elevationDeg >= 0 || elevationDeg < -18
+      ? 90
+      : zenithAngleFromSun != null
+        ? (Math.abs(zenithAngleFromSun) * 180) / Math.PI
+        : 90 - elevationDeg;
+
+  return { color, halfAngle };
+}
+
 function renderVisibilityCone(
   svg: SVGElement,
   anchorX: number,
@@ -198,26 +230,11 @@ export function renderDayNightSplit(
   const displayObserverAngle =
     zenithAngleFromSun != null ? earthAngle + Math.PI + zenithAngleFromSun : observerAngle;
 
-  let coneColor: string;
-  if (elevationDeg >= 0) coneColor = colors.cone_day ?? CONE_DAY;
-  else if (elevationDeg >= -6) coneColor = colors.cone_twilight_civil ?? CONE_CIVIL;
-  else if (elevationDeg >= -12) coneColor = colors.cone_twilight_nautical ?? CONE_NAUTICAL;
-  else if (elevationDeg >= -18) coneColor = colors.cone_twilight_astronomical ?? CONE_ASTRONOMICAL;
-  else coneColor = colors.cone_night ?? CONE_NIGHT;
-
-  // Twilight half-angle must expand in the SAME frame as displayObserverAngle (the cone's
-  // axis), or the two disagree away from solar noon/midnight. displayObserverAngle is built
-  // from zenithAngleFromSun, an ecliptic-PLANE PROJECTION of the true 3D zenith angle — so
-  // reuse that same projected magnitude here instead of the true unprojected (90 -
-  // elevationDeg), which was silently assumed to be interchangeable with it. Using the
-  // mismatched true-angle magnitude on a projected axis is exactly what pushed the -6/-12/-18
-  // cone edges away from the Sun's actual direction after sunset (worst at mid latitudes).
-  const halfAngle =
-    elevationDeg >= 0 || elevationDeg < -18
-      ? 90
-      : zenithAngleFromSun != null
-        ? (Math.abs(zenithAngleFromSun) * 180) / Math.PI
-        : 90 - elevationDeg;
+  const { color: coneColor, halfAngle } = computeTwilightBand(
+    elevationDeg,
+    zenithAngleFromSun,
+    colors
+  );
   renderVisibilityCone(
     svg,
     anchorX,

--- a/test/renderer/observer.test.ts
+++ b/test/renderer/observer.test.ts
@@ -13,6 +13,7 @@ import {
   CONE_NIGHT,
   calculateObserverAngle,
   calculateSolarElevationDeg,
+  computeTwilightBand,
   rayCircleDistance,
   renderDayNightSplit,
   renderObserverNeedle,
@@ -619,5 +620,42 @@ describe("computeZenithAngleFromSun", () => {
     // Real azimuthal rate peaks near culmination (measured ~0.43°/min at this lat/season),
     // well below the ~0.25°/min naive average but nowhere near the old bug's 122° jump.
     expect(maxJumpDeg).toBeLessThan(2);
+  });
+});
+
+describe("computeTwilightBand", () => {
+  it("day elevation gets CONE_DAY and a 90° half-angle", () => {
+    expect(computeTwilightBand(10, null, {})).toEqual({ color: CONE_DAY, halfAngle: 90 });
+  });
+
+  it("civil twilight (0 to -6) gets CONE_CIVIL", () => {
+    expect(computeTwilightBand(-3, null, {}).color).toBe(CONE_CIVIL);
+  });
+
+  it("nautical twilight (-6 to -12) gets CONE_NAUTICAL", () => {
+    expect(computeTwilightBand(-9, null, {}).color).toBe(CONE_NAUTICAL);
+  });
+
+  it("astronomical twilight (-12 to -18) gets CONE_ASTRONOMICAL", () => {
+    expect(computeTwilightBand(-15, null, {}).color).toBe(CONE_ASTRONOMICAL);
+  });
+
+  it("below -18 gets CONE_NIGHT and a 90° half-angle", () => {
+    expect(computeTwilightBand(-20, null, {})).toEqual({ color: CONE_NIGHT, halfAngle: 90 });
+  });
+
+  it("colors overrides take precedence over the CONE_* defaults", () => {
+    const band = computeTwilightBand(10, null, { cone_day: "red" });
+    expect(band.color).toBe("red");
+  });
+
+  it("half-angle during twilight uses the projected zenith magnitude when available", () => {
+    const band = computeTwilightBand(-9, Math.PI / 3, {});
+    expect(band.halfAngle).toBeCloseTo(60, 5);
+  });
+
+  it("half-angle during twilight falls back to 90 - elevationDeg without a projected zenith", () => {
+    const band = computeTwilightBand(-9, null, {});
+    expect(band.halfAngle).toBeCloseTo(99, 5);
   });
 });


### PR DESCRIPTION
## Summary
- renderDayNightSplit (145 lines) fused a business rule (elevation/zenith angle -> twilight color + cone half-angle) with SVG element construction — testing "what color at elevation X" required calling the DOM-coupled function
- New `computeTwilightBand(elevationDeg, zenithAngleFromSun, colors)` is pure, same file, alongside renderDayNightSplit — matches bodies.ts/offscreen-markers.ts's existing pure-math/DOM-builder split within one file
- Anchor-point geometry and horizon/zenith line math left untouched — out of scope, genuinely DOM-adjacent
- Third candidate from the architecture-improvement review (Worth exploring); follow-up to #110, #111

## Test plan
- [x] New computeTwilightBand tests cover all 5 bands, colors overrides, and both half-angle branches (projected zenith vs elevation fallback) in isolation
- [x] npm run test:coverage — 671 passed, 100% coverage (twilight-accuracy.test.ts and full-render tests confirm no behavior change)
- [x] npm run check:ci clean
- [x] ponytail-review: lean, nothing to cut

🤖 Generated with [Claude Code](https://claude.com/claude-code)