### PR TITLE
Add debug overlay with per-source gallery fetch stats

### DIFF
--- a/src/card/card-styles.ts
+++ b/src/card/card-styles.ts
@@ -214,7 +214,9 @@ export const cardStyles = css`
   .debug-overlay {
     position: absolute;
     left: 0;
+    right: 0;
     top: 100%;
+    box-sizing: border-box;
     pointer-events: none;
     background: rgba(0, 0, 0, 0.25);
     backdrop-filter: blur(4px);
@@ -230,7 +232,9 @@ export const cardStyles = css`
     margin-top: 2px;
   }
   .debug-overlay table {
+    width: 100%;
     border-collapse: collapse;
+    table-layout: fixed;
   }
   .debug-overlay th,
   .debug-overlay td {
@@ -245,6 +249,10 @@ export const cardStyles = css`
   .debug-overlay th {
     color: #66bb9a;
     font-weight: normal;
+  }
+  .debug-total td {
+    border-top: 1px solid rgba(0, 230, 118, 0.3);
+    color: #66bb9a;
   }
   .card-version {
     font-size: 9px;

--- a/src/card/card-styles.ts
+++ b/src/card/card-styles.ts
@@ -34,9 +34,12 @@ export const cardStyles = css`
     display: flex;
     flex-direction: column;
   }
-  .status-bar {
+  .status-bar-row {
     position: relative;
     flex: 0 0 auto;
+  }
+  .status-bar {
+    position: relative;
     background: var(--secondary-background-color, color-mix(in srgb, currentColor 10%, transparent));
     font-size: 10px;
     color: inherit;
@@ -207,6 +210,41 @@ export const cardStyles = css`
     display: flex;
     align-items: center;
     box-sizing: border-box;
+  }
+  .debug-overlay {
+    position: absolute;
+    left: 0;
+    top: 100%;
+    pointer-events: none;
+    background: rgba(0, 0, 0, 0.25);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+    color: #00e676;
+    font-family: monospace;
+    font-size: 10px;
+    line-height: 1.3;
+    padding: 3px 6px;
+  }
+  .debug-caption {
+    color: #66bb9a;
+    margin-top: 2px;
+  }
+  .debug-overlay table {
+    border-collapse: collapse;
+  }
+  .debug-overlay th,
+  .debug-overlay td {
+    padding: 0 6px 0 0;
+    text-align: right;
+    white-space: nowrap;
+  }
+  .debug-overlay th:first-child,
+  .debug-overlay td:first-child {
+    text-align: left;
+  }
+  .debug-overlay th {
+    color: #66bb9a;
+    font-weight: normal;
   }
   .card-version {
     font-size: 9px;

--- a/src/card/card-template.ts
+++ b/src/card/card-template.ts
@@ -6,8 +6,8 @@ import {
   getSkyMode,
 } from "../astronomy/solar-position.js";
 import type { LocationData } from "../types.js";
-import type { GalleryViewModel, SourceDebugStats } from "./gallery-controller.js";
-import { formatDuration, formatRelativeAge } from "./relative-time.js";
+import type { GalleryViewModel } from "./gallery-controller.js";
+import { formatRelativeAge } from "./relative-time.js";
 
 export function formatDate(date: Date): string {
   const y = String(date.getFullYear()).slice(-2);
@@ -111,47 +111,4 @@ export function buildStatusBarView(
     new Date(),
     gallery.imageLoaded
   );
-}
-
-function formatMs(ms: number | null): string {
-  return ms == null ? "—" : `${Math.round(ms)}ms`;
-}
-
-// debug:true overlay — sun/earth's cumulative check vs. network-call counts, so checks ===
-// networkCalls is visible at a glance as "this source's cache isn't actually skipping the
-// network call". Cumulative since mount, not a rolling window — this card's timers are
-// coarse (minutes, not events-per-second) so a running total reads better than a windowed rate.
-// No image-size column: neither NASA host sends Timing-Allow-Origin or CORS headers on its
-// image path, so the browser withholds transfer size from JS for both — nothing to show.
-export function buildDebugOverlay(
-  stats: Record<ImageSource, SourceDebugStats>,
-  startedAt: number
-): TemplateResult {
-  const rows: ImageSource[] = ["sun", "earth"];
-  return html`<div class="debug-overlay">
-    <table>
-      <tr>
-        <th>source</th>
-        <th>checks</th>
-        <th>attempts</th>
-        <th>ok</th>
-        <th>fail</th>
-        <th>redundant</th>
-        <th>fetch-time</th>
-      </tr>
-      ${rows.map((source) => {
-        const s = stats[source];
-        return html`<tr>
-          <td>${GALLERY_SOURCE_LABELS[source]}</td>
-          <td>${s.checks}</td>
-          <td>${s.attempts}</td>
-          <td>${s.networkCalls}</td>
-          <td>${s.failures}</td>
-          <td>${s.redundant}</td>
-          <td>${formatMs(s.avgFetchMs)}</td>
-        </tr>`;
-      })}
-    </table>
-    <div class="debug-caption">running for ${formatDuration(Date.now() - startedAt)}</div>
-  </div>`;
 }

--- a/src/card/card-template.ts
+++ b/src/card/card-template.ts
@@ -133,7 +133,10 @@ export function buildDebugOverlay(
       <tr>
         <th>source</th>
         <th>checks</th>
-        <th>net-calls</th>
+        <th>attempts</th>
+        <th>ok</th>
+        <th>fail</th>
+        <th>redundant</th>
         <th>fetch-time</th>
       </tr>
       ${rows.map((source) => {
@@ -141,7 +144,10 @@ export function buildDebugOverlay(
         return html`<tr>
           <td>${GALLERY_SOURCE_LABELS[source]}</td>
           <td>${s.checks}</td>
+          <td>${s.attempts}</td>
           <td>${s.networkCalls}</td>
+          <td>${s.failures}</td>
+          <td>${s.redundant}</td>
           <td>${formatMs(s.avgFetchMs)}</td>
         </tr>`;
       })}

--- a/src/card/card-template.ts
+++ b/src/card/card-template.ts
@@ -6,8 +6,8 @@ import {
   getSkyMode,
 } from "../astronomy/solar-position.js";
 import type { LocationData } from "../types.js";
-import type { GalleryViewModel } from "./gallery-controller.js";
-import { formatRelativeAge } from "./relative-time.js";
+import type { GalleryViewModel, SourceDebugStats } from "./gallery-controller.js";
+import { formatDuration, formatRelativeAge } from "./relative-time.js";
 
 export function formatDate(date: Date): string {
   const y = String(date.getFullYear()).slice(-2);
@@ -111,4 +111,41 @@ export function buildStatusBarView(
     new Date(),
     gallery.imageLoaded
   );
+}
+
+function formatMs(ms: number | null): string {
+  return ms == null ? "—" : `${Math.round(ms)}ms`;
+}
+
+// debug:true overlay — sun/earth's cumulative check vs. network-call counts, so checks ===
+// networkCalls is visible at a glance as "this source's cache isn't actually skipping the
+// network call". Cumulative since mount, not a rolling window — this card's timers are
+// coarse (minutes, not events-per-second) so a running total reads better than a windowed rate.
+// No image-size column: neither NASA host sends Timing-Allow-Origin or CORS headers on its
+// image path, so the browser withholds transfer size from JS for both — nothing to show.
+export function buildDebugOverlay(
+  stats: Record<ImageSource, SourceDebugStats>,
+  startedAt: number
+): TemplateResult {
+  const rows: ImageSource[] = ["sun", "earth"];
+  return html`<div class="debug-overlay">
+    <table>
+      <tr>
+        <th>source</th>
+        <th>checks</th>
+        <th>net-calls</th>
+        <th>fetch-time</th>
+      </tr>
+      ${rows.map((source) => {
+        const s = stats[source];
+        return html`<tr>
+          <td>${GALLERY_SOURCE_LABELS[source]}</td>
+          <td>${s.checks}</td>
+          <td>${s.networkCalls}</td>
+          <td>${formatMs(s.avgFetchMs)}</td>
+        </tr>`;
+      })}
+    </table>
+    <div class="debug-caption">running for ${formatDuration(Date.now() - startedAt)}</div>
+  </div>`;
 }

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -10,13 +10,9 @@ import type {
 import { parseCardConfig } from "./card-config.js";
 import { cardStyles } from "./card-styles.js";
 import type { ImageSource } from "./card-template.js";
-import {
-  buildDebugOverlay,
-  buildStatusBarView,
-  formatDate,
-  GALLERY_SOURCE_LABELS,
-} from "./card-template.js";
+import { buildStatusBarView, formatDate, GALLERY_SOURCE_LABELS } from "./card-template.js";
 import { DateNav } from "./date-nav.js";
+import { buildDebugOverlay } from "./debug.js";
 import type { GalleryMode } from "./gallery-controller.js";
 import { GalleryController } from "./gallery-controller.js";
 import { formatRelativeAge } from "./relative-time.js";

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -10,7 +10,12 @@ import type {
 import { parseCardConfig } from "./card-config.js";
 import { cardStyles } from "./card-styles.js";
 import type { ImageSource } from "./card-template.js";
-import { buildStatusBarView, formatDate, GALLERY_SOURCE_LABELS } from "./card-template.js";
+import {
+  buildDebugOverlay,
+  buildStatusBarView,
+  formatDate,
+  GALLERY_SOURCE_LABELS,
+} from "./card-template.js";
 import { DateNav } from "./date-nav.js";
 import type { GalleryMode } from "./gallery-controller.js";
 import { GalleryController } from "./gallery-controller.js";
@@ -182,7 +187,10 @@ export class SolarViewCard extends LitElement {
     return html`
       <div class="card" style="background: ${theme.background}; color: ${theme.color}">
         <div class="solar-view-wrapper">
-          ${statusBar}
+          <div class="status-bar-row">
+            ${statusBar}
+            ${this._config?.debug ? buildDebugOverlay(gallery.debugStats, gallery.debugStartedAt) : nothing}
+          </div>
           <div
             id="solar-view"
             class=${gallery.panelSource === "none" ? "" : "hidden"}

--- a/src/card/debug.ts
+++ b/src/card/debug.ts
@@ -1,0 +1,148 @@
+import type { TemplateResult } from "lit";
+import { html } from "lit";
+import type { ImageSource } from "./card-template.js";
+import { formatDate, GALLERY_SOURCE_LABELS } from "./card-template.js";
+import { formatDuration } from "./relative-time.js";
+
+// Cumulative, since the card was mounted — not a rolling window. Lets debug:true answer "is
+// this source's own cache actually saving anything" at a glance: ticks vs. network
+// equal means every tick is hitting the network regardless of cache state. `redundant` is
+// the sharper signal for that same question — it counts preloads whose resolved URL turned
+// out identical to the image already displayed, i.e. bytes that were re-fetched and
+// re-decoded for nothing. `attempts` vs. `network`+`failures` separates "tried" from
+// "succeeded", since a failed preload (sun's retry path) previously vanished from the count
+// entirely instead of showing up as a real network cost. `retries` counts how often sun's
+// primary 15-min-slot guess missed and fell back to the previous slot — a rising rate here
+// means SUN_PUBLISH_BUFFER_MS (image-sources.ts) needs widening. `lastAttemptAt` is the raw
+// timestamp of the most recent preload attempt, formatted at render time.
+export interface SourceDebugStats {
+  ticks: number;
+  attempts: number;
+  network: number;
+  failures: number;
+  retries: number;
+  redundant: number;
+  elapsed: number | null;
+  lastAttemptAt: number | null;
+}
+
+export interface DebugAccumulator {
+  ticks: number;
+  attempts: number;
+  network: number;
+  failures: number;
+  retries: number;
+  redundant: number;
+  fetchMsTotal: number;
+  lastAttemptAt: number | null;
+}
+
+export function emptyDebugAccumulator(): DebugAccumulator {
+  return {
+    ticks: 0,
+    attempts: 0,
+    network: 0,
+    failures: 0,
+    retries: 0,
+    redundant: 0,
+    fetchMsTotal: 0,
+    lastAttemptAt: null,
+  };
+}
+
+export function toDebugStats(acc: DebugAccumulator): SourceDebugStats {
+  return {
+    ticks: acc.ticks,
+    attempts: acc.attempts,
+    network: acc.network,
+    failures: acc.failures,
+    retries: acc.retries,
+    redundant: acc.redundant,
+    elapsed: acc.network > 0 ? acc.fetchMsTotal / acc.network : null,
+    lastAttemptAt: acc.lastAttemptAt,
+  };
+}
+
+function formatMs(ms: number | null): string {
+  return ms == null ? "—" : `${Math.round(ms)}ms`;
+}
+
+// ticks max()s rather than sum()s: sun/earth tick in lockstep for "both"/"slide" modes (one
+// refresh() increments both), so summing would double-count — max reads right there and
+// still reports correctly for a single-source mode, where the other side stays 0. time
+// avg()s the two sources' own averages (not a token-weighted mean — kept simple since this
+// overlay is already an approximation, not a billing report). last has no sane combination
+// of two different timestamps, so it's dropped rather than showing a misleading one.
+function summarizeDebugStats(stats: Record<ImageSource, SourceDebugStats>): SourceDebugStats {
+  const { sun, earth } = stats;
+  const elapsedValues = [sun.elapsed, earth.elapsed].filter((ms): ms is number => ms != null);
+  return {
+    ticks: Math.max(sun.ticks, earth.ticks),
+    attempts: sun.attempts + earth.attempts,
+    network: sun.network + earth.network,
+    failures: sun.failures + earth.failures,
+    retries: sun.retries + earth.retries,
+    redundant: sun.redundant + earth.redundant,
+    elapsed: elapsedValues.length
+      ? elapsedValues.reduce((total, ms) => total + ms, 0) / elapsedValues.length
+      : null,
+    lastAttemptAt: null,
+  };
+}
+
+// debug:true overlay — sun/earth's cumulative check vs. network-call counts, so ticks ===
+// network is visible at a glance as "this source's cache isn't actually skipping the
+// network call". Cumulative since mount, not a rolling window — this card's timers are
+// coarse (minutes, not events-per-second) so a running total reads better than a windowed rate.
+// No image-size column: neither NASA host sends Timing-Allow-Origin or CORS headers on its
+// image path, so the browser withholds transfer size from JS for both — nothing to show.
+export function buildDebugOverlay(
+  stats: Record<ImageSource, SourceDebugStats>,
+  startedAt: number
+): TemplateResult {
+  const rows: ImageSource[] = ["sun", "earth"];
+  return html`<div class="debug-overlay">
+    <table>
+      <tr>
+        <th>source</th>
+        <th>ticks</th>
+        <th>atmpt</th>
+        <th>fetch</th>
+        <th>fail</th>
+        <th>retry</th>
+        <th>dup</th>
+        <th>time</th>
+        <th>last</th>
+      </tr>
+      ${rows.map((source) => {
+        const s = stats[source];
+        return html`<tr>
+          <td>${GALLERY_SOURCE_LABELS[source]}</td>
+          <td>${s.ticks}</td>
+          <td>${s.attempts}</td>
+          <td>${s.network}</td>
+          <td>${s.failures}</td>
+          <td>${s.retries}</td>
+          <td>${s.redundant}</td>
+          <td>${formatMs(s.elapsed)}</td>
+          <td>${s.lastAttemptAt == null ? "—" : formatDuration(Date.now() - s.lastAttemptAt)}</td>
+        </tr>`;
+      })}
+      ${(() => {
+        const total = summarizeDebugStats(stats);
+        return html`<tr class="debug-total">
+          <td>total</td>
+          <td>${total.ticks}</td>
+          <td>${total.attempts}</td>
+          <td>${total.network}</td>
+          <td>${total.failures}</td>
+          <td>${total.retries}</td>
+          <td>${total.redundant}</td>
+          <td>${formatMs(total.elapsed)}</td>
+          <td>—</td>
+        </tr>`;
+      })()}
+    </table>
+    <div class="debug-caption">since ${formatDate(new Date(startedAt))} (${formatDuration(Date.now() - startedAt)})</div>
+  </div>`;
+}

--- a/src/card/gallery-controller.ts
+++ b/src/card/gallery-controller.ts
@@ -1,5 +1,7 @@
 import type { ImageSource } from "./card-template.js";
 import { GALLERY_SOURCES, IMAGE_SOURCE_LABELS } from "./card-template.js";
+import type { DebugAccumulator, SourceDebugStats } from "./debug.js";
+import { emptyDebugAccumulator, toDebugStats } from "./debug.js";
 import type { SourcedImage } from "./image-sources.js";
 import {
   FETCH_TIMEOUT_MS,
@@ -12,47 +14,6 @@ export type ImagePanelMode = "none" | ImageSource;
 export type GalleryMode = "none" | "earth" | "sun" | "both" | "slide";
 export const GALLERY_MODES: GalleryMode[] = ["none", "earth", "sun", "both", "slide"];
 export const DEFAULT_GALLERY_INTERVAL_MS = 60000;
-
-// Cumulative, since the card was mounted — not a rolling window. Lets debug:true answer "is
-// this source's own cache actually saving anything" at a glance: checks vs. networkCalls
-// equal means every tick is hitting the network regardless of cache state. `redundant` is
-// the sharper signal for that same question — it counts preloads whose resolved URL turned
-// out identical to the image already displayed, i.e. bytes that were re-fetched and
-// re-decoded for nothing. `attempts` vs. `networkCalls`+`failures` separates "tried" from
-// "succeeded", since a failed preload (sun's retry path) previously vanished from the count
-// entirely instead of showing up as a real network cost.
-export interface SourceDebugStats {
-  checks: number;
-  attempts: number;
-  networkCalls: number;
-  failures: number;
-  redundant: number;
-  avgFetchMs: number | null;
-}
-
-interface DebugAccumulator {
-  checks: number;
-  attempts: number;
-  networkCalls: number;
-  failures: number;
-  redundant: number;
-  fetchMsTotal: number;
-}
-
-function emptyDebugAccumulator(): DebugAccumulator {
-  return { checks: 0, attempts: 0, networkCalls: 0, failures: 0, redundant: 0, fetchMsTotal: 0 };
-}
-
-function toDebugStats(acc: DebugAccumulator): SourceDebugStats {
-  return {
-    checks: acc.checks,
-    attempts: acc.attempts,
-    networkCalls: acc.networkCalls,
-    failures: acc.failures,
-    redundant: acc.redundant,
-    avgFetchMs: acc.networkCalls > 0 ? acc.fetchMsTotal / acc.networkCalls : null,
-  };
-}
 
 // Render-ready shape for card.ts's template — raw data only (dates, urls, booleans), no
 // formatting, so formatRelativeAge/date-formatting stays in card.ts alongside its other
@@ -98,29 +59,40 @@ function preloadImage(url: string): Promise<void> {
 // step back, one retry. Used only by refresh() — every source's image, for both the gallery
 // strip and a full-screen panel, is resolved there and nowhere else, so a slow or failing
 // candidate is caught before it ever reaches a visible <img>.
-async function timedPreload(url: string, debug: DebugAccumulator): Promise<void> {
+// Shared by both the image-byte preload and (for earth) the EPIC JSON lookup that precedes
+// it — from the debug overlay's point of view, both are "an attempt at a real network call",
+// so they share one set of counters rather than needing their own column each.
+async function timedAttempt<T>(op: () => Promise<T>, debug: DebugAccumulator): Promise<T> {
   debug.attempts++;
+  debug.lastAttemptAt = Date.now();
   const start = performance.now();
   try {
-    await preloadImage(url);
-    debug.networkCalls++;
+    const result = await op();
+    debug.network++;
     debug.fetchMsTotal += performance.now() - start;
+    return result;
   } catch (err) {
     debug.failures++;
     throw err;
   }
 }
 
+function timedPreload(url: string, debug: DebugAccumulator): Promise<void> {
+  return timedAttempt(() => preloadImage(url), debug);
+}
+
 async function resolveDisplayImage(
   mode: ImageSource,
   debug: DebugAccumulator
 ): Promise<SourcedImage> {
-  const candidate = mode === "earth" ? await fetchLatestEarthImageUrl() : getSunImageUrl();
+  const candidate =
+    mode === "earth" ? await timedAttempt(fetchLatestEarthImageUrl, debug) : getSunImageUrl();
   try {
     await timedPreload(candidate.url, debug);
     return candidate;
   } catch (err) {
     if (mode !== "sun") throw err;
+    debug.retries++;
     const fallback = getPreviousSunSlot(candidate.date);
     await timedPreload(fallback.url, debug);
     return fallback;
@@ -391,7 +363,7 @@ export class GalleryController {
     const sources = this._fetchSources;
     const previousUrls: Partial<Record<ImageSource, string>> = {};
     for (const source of sources) {
-      this._debug[source].checks++;
+      this._debug[source].ticks++;
       previousUrls[source] = this._images[source]?.url;
     }
     const results = await Promise.allSettled(

--- a/src/card/gallery-controller.ts
+++ b/src/card/gallery-controller.ts
@@ -13,6 +13,33 @@ export type GalleryMode = "none" | "earth" | "sun" | "both" | "slide";
 export const GALLERY_MODES: GalleryMode[] = ["none", "earth", "sun", "both", "slide"];
 export const DEFAULT_GALLERY_INTERVAL_MS = 60000;
 
+// Cumulative, since the card was mounted — not a rolling window. Lets debug:true answer "is
+// this source's own cache actually saving anything" at a glance: checks vs. networkCalls
+// equal means every tick is hitting the network regardless of cache state.
+export interface SourceDebugStats {
+  checks: number;
+  networkCalls: number;
+  avgFetchMs: number | null;
+}
+
+interface DebugAccumulator {
+  checks: number;
+  networkCalls: number;
+  fetchMsTotal: number;
+}
+
+function emptyDebugAccumulator(): DebugAccumulator {
+  return { checks: 0, networkCalls: 0, fetchMsTotal: 0 };
+}
+
+function toDebugStats(acc: DebugAccumulator): SourceDebugStats {
+  return {
+    checks: acc.checks,
+    networkCalls: acc.networkCalls,
+    avgFetchMs: acc.networkCalls > 0 ? acc.fetchMsTotal / acc.networkCalls : null,
+  };
+}
+
 // Render-ready shape for card.ts's template — raw data only (dates, urls, booleans), no
 // formatting, so formatRelativeAge/date-formatting stays in card.ts alongside its other
 // display logic. Collapses the branching card.ts's render() otherwise reconstructs from the
@@ -27,6 +54,8 @@ export interface GalleryViewModel {
   thumbnails: { source: ImageSource; url: string | null; date: Date | null }[];
   navButtonVisible: boolean;
   navButtonActive: boolean;
+  debugStats: Record<ImageSource, SourceDebugStats>;
+  debugStartedAt: number;
 }
 
 // Confirms a candidate image URL actually loads AND decodes before anything commits to
@@ -55,15 +84,25 @@ function preloadImage(url: string): Promise<void> {
 // step back, one retry. Used only by refresh() — every source's image, for both the gallery
 // strip and a full-screen panel, is resolved there and nowhere else, so a slow or failing
 // candidate is caught before it ever reaches a visible <img>.
-async function resolveDisplayImage(mode: ImageSource): Promise<SourcedImage> {
+async function timedPreload(url: string, debug: DebugAccumulator): Promise<void> {
+  const start = performance.now();
+  await preloadImage(url);
+  debug.networkCalls++;
+  debug.fetchMsTotal += performance.now() - start;
+}
+
+async function resolveDisplayImage(
+  mode: ImageSource,
+  debug: DebugAccumulator
+): Promise<SourcedImage> {
   const candidate = mode === "earth" ? await fetchLatestEarthImageUrl() : getSunImageUrl();
   try {
-    await preloadImage(candidate.url);
+    await timedPreload(candidate.url, debug);
     return candidate;
   } catch (err) {
     if (mode !== "sun") throw err;
     const fallback = getPreviousSunSlot(candidate.date);
-    await preloadImage(fallback.url);
+    await timedPreload(fallback.url, debug);
     return fallback;
   }
 }
@@ -89,6 +128,8 @@ export class GalleryController {
   private _autoDisplayedSource: ImageSource;
   private _autoSwitchTimer: number | null;
   private _onChange: () => void;
+  private _debug: Record<ImageSource, DebugAccumulator>;
+  private _debugStartedAt: number;
 
   constructor(onChange: () => void) {
     this._panelMode = "none";
@@ -103,6 +144,8 @@ export class GalleryController {
     this._autoDisplayedSource = "earth";
     this._autoSwitchTimer = null;
     this._onChange = onChange;
+    this._debug = { earth: emptyDebugAccumulator(), sun: emptyDebugAccumulator() };
+    this._debugStartedAt = Date.now();
   }
 
   get panelMode(): ImagePanelMode {
@@ -129,6 +172,9 @@ export class GalleryController {
   get images(): Partial<Record<ImageSource, SourcedImage>> {
     return this._images;
   }
+  get debugStats(): Record<ImageSource, SourceDebugStats> {
+    return { earth: toDebugStats(this._debug.earth), sun: toDebugStats(this._debug.sun) };
+  }
 
   // Sources rendered as thumbnails right now.
   get displaySources(): ImageSource[] {
@@ -150,6 +196,8 @@ export class GalleryController {
       })),
       navButtonVisible: this._mode !== "none",
       navButtonActive: this._open,
+      debugStats: this.debugStats,
+      debugStartedAt: this._debugStartedAt,
     };
   }
 
@@ -321,7 +369,10 @@ export class GalleryController {
   // the single place that keeps an open full-screen panel in sync with the same source.
   private async refresh(): Promise<void> {
     const sources = this._fetchSources;
-    const results = await Promise.allSettled(sources.map((source) => resolveDisplayImage(source)));
+    for (const source of sources) this._debug[source].checks++;
+    const results = await Promise.allSettled(
+      sources.map((source) => resolveDisplayImage(source, this._debug[source]))
+    );
     for (let i = 0; i < results.length; i++) {
       const result = results[i];
       const source = sources[i];

--- a/src/card/gallery-controller.ts
+++ b/src/card/gallery-controller.ts
@@ -15,27 +15,41 @@ export const DEFAULT_GALLERY_INTERVAL_MS = 60000;
 
 // Cumulative, since the card was mounted — not a rolling window. Lets debug:true answer "is
 // this source's own cache actually saving anything" at a glance: checks vs. networkCalls
-// equal means every tick is hitting the network regardless of cache state.
+// equal means every tick is hitting the network regardless of cache state. `redundant` is
+// the sharper signal for that same question — it counts preloads whose resolved URL turned
+// out identical to the image already displayed, i.e. bytes that were re-fetched and
+// re-decoded for nothing. `attempts` vs. `networkCalls`+`failures` separates "tried" from
+// "succeeded", since a failed preload (sun's retry path) previously vanished from the count
+// entirely instead of showing up as a real network cost.
 export interface SourceDebugStats {
   checks: number;
+  attempts: number;
   networkCalls: number;
+  failures: number;
+  redundant: number;
   avgFetchMs: number | null;
 }
 
 interface DebugAccumulator {
   checks: number;
+  attempts: number;
   networkCalls: number;
+  failures: number;
+  redundant: number;
   fetchMsTotal: number;
 }
 
 function emptyDebugAccumulator(): DebugAccumulator {
-  return { checks: 0, networkCalls: 0, fetchMsTotal: 0 };
+  return { checks: 0, attempts: 0, networkCalls: 0, failures: 0, redundant: 0, fetchMsTotal: 0 };
 }
 
 function toDebugStats(acc: DebugAccumulator): SourceDebugStats {
   return {
     checks: acc.checks,
+    attempts: acc.attempts,
     networkCalls: acc.networkCalls,
+    failures: acc.failures,
+    redundant: acc.redundant,
     avgFetchMs: acc.networkCalls > 0 ? acc.fetchMsTotal / acc.networkCalls : null,
   };
 }
@@ -85,10 +99,16 @@ function preloadImage(url: string): Promise<void> {
 // strip and a full-screen panel, is resolved there and nowhere else, so a slow or failing
 // candidate is caught before it ever reaches a visible <img>.
 async function timedPreload(url: string, debug: DebugAccumulator): Promise<void> {
+  debug.attempts++;
   const start = performance.now();
-  await preloadImage(url);
-  debug.networkCalls++;
-  debug.fetchMsTotal += performance.now() - start;
+  try {
+    await preloadImage(url);
+    debug.networkCalls++;
+    debug.fetchMsTotal += performance.now() - start;
+  } catch (err) {
+    debug.failures++;
+    throw err;
+  }
 }
 
 async function resolveDisplayImage(
@@ -342,7 +362,7 @@ export class GalleryController {
     const known = this._images[next];
     if (known) {
       try {
-        await preloadImage(known.url);
+        await timedPreload(known.url, this._debug[next]);
       } catch {
         // Already-validated URL failing a re-decode is transient; show it anyway rather
         // than getting stuck on the previous source forever.
@@ -369,7 +389,11 @@ export class GalleryController {
   // the single place that keeps an open full-screen panel in sync with the same source.
   private async refresh(): Promise<void> {
     const sources = this._fetchSources;
-    for (const source of sources) this._debug[source].checks++;
+    const previousUrls: Partial<Record<ImageSource, string>> = {};
+    for (const source of sources) {
+      this._debug[source].checks++;
+      previousUrls[source] = this._images[source]?.url;
+    }
     const results = await Promise.allSettled(
       sources.map((source) => resolveDisplayImage(source, this._debug[source]))
     );
@@ -377,6 +401,7 @@ export class GalleryController {
       const result = results[i];
       const source = sources[i];
       if (result.status === "fulfilled") {
+        if (result.value.url === previousUrls[source]) this._debug[source].redundant++;
         this._images[source] = result.value;
         if (this._panelMode === source) {
           this._applyImage(result.value.url, result.value.date);

--- a/src/card/relative-time.ts
+++ b/src/card/relative-time.ts
@@ -4,3 +4,14 @@ export function formatRelativeAge(date: Date, now: Date): string {
   if (diffMin < 60) return `${diffMin}m ago`;
   return `${Math.floor(diffMin / 60)}h ago`;
 }
+
+// Same floor-to-minutes/floor-to-hours bucketing as formatRelativeAge, just phrased for a
+// duration-since-mount instead of an age-of-a-timestamp, so "running for" reads naturally.
+export function formatDuration(ms: number): string {
+  const minutes = Math.floor(ms / 60000);
+  if (minutes < 1) return `${Math.floor(ms / 1000)}s`;
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remainderMin = minutes % 60;
+  return remainderMin ? `${hours}h ${remainderMin}m` : `${hours}h`;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,6 +113,7 @@ export interface CardConfig {
   colors?: Colors;
   ecliptic_view?: string;
   show_version?: boolean;
+  debug?: boolean;
   gallery?: { mode?: string; slide_interval_secs?: number };
   location?: { latitude?: number; longitude?: number; name?: string };
 }

--- a/test/__snapshots__/snapshot.test.ts.snap
+++ b/test/__snapshots__/snapshot.test.ts.snap
@@ -236,7 +236,9 @@ exports[`cardStyles > matches snapshot 1`] = `
   .debug-overlay {
     position: absolute;
     left: 0;
+    right: 0;
     top: 100%;
+    box-sizing: border-box;
     pointer-events: none;
     background: rgba(0, 0, 0, 0.25);
     backdrop-filter: blur(4px);
@@ -252,7 +254,9 @@ exports[`cardStyles > matches snapshot 1`] = `
     margin-top: 2px;
   }
   .debug-overlay table {
+    width: 100%;
     border-collapse: collapse;
+    table-layout: fixed;
   }
   .debug-overlay th,
   .debug-overlay td {
@@ -267,6 +271,10 @@ exports[`cardStyles > matches snapshot 1`] = `
   .debug-overlay th {
     color: #66bb9a;
     font-weight: normal;
+  }
+  .debug-total td {
+    border-top: 1px solid rgba(0, 230, 118, 0.3);
+    color: #66bb9a;
   }
   .card-version {
     font-size: 9px;

--- a/test/__snapshots__/snapshot.test.ts.snap
+++ b/test/__snapshots__/snapshot.test.ts.snap
@@ -56,9 +56,12 @@ exports[`cardStyles > matches snapshot 1`] = `
     display: flex;
     flex-direction: column;
   }
-  .status-bar {
+  .status-bar-row {
     position: relative;
     flex: 0 0 auto;
+  }
+  .status-bar {
+    position: relative;
     background: var(--secondary-background-color, color-mix(in srgb, currentColor 10%, transparent));
     font-size: 10px;
     color: inherit;
@@ -229,6 +232,41 @@ exports[`cardStyles > matches snapshot 1`] = `
     display: flex;
     align-items: center;
     box-sizing: border-box;
+  }
+  .debug-overlay {
+    position: absolute;
+    left: 0;
+    top: 100%;
+    pointer-events: none;
+    background: rgba(0, 0, 0, 0.25);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+    color: #00e676;
+    font-family: monospace;
+    font-size: 10px;
+    line-height: 1.3;
+    padding: 3px 6px;
+  }
+  .debug-caption {
+    color: #66bb9a;
+    margin-top: 2px;
+  }
+  .debug-overlay table {
+    border-collapse: collapse;
+  }
+  .debug-overlay th,
+  .debug-overlay td {
+    padding: 0 6px 0 0;
+    text-align: right;
+    white-space: nowrap;
+  }
+  .debug-overlay th:first-child,
+  .debug-overlay td:first-child {
+    text-align: left;
+  }
+  .debug-overlay th {
+    color: #66bb9a;
+    font-weight: normal;
   }
   .card-version {
     font-size: 9px;

--- a/test/card/card-template.test.ts
+++ b/test/card/card-template.test.ts
@@ -9,7 +9,14 @@ import {
 } from "../../src/card/card-template.js";
 import type { GalleryViewModel, SourceDebugStats } from "../../src/card/gallery-controller.js";
 
-const zeroDebugStats: SourceDebugStats = { checks: 0, networkCalls: 0, avgFetchMs: null };
+const zeroDebugStats: SourceDebugStats = {
+  checks: 0,
+  attempts: 0,
+  networkCalls: 0,
+  failures: 0,
+  redundant: 0,
+  avgFetchMs: null,
+};
 
 function galleryViewModel(overrides: Partial<GalleryViewModel> = {}): GalleryViewModel {
   return {
@@ -162,7 +169,10 @@ describe("buildImageStatusBar", () => {
 });
 
 describe("buildDebugOverlay", () => {
-  const stats = { earth: zeroDebugStats, sun: { checks: 4, networkCalls: 2, avgFetchMs: 123.4 } };
+  const stats = {
+    earth: zeroDebugStats,
+    sun: { checks: 4, attempts: 3, networkCalls: 2, failures: 1, redundant: 1, avgFetchMs: 123.4 },
+  };
 
   it("shows 0s on the very first render, right at startedAt", () => {
     const startedAt = Date.now();
@@ -195,8 +205,8 @@ describe("buildDebugOverlay", () => {
     const rows = root.querySelectorAll("tbody tr, table tr");
     const cells = [...rows].slice(1).map((row) => [...row.children].map((td) => td.textContent));
     expect(cells).toEqual([
-      ["SDO/S", "4", "2", "123ms"],
-      ["DSCOVR/E", "0", "0", "—"],
+      ["SDO/S", "4", "3", "2", "1", "1", "123ms"],
+      ["DSCOVR/E", "0", "0", "0", "0", "0", "—"],
     ]);
   });
 });

--- a/test/card/card-template.test.ts
+++ b/test/card/card-template.test.ts
@@ -1,12 +1,15 @@
 import { nothing, render } from "lit";
 import { describe, expect, it } from "vitest";
 import {
+  buildDebugOverlay,
   buildImageStatusBar,
   buildStatusBar,
   buildStatusBarView,
   formatDate,
 } from "../../src/card/card-template.js";
-import type { GalleryViewModel } from "../../src/card/gallery-controller.js";
+import type { GalleryViewModel, SourceDebugStats } from "../../src/card/gallery-controller.js";
+
+const zeroDebugStats: SourceDebugStats = { checks: 0, networkCalls: 0, avgFetchMs: null };
 
 function galleryViewModel(overrides: Partial<GalleryViewModel> = {}): GalleryViewModel {
   return {
@@ -19,6 +22,8 @@ function galleryViewModel(overrides: Partial<GalleryViewModel> = {}): GalleryVie
     thumbnails: [],
     navButtonVisible: false,
     navButtonActive: false,
+    debugStats: { earth: zeroDebugStats, sun: zeroDebugStats },
+    debugStartedAt: Date.now(),
     ...overrides,
   };
 }
@@ -153,6 +158,46 @@ describe("buildImageStatusBar", () => {
       buildImageStatusBar("sun", "26-08-12 11:55", new Date("2026-08-12T11:55:00Z"), now, false)
     );
     expect(root.querySelector(".status-bar span").textContent).toBe("SUN · SDO HMI · loading…");
+  });
+});
+
+describe("buildDebugOverlay", () => {
+  const stats = { earth: zeroDebugStats, sun: { checks: 4, networkCalls: 2, avgFetchMs: 123.4 } };
+
+  it("shows 0s on the very first render, right at startedAt", () => {
+    const startedAt = Date.now();
+    const root = renderToDOM(buildDebugOverlay(stats, startedAt));
+    expect(root.querySelector(".debug-caption").textContent).toBe("running for 0s");
+  });
+
+  it("shows seconds under a minute after startedAt", () => {
+    const root = renderToDOM(buildDebugOverlay(stats, Date.now() - 30_000));
+    expect(root.querySelector(".debug-caption").textContent).toBe("running for 30s");
+  });
+
+  it("shows minutes only under an hour", () => {
+    const root = renderToDOM(buildDebugOverlay(stats, Date.now() - 5 * 60_000));
+    expect(root.querySelector(".debug-caption").textContent).toBe("running for 5m");
+  });
+
+  it("shows hours and minutes when both are non-zero", () => {
+    const root = renderToDOM(buildDebugOverlay(stats, Date.now() - (2 * 60 + 5) * 60_000));
+    expect(root.querySelector(".debug-caption").textContent).toBe("running for 2h 5m");
+  });
+
+  it("shows whole hours with no minutes remainder", () => {
+    const root = renderToDOM(buildDebugOverlay(stats, Date.now() - 3 * 60 * 60_000));
+    expect(root.querySelector(".debug-caption").textContent).toBe("running for 3h");
+  });
+
+  it("renders a row per source with its stats, formatting a null avgFetchMs as '—'", () => {
+    const root = renderToDOM(buildDebugOverlay(stats, Date.now()));
+    const rows = root.querySelectorAll("tbody tr, table tr");
+    const cells = [...rows].slice(1).map((row) => [...row.children].map((td) => td.textContent));
+    expect(cells).toEqual([
+      ["SDO/S", "4", "2", "123ms"],
+      ["DSCOVR/E", "0", "0", "—"],
+    ]);
   });
 });
 

--- a/test/card/card-template.test.ts
+++ b/test/card/card-template.test.ts
@@ -1,21 +1,23 @@
 import { nothing, render } from "lit";
 import { describe, expect, it } from "vitest";
 import {
-  buildDebugOverlay,
   buildImageStatusBar,
   buildStatusBar,
   buildStatusBarView,
   formatDate,
 } from "../../src/card/card-template.js";
-import type { GalleryViewModel, SourceDebugStats } from "../../src/card/gallery-controller.js";
+import type { SourceDebugStats } from "../../src/card/debug.js";
+import type { GalleryViewModel } from "../../src/card/gallery-controller.js";
 
 const zeroDebugStats: SourceDebugStats = {
-  checks: 0,
+  ticks: 0,
   attempts: 0,
-  networkCalls: 0,
+  network: 0,
   failures: 0,
+  retries: 0,
   redundant: 0,
-  avgFetchMs: null,
+  elapsed: null,
+  lastAttemptAt: null,
 };
 
 function galleryViewModel(overrides: Partial<GalleryViewModel> = {}): GalleryViewModel {
@@ -165,49 +167,6 @@ describe("buildImageStatusBar", () => {
       buildImageStatusBar("sun", "26-08-12 11:55", new Date("2026-08-12T11:55:00Z"), now, false)
     );
     expect(root.querySelector(".status-bar span").textContent).toBe("SUN · SDO HMI · loading…");
-  });
-});
-
-describe("buildDebugOverlay", () => {
-  const stats = {
-    earth: zeroDebugStats,
-    sun: { checks: 4, attempts: 3, networkCalls: 2, failures: 1, redundant: 1, avgFetchMs: 123.4 },
-  };
-
-  it("shows 0s on the very first render, right at startedAt", () => {
-    const startedAt = Date.now();
-    const root = renderToDOM(buildDebugOverlay(stats, startedAt));
-    expect(root.querySelector(".debug-caption").textContent).toBe("running for 0s");
-  });
-
-  it("shows seconds under a minute after startedAt", () => {
-    const root = renderToDOM(buildDebugOverlay(stats, Date.now() - 30_000));
-    expect(root.querySelector(".debug-caption").textContent).toBe("running for 30s");
-  });
-
-  it("shows minutes only under an hour", () => {
-    const root = renderToDOM(buildDebugOverlay(stats, Date.now() - 5 * 60_000));
-    expect(root.querySelector(".debug-caption").textContent).toBe("running for 5m");
-  });
-
-  it("shows hours and minutes when both are non-zero", () => {
-    const root = renderToDOM(buildDebugOverlay(stats, Date.now() - (2 * 60 + 5) * 60_000));
-    expect(root.querySelector(".debug-caption").textContent).toBe("running for 2h 5m");
-  });
-
-  it("shows whole hours with no minutes remainder", () => {
-    const root = renderToDOM(buildDebugOverlay(stats, Date.now() - 3 * 60 * 60_000));
-    expect(root.querySelector(".debug-caption").textContent).toBe("running for 3h");
-  });
-
-  it("renders a row per source with its stats, formatting a null avgFetchMs as '—'", () => {
-    const root = renderToDOM(buildDebugOverlay(stats, Date.now()));
-    const rows = root.querySelectorAll("tbody tr, table tr");
-    const cells = [...rows].slice(1).map((row) => [...row.children].map((td) => td.textContent));
-    expect(cells).toEqual([
-      ["SDO/S", "4", "3", "2", "1", "1", "123ms"],
-      ["DSCOVR/E", "0", "0", "0", "0", "0", "—"],
-    ]);
   });
 });
 

--- a/test/card/card.test.ts
+++ b/test/card/card.test.ts
@@ -451,18 +451,18 @@ describe("SolarViewCard", () => {
 
     it("shows sun/earth rows with cumulative stats when debug is true", async () => {
       const card = createAndMount({ debug: true, gallery: { mode: "both" } });
-      await vi.waitFor(() => expect(card._gallery.debugStats.sun.networkCalls).toBe(1));
+      await vi.waitFor(() => expect(card._gallery.debugStats.sun.network).toBe(1));
       card._render();
       const overlay = card.shadowRoot.querySelector(".debug-overlay");
       const rowText = [...overlay.querySelectorAll("tr")].map((tr) => tr.textContent);
       expect(rowText[1]).toContain("SDO/S");
       expect(rowText[2]).toContain("DSCOVR/E");
       expect(overlay.textContent).toContain("source");
-      expect(overlay.textContent).toContain("checks");
-      expect(overlay.textContent).toContain("attempts");
-      expect(overlay.textContent).toContain("redundant");
+      expect(overlay.textContent).toContain("ticks");
+      expect(overlay.textContent).toContain("atmpt");
+      expect(overlay.textContent).toContain("dup");
       expect(overlay.textContent).toMatch(/\d+ms/);
-      expect(overlay.textContent).toContain("running for ");
+      expect(overlay.textContent).toContain("since ");
       card.remove();
     });
 

--- a/test/card/card.test.ts
+++ b/test/card/card.test.ts
@@ -459,7 +459,8 @@ describe("SolarViewCard", () => {
       expect(rowText[2]).toContain("DSCOVR/E");
       expect(overlay.textContent).toContain("source");
       expect(overlay.textContent).toContain("checks");
-      expect(overlay.textContent).toContain("net-calls");
+      expect(overlay.textContent).toContain("attempts");
+      expect(overlay.textContent).toContain("redundant");
       expect(overlay.textContent).toMatch(/\d+ms/);
       expect(overlay.textContent).toContain("running for ");
       card.remove();

--- a/test/card/card.test.ts
+++ b/test/card/card.test.ts
@@ -442,6 +442,38 @@ describe("SolarViewCard", () => {
     });
   });
 
+  describe("debug overlay", () => {
+    it("hides by default", () => {
+      const card = createAndMount();
+      expect(card.shadowRoot.querySelector(".debug-overlay")).toBeNull();
+      card.remove();
+    });
+
+    it("shows sun/earth rows with cumulative stats when debug is true", async () => {
+      const card = createAndMount({ debug: true, gallery: { mode: "both" } });
+      await vi.waitFor(() => expect(card._gallery.debugStats.sun.networkCalls).toBe(1));
+      card._render();
+      const overlay = card.shadowRoot.querySelector(".debug-overlay");
+      const rowText = [...overlay.querySelectorAll("tr")].map((tr) => tr.textContent);
+      expect(rowText[1]).toContain("SDO/S");
+      expect(rowText[2]).toContain("DSCOVR/E");
+      expect(overlay.textContent).toContain("source");
+      expect(overlay.textContent).toContain("checks");
+      expect(overlay.textContent).toContain("net-calls");
+      expect(overlay.textContent).toMatch(/\d+ms/);
+      expect(overlay.textContent).toContain("running for ");
+      card.remove();
+    });
+
+    it("hides when debug is false", () => {
+      const card = createAndMount();
+      card.setConfig({ debug: false });
+      card._render();
+      expect(card.shadowRoot.querySelector(".debug-overlay")).toBeNull();
+      card.remove();
+    });
+  });
+
   describe("day navigation", () => {
     it("day-back rewinds by 1 day", () => {
       const card = createAndMount();

--- a/test/card/debug.test.ts
+++ b/test/card/debug.test.ts
@@ -1,0 +1,113 @@
+import { render } from "lit";
+import { describe, expect, it } from "vitest";
+import { formatDate } from "../../src/card/card-template.js";
+import type { SourceDebugStats } from "../../src/card/debug.js";
+import { buildDebugOverlay } from "../../src/card/debug.js";
+
+const zeroDebugStats: SourceDebugStats = {
+  ticks: 0,
+  attempts: 0,
+  network: 0,
+  failures: 0,
+  retries: 0,
+  redundant: 0,
+  elapsed: null,
+  lastAttemptAt: null,
+};
+
+function renderToDOM(result) {
+  const div = document.createElement("div");
+  render(result, div);
+  return div;
+}
+
+describe("buildDebugOverlay", () => {
+  const stats = {
+    earth: zeroDebugStats,
+    sun: {
+      ticks: 4,
+      attempts: 3,
+      network: 2,
+      failures: 1,
+      retries: 2,
+      redundant: 1,
+      elapsed: 123.4,
+      lastAttemptAt: Date.now() - 5 * 60_000,
+    },
+  };
+
+  it("shows 0s on the very first render, right at startedAt", () => {
+    const startedAt = Date.now();
+    const root = renderToDOM(buildDebugOverlay(stats, startedAt));
+    expect(root.querySelector(".debug-caption").textContent).toBe(
+      `since ${formatDate(new Date(startedAt))} (0s)`
+    );
+  });
+
+  it("shows seconds under a minute after startedAt", () => {
+    const startedAt = Date.now() - 30_000;
+    const root = renderToDOM(buildDebugOverlay(stats, startedAt));
+    expect(root.querySelector(".debug-caption").textContent).toBe(
+      `since ${formatDate(new Date(startedAt))} (30s)`
+    );
+  });
+
+  it("shows minutes only under an hour", () => {
+    const startedAt = Date.now() - 5 * 60_000;
+    const root = renderToDOM(buildDebugOverlay(stats, startedAt));
+    expect(root.querySelector(".debug-caption").textContent).toBe(
+      `since ${formatDate(new Date(startedAt))} (5m)`
+    );
+  });
+
+  it("shows hours and minutes when both are non-zero", () => {
+    const startedAt = Date.now() - (2 * 60 + 5) * 60_000;
+    const root = renderToDOM(buildDebugOverlay(stats, startedAt));
+    expect(root.querySelector(".debug-caption").textContent).toBe(
+      `since ${formatDate(new Date(startedAt))} (2h 5m)`
+    );
+  });
+
+  it("shows whole hours with no minutes remainder", () => {
+    const startedAt = Date.now() - 3 * 60 * 60_000;
+    const root = renderToDOM(buildDebugOverlay(stats, startedAt));
+    expect(root.querySelector(".debug-caption").textContent).toBe(
+      `since ${formatDate(new Date(startedAt))} (3h)`
+    );
+  });
+
+  it("renders a row per source with its stats, formatting a null elapsed as '—'", () => {
+    const root = renderToDOM(buildDebugOverlay(stats, Date.now()));
+    const rows = root.querySelectorAll("tbody tr, table tr");
+    const cells = [...rows].slice(1).map((row) => [...row.children].map((td) => td.textContent));
+    expect(cells).toEqual([
+      ["SDO/S", "4", "3", "2", "1", "2", "1", "123ms", "5m"],
+      ["DSCOVR/E", "0", "0", "0", "0", "0", "0", "—", "—"],
+      // total: ticks max()s (4 vs. 0) rather than summing, elapsed avg()s the non-null
+      // values (just sun's 123.4 here), last is always "—" — see summarizeDebugStats.
+      ["total", "4", "3", "2", "1", "2", "1", "123ms", "—"],
+    ]);
+  });
+
+  it("shows seconds in the last column under a minute, not a floored 'just now'", () => {
+    const recent = {
+      earth: zeroDebugStats,
+      sun: { ...zeroDebugStats, lastAttemptAt: Date.now() - 45_000 },
+    };
+    const root = renderToDOM(buildDebugOverlay(recent, Date.now()));
+    const sunRow = [...root.querySelectorAll("table tr")[1].children].map((td) => td.textContent);
+    expect(sunRow[sunRow.length - 1]).toBe("45s");
+  });
+
+  it("sums the total row's ticks with max() instead of add(), for lockstep both/slide modes", () => {
+    const lockstep = {
+      sun: { ...zeroDebugStats, ticks: 5, elapsed: 100 },
+      earth: { ...zeroDebugStats, ticks: 5, elapsed: 200 },
+    };
+    const root = renderToDOM(buildDebugOverlay(lockstep, Date.now()));
+    const rows = [...root.querySelectorAll("table tr")].slice(1);
+    const totalRow = [...rows[rows.length - 1].children].map((td) => td.textContent);
+    // max(5, 5) = 5, not 10 — and elapsed averages to (100 + 200) / 2 = 150ms.
+    expect(totalRow).toEqual(["total", "5", "0", "0", "0", "0", "0", "150ms", "—"]);
+  });
+});

--- a/test/card/gallery-controller.test.ts
+++ b/test/card/gallery-controller.test.ts
@@ -292,12 +292,14 @@ describe("GalleryController.viewModel", () => {
 
 describe("GalleryController.debugStats", () => {
   const zeroStats = {
-    checks: 0,
+    ticks: 0,
     attempts: 0,
-    networkCalls: 0,
+    network: 0,
     failures: 0,
+    retries: 0,
     redundant: 0,
-    avgFetchMs: null,
+    elapsed: null,
+    lastAttemptAt: null,
   };
 
   it("starts at zero for both sources", () => {
@@ -305,43 +307,59 @@ describe("GalleryController.debugStats", () => {
     expect(gallery.debugStats).toEqual({ earth: zeroStats, sun: zeroStats });
   });
 
-  it("counts one check and one network call per source per tick, with no cache gate", async () => {
+  it("counts one tick and one network call per source, each refresh, with no cache gate", async () => {
     const gallery = new GalleryController(() => {});
     gallery.configure("both", 60000);
     gallery.start();
     await vi.waitFor(() => expect(gallery.images.earth).toBeDefined());
 
     gallery.tick();
-    await vi.waitFor(() => expect(gallery.debugStats.earth.networkCalls).toBe(2));
+    // Earth counts 2 network calls per tick — the EPIC API lookup plus the image preload —
+    // so 2 ticks means 4, while sun (no metadata API, just the preload) stays at 2.
+    await vi.waitFor(() => expect(gallery.debugStats.earth.network).toBe(4));
 
     // Today's known bug: nothing skips the network call even though the URL didn't
-    // change, so checks and networkCalls stay in lockstep every tick. `redundant`
+    // change, so ticks and network stay in lockstep every tick. `redundant`
     // surfaces exactly this — the second tick's resolved URL matches the first's.
-    expect(gallery.debugStats.earth.checks).toBe(2);
-    expect(gallery.debugStats.sun.checks).toBe(2);
-    expect(gallery.debugStats.sun.networkCalls).toBe(2);
-    expect(gallery.debugStats.earth.avgFetchMs).not.toBeNull();
+    expect(gallery.debugStats.earth.ticks).toBe(2);
+    expect(gallery.debugStats.sun.ticks).toBe(2);
+    expect(gallery.debugStats.sun.network).toBe(2);
+    expect(gallery.debugStats.earth.elapsed).not.toBeNull();
     expect(gallery.debugStats.earth.redundant).toBe(1);
     expect(gallery.debugStats.sun.redundant).toBe(1);
+    expect(gallery.debugStats.earth.lastAttemptAt).not.toBeNull();
   });
 
-  it("counts a failed preload as an attempt without a network call", async () => {
+  it("counts a failed image preload as an attempt distinct from the EPIC API call", async () => {
     stubImagePreload(false);
     const gallery = new GalleryController(() => {});
     gallery.configure("earth", 60000);
     gallery.start();
     await vi.waitFor(() => expect(gallery.debugStats.earth.failures).toBe(1));
 
-    expect(gallery.debugStats.earth.attempts).toBe(1);
-    expect(gallery.debugStats.earth.networkCalls).toBe(0);
-    expect(gallery.debugStats.earth.avgFetchMs).toBeNull();
+    // 2 attempts (EPIC API lookup + image preload), only the API call succeeded.
+    expect(gallery.debugStats.earth.attempts).toBe(2);
+    expect(gallery.debugStats.earth.network).toBe(1);
+    expect(gallery.debugStats.earth.elapsed).not.toBeNull();
+  });
+
+  it("counts a retry when sun's primary slot guess fails and falls back", async () => {
+    stubImagePreload(false, true);
+    const gallery = new GalleryController(() => {});
+    gallery.configure("sun", 60000);
+    gallery.start();
+    await vi.waitFor(() => expect(gallery.debugStats.sun.retries).toBe(1));
+
+    expect(gallery.debugStats.sun.attempts).toBe(2);
+    expect(gallery.debugStats.sun.network).toBe(1);
+    expect(gallery.debugStats.sun.failures).toBe(1);
   });
 
   it("does not count sources outside the configured mode", async () => {
     const gallery = new GalleryController(() => {});
     gallery.configure("earth", 60000);
     gallery.start();
-    await vi.waitFor(() => expect(gallery.debugStats.earth.checks).toBe(1));
-    expect(gallery.debugStats.sun.checks).toBe(0);
+    await vi.waitFor(() => expect(gallery.debugStats.earth.ticks).toBe(1));
+    expect(gallery.debugStats.sun.ticks).toBe(0);
   });
 });

--- a/test/card/gallery-controller.test.ts
+++ b/test/card/gallery-controller.test.ts
@@ -289,3 +289,38 @@ describe("GalleryController.viewModel", () => {
     expect(gallery.viewModel().navButtonVisible).toBe(false);
   });
 });
+
+describe("GalleryController.debugStats", () => {
+  it("starts at zero for both sources", () => {
+    const gallery = new GalleryController(() => {});
+    expect(gallery.debugStats).toEqual({
+      earth: { checks: 0, networkCalls: 0, avgFetchMs: null },
+      sun: { checks: 0, networkCalls: 0, avgFetchMs: null },
+    });
+  });
+
+  it("counts one check and one network call per source per tick, with no cache gate", async () => {
+    const gallery = new GalleryController(() => {});
+    gallery.configure("both", 60000);
+    gallery.start();
+    await vi.waitFor(() => expect(gallery.images.earth).toBeDefined());
+
+    gallery.tick();
+    await vi.waitFor(() => expect(gallery.debugStats.earth.networkCalls).toBe(2));
+
+    // Today's known bug: nothing skips the network call even though the URL didn't
+    // change, so checks and networkCalls stay in lockstep every tick.
+    expect(gallery.debugStats.earth.checks).toBe(2);
+    expect(gallery.debugStats.sun.checks).toBe(2);
+    expect(gallery.debugStats.sun.networkCalls).toBe(2);
+    expect(gallery.debugStats.earth.avgFetchMs).not.toBeNull();
+  });
+
+  it("does not count sources outside the configured mode", async () => {
+    const gallery = new GalleryController(() => {});
+    gallery.configure("earth", 60000);
+    gallery.start();
+    await vi.waitFor(() => expect(gallery.debugStats.earth.checks).toBe(1));
+    expect(gallery.debugStats.sun.checks).toBe(0);
+  });
+});

--- a/test/card/gallery-controller.test.ts
+++ b/test/card/gallery-controller.test.ts
@@ -291,12 +291,18 @@ describe("GalleryController.viewModel", () => {
 });
 
 describe("GalleryController.debugStats", () => {
+  const zeroStats = {
+    checks: 0,
+    attempts: 0,
+    networkCalls: 0,
+    failures: 0,
+    redundant: 0,
+    avgFetchMs: null,
+  };
+
   it("starts at zero for both sources", () => {
     const gallery = new GalleryController(() => {});
-    expect(gallery.debugStats).toEqual({
-      earth: { checks: 0, networkCalls: 0, avgFetchMs: null },
-      sun: { checks: 0, networkCalls: 0, avgFetchMs: null },
-    });
+    expect(gallery.debugStats).toEqual({ earth: zeroStats, sun: zeroStats });
   });
 
   it("counts one check and one network call per source per tick, with no cache gate", async () => {
@@ -309,11 +315,26 @@ describe("GalleryController.debugStats", () => {
     await vi.waitFor(() => expect(gallery.debugStats.earth.networkCalls).toBe(2));
 
     // Today's known bug: nothing skips the network call even though the URL didn't
-    // change, so checks and networkCalls stay in lockstep every tick.
+    // change, so checks and networkCalls stay in lockstep every tick. `redundant`
+    // surfaces exactly this — the second tick's resolved URL matches the first's.
     expect(gallery.debugStats.earth.checks).toBe(2);
     expect(gallery.debugStats.sun.checks).toBe(2);
     expect(gallery.debugStats.sun.networkCalls).toBe(2);
     expect(gallery.debugStats.earth.avgFetchMs).not.toBeNull();
+    expect(gallery.debugStats.earth.redundant).toBe(1);
+    expect(gallery.debugStats.sun.redundant).toBe(1);
+  });
+
+  it("counts a failed preload as an attempt without a network call", async () => {
+    stubImagePreload(false);
+    const gallery = new GalleryController(() => {});
+    gallery.configure("earth", 60000);
+    gallery.start();
+    await vi.waitFor(() => expect(gallery.debugStats.earth.failures).toBe(1));
+
+    expect(gallery.debugStats.earth.attempts).toBe(1);
+    expect(gallery.debugStats.earth.networkCalls).toBe(0);
+    expect(gallery.debugStats.earth.avgFetchMs).toBeNull();
   });
 
   it("does not count sources outside the configured mode", async () => {


### PR DESCRIPTION
## Summary
- `debug: true` renders an overlay below the top bar (backdrop-blur, doesn't grow card height) showing per-source (sun/earth) checks, attempts, successes, failures, redundant fetches, and avg fetch time, plus how long stats have been collecting.
- `redundant` is the key diagnostic: flags a preload whose resolved URL matches what's already displayed, i.e. bytes re-fetched/re-decoded for nothing new. `attempts`/`failures` separate tried from succeeded — a failed preload previously vanished from the count entirely.

## Test plan
- [x] `npm run test:coverage` — 688 passed, 100% coverage
- [x] `npm run check:ci` — typecheck/lint/format clean