### PR TITLE
refactor: extract buildStatusBarView from card.ts's render()

### DIFF
--- a/src/card/card-template.ts
+++ b/src/card/card-template.ts
@@ -6,7 +6,17 @@ import {
   getSkyMode,
 } from "../astronomy/solar-position.js";
 import type { LocationData } from "../types.js";
+import type { GalleryViewModel } from "./gallery-controller.js";
 import { formatRelativeAge } from "./relative-time.js";
+
+export function formatDate(date: Date): string {
+  const y = String(date.getFullYear()).slice(-2);
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  const hh = String(date.getHours()).padStart(2, "0");
+  const mm = String(date.getMinutes()).padStart(2, "0");
+  return `${y}-${m}-${d} ${hh}:${mm}`;
+}
 
 export function buildStatusBar(
   locationData: LocationData | null,
@@ -75,4 +85,30 @@ export function buildImageStatusBar(
   return html`<div class="status-bar">
     <span>${IMAGE_STATUS_TARGET[mode]} · ${IMAGE_STATUS_INSTRUMENT[mode]} · ${status}</span>
   </div>`;
+}
+
+// Picks which status bar variant to show — error banner wins outright, then the image panel's
+// own status line, falling back to the location/sky status bar. Owns the branching card.ts's
+// render() used to reconstruct from GalleryViewModel's raw fields on every render.
+export function buildStatusBarView(
+  gallery: GalleryViewModel,
+  locationData: LocationData | null,
+  locationName: string | null,
+  currentDate: Date
+): TemplateResult | typeof nothing {
+  if (gallery.error) {
+    return html`<div class="status-bar">
+      <span>${gallery.error}</span>
+    </div>`;
+  }
+  if (gallery.panelSource === "none") {
+    return buildStatusBar(locationData, locationName, currentDate);
+  }
+  return buildImageStatusBar(
+    gallery.panelSource,
+    gallery.imageDate ? formatDate(gallery.imageDate) : "",
+    gallery.imageDate ?? new Date(),
+    new Date(),
+    gallery.imageLoaded
+  );
 }

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -10,7 +10,7 @@ import type {
 import { parseCardConfig } from "./card-config.js";
 import { cardStyles } from "./card-styles.js";
 import type { ImageSource } from "./card-template.js";
-import { buildImageStatusBar, buildStatusBar, GALLERY_SOURCE_LABELS } from "./card-template.js";
+import { buildStatusBarView, formatDate, GALLERY_SOURCE_LABELS } from "./card-template.js";
 import { DateNav } from "./date-nav.js";
 import type { GalleryMode } from "./gallery-controller.js";
 import { GalleryController } from "./gallery-controller.js";
@@ -170,19 +170,12 @@ export class SolarViewCard extends LitElement {
     }
 
     const gallery = this._gallery.viewModel();
-    const statusBar = gallery.error
-      ? html`<div class="status-bar">
-          <span>${gallery.error}</span>
-        </div>`
-      : gallery.panelSource === "none"
-        ? buildStatusBar(this._locationData, this._effectiveLocationName, this._dateNav.currentDate)
-        : buildImageStatusBar(
-            gallery.panelSource,
-            gallery.imageDate ? this._formatDate(gallery.imageDate) : "",
-            gallery.imageDate ?? new Date(),
-            new Date(),
-            gallery.imageLoaded
-          );
+    const statusBar = buildStatusBarView(
+      gallery,
+      this._locationData,
+      this._effectiveLocationName,
+      this._dateNav.currentDate
+    );
     const zoomLevel = this._zoom.displayZoomLevel;
     const theme = resolveTheme(this._theme, this._colors.background);
 
@@ -325,12 +318,7 @@ export class SolarViewCard extends LitElement {
   }
 
   private _formatDate(date: Date): string {
-    const y = String(date.getFullYear()).slice(-2);
-    const m = String(date.getMonth() + 1).padStart(2, "0");
-    const d = String(date.getDate()).padStart(2, "0");
-    const hh = String(date.getHours()).padStart(2, "0");
-    const mm = String(date.getMinutes()).padStart(2, "0");
-    return `${y}-${m}-${d} ${hh}:${mm}`;
+    return formatDate(date);
   }
 
   private _navigate(deltaMs: number): void {

--- a/test/card/card-template.test.ts
+++ b/test/card/card-template.test.ts
@@ -1,6 +1,27 @@
 import { nothing, render } from "lit";
 import { describe, expect, it } from "vitest";
-import { buildImageStatusBar, buildStatusBar } from "../../src/card/card-template.js";
+import {
+  buildImageStatusBar,
+  buildStatusBar,
+  buildStatusBarView,
+  formatDate,
+} from "../../src/card/card-template.js";
+import type { GalleryViewModel } from "../../src/card/gallery-controller.js";
+
+function galleryViewModel(overrides: Partial<GalleryViewModel> = {}): GalleryViewModel {
+  return {
+    error: null,
+    panelSource: "none",
+    imageUrl: null,
+    imageDate: null,
+    imageLoaded: false,
+    showStrip: false,
+    thumbnails: [],
+    navButtonVisible: false,
+    navButtonActive: false,
+    ...overrides,
+  };
+}
 
 function renderToDOM(result) {
   const div = document.createElement("div");
@@ -130,6 +151,61 @@ describe("buildImageStatusBar", () => {
   it("shows 'loading…' instead of the date until the image has actually loaded", () => {
     const root = renderToDOM(
       buildImageStatusBar("sun", "26-08-12 11:55", new Date("2026-08-12T11:55:00Z"), now, false)
+    );
+    expect(root.querySelector(".status-bar span").textContent).toBe("SUN · SDO HMI · loading…");
+  });
+});
+
+describe("formatDate", () => {
+  it("formats as YY-MM-DD HH:MM with zero-padding", () => {
+    expect(formatDate(new Date(2026, 1, 5, 9, 3))).toBe("26-02-05 09:03");
+  });
+});
+
+describe("buildStatusBarView", () => {
+  const locationData = { lat: 51.5, lon: -0.1, timezone: "Europe/London" };
+  const currentDate = new Date("2026-03-05T12:00:00Z");
+
+  it("shows the gallery error when one is present, regardless of panelSource", () => {
+    const root = renderToDOM(
+      buildStatusBarView(
+        galleryViewModel({ error: "Feed unavailable", panelSource: "earth" }),
+        locationData,
+        "London",
+        currentDate
+      )
+    );
+    expect(root.querySelector(".status-bar span").textContent).toBe("Feed unavailable");
+  });
+
+  it("delegates to buildStatusBar when panelSource is 'none'", () => {
+    const root = renderToDOM(
+      buildStatusBarView(galleryViewModel(), locationData, "London", currentDate)
+    );
+    expect(root.querySelector(".status-bar span:first-child").textContent).toMatch(/^London \|/);
+  });
+
+  it("delegates to buildImageStatusBar with a formatted date when panelSource is an image source", () => {
+    const imageDate = new Date("2026-08-10T18:49:00Z");
+    const root = renderToDOM(
+      buildStatusBarView(
+        galleryViewModel({ panelSource: "earth", imageDate, imageLoaded: true }),
+        locationData,
+        "London",
+        currentDate
+      )
+    );
+    expect(root.querySelector(".status-bar span").textContent).toContain(formatDate(imageDate));
+  });
+
+  it("passes an empty date text to buildImageStatusBar when imageDate is null", () => {
+    const root = renderToDOM(
+      buildStatusBarView(
+        galleryViewModel({ panelSource: "sun", imageDate: null, imageLoaded: false }),
+        locationData,
+        "London",
+        currentDate
+      )
     );
     expect(root.querySelector(".status-bar span").textContent).toBe("SUN · SDO HMI · loading…");
   });


### PR DESCRIPTION
## Summary
- card.ts's render() reconstructed status-bar branching (error banner / image panel / location bar) from GalleryViewModel every render — moved to card-template.ts's buildStatusBarView, alongside its existing buildStatusBar/buildImageStatusBar
- formatDate moved with it; card.ts keeps a thin `_formatDate` delegate (used by 8 test call sites and one render() span)

## Test plan
- [x] npm run test:coverage — 676 passed, 100% coverage
- [x] npm run check:ci — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)