### PR TITLE
refactor: consolidate gallery freshness and refresh accounting

### DIFF
--- a/src/card/image-resolver.ts
+++ b/src/card/image-resolver.ts
@@ -39,7 +39,6 @@ export class ImageResolver {
   ): Promise<{ source: ImageSource; result: PromiseSettledResult<SourcedImage> }[]> {
     const pending = sources.filter((source) => !this._inFlight[source]);
     for (const source of pending) {
-      debug[DEBUG_ROW_KEYS[source].url].refreshes++;
       this._inFlight[source] = true;
     }
     const settled = await Promise.allSettled(

--- a/src/card/source-resolver.ts
+++ b/src/card/source-resolver.ts
@@ -1,6 +1,7 @@
 import type { ImageSource } from "./card-template.js";
 import type { DebugAccumulator } from "./debug.js";
 import type { SourcedImage } from "./url-cache.js";
+import { urlCache } from "./url-cache.js";
 
 // Bounds a hung network request — without it, a stalled fetch or image load has no
 // app-level ceiling and blocks that gallery source indefinitely (only the browser's own
@@ -16,7 +17,6 @@ export const FETCH_TIMEOUT_MS = 15000;
 // extending this and providing those three, without touching the shared protocol.
 export abstract class SourceResolver {
   abstract readonly source: ImageSource;
-  private _decodedUrl: string | undefined;
 
   protected abstract getCached(): SourcedImage | null;
   protected abstract fetchCandidateUrl(debug: DebugAccumulator): Promise<SourcedImage>;
@@ -37,7 +37,7 @@ export abstract class SourceResolver {
   // remount doesn't decode a URL the cache already confirmed current.
   hydrate(): SourcedImage | undefined {
     const cached = this.getCached();
-    if (cached) this._decodedUrl = cached.url;
+    if (cached) urlCache.markDecoded(this.source, cached.url);
     return cached ?? undefined;
   }
 
@@ -46,7 +46,13 @@ export abstract class SourceResolver {
   // + retry). Earth's caller passes two distinct DebugAccumulators (its URL lookup is a real
   // EPIC API call, separate from the image byte fetch); sun's caller passes the same one
   // twice, since its candidate URL is pure math with nothing to separate out.
+  //
+  // Owns `refreshes` itself (bumped unconditionally below) rather than leaving it to the
+  // caller — every call here is one refresh attempt for this source, so the counter and the
+  // attempt it counts live in the same place instead of two files staying in sync by
+  // convention (ImageResolver used to bump this before ever calling resolve()).
   async resolve(urlDebug: DebugAccumulator, imgDebug: DebugAccumulator): Promise<SourcedImage> {
+    urlDebug.refreshes++;
     // Checked before any fetch is attempted, so `cacheHits` climbs on every refresh that's
     // served straight from cache — the direct answer to "is this source's TTL actually
     // skipping the network" that `refreshes` vs. `fetches` alone only implies.
@@ -58,21 +64,21 @@ export abstract class SourceResolver {
     // when the TTL cache had just expired (`expired`): a real fetchCandidateUrl() call that
     // ended up confirming nothing changed. The cache-still-fresh case needs no counter of its
     // own — `cacheHits` already answers that question.
-    if (candidate.url === this._decodedUrl) {
+    if (urlCache.isDecoded(this.source, candidate.url)) {
       if (!cached) urlDebug.expired++;
       return candidate;
     }
     // sun's imgDebug is the same object as urlDebug (see the accumulator comment above), so
-    // it's already been bumped by resolveAll()'s own refreshes++ — only earth's split-off img
-    // row needs its own count of "an image refresh was actually needed" here.
+    // it's already been bumped by the unconditional refreshes++ above — only earth's split-off
+    // img row needs its own count of "an image refresh was actually needed" here.
     if (imgDebug !== urlDebug) imgDebug.refreshes++;
     try {
       await timedPreload(candidate.url, imgDebug);
-      this._decodedUrl = candidate.url;
+      urlCache.markDecoded(this.source, candidate.url);
       return candidate;
     } catch (err) {
       const recovered = await this.recover(err, candidate, imgDebug);
-      this._decodedUrl = recovered.url;
+      urlCache.markDecoded(this.source, recovered.url);
       return recovered;
     }
   }

--- a/src/card/url-cache.ts
+++ b/src/card/url-cache.ts
@@ -12,8 +12,16 @@ interface CacheEntry {
 // eviction beyond that). Owns only the freshness mechanism; each source's own resolver module
 // (source-resolver-dscovrearth.ts, source-resolver-sdosun.ts) owns what a stale entry means for its NASA
 // feed (when to refetch, what TTL it gets).
+//
+// Also owns decode identity per key: which URL that source last confirmed loads. TTL freshness
+// and decode identity answer different questions (is our candidate lookup still current vs.
+// have we already paid the decode cost for this exact URL) and don't share a clock — a TTL can
+// expire while the recomputed candidate is still the same URL we've already decoded. Both live
+// here, not split into a second field on the caller, since both are "what do we already know
+// about this source's state" and a caller needing one usually needs the other in the same call.
 export class UrlCache {
   private entries = new Map<string, CacheEntry>();
+  private decoded = new Map<string, string>();
 
   get(key: string, maxAgeMs: number): SourcedImage | null {
     const entry = this.entries.get(key);
@@ -24,8 +32,17 @@ export class UrlCache {
     this.entries.set(key, { image, fetchedAt: Date.now() });
   }
 
+  isDecoded(key: string, url: string): boolean {
+    return this.decoded.get(key) === url;
+  }
+
+  markDecoded(key: string, url: string): void {
+    this.decoded.set(key, url);
+  }
+
   clear(): void {
     this.entries.clear();
+    this.decoded.clear();
   }
 }
 

--- a/test/card/url-cache.test.ts
+++ b/test/card/url-cache.test.ts
@@ -45,4 +45,30 @@ describe("UrlCache", () => {
     expect(cache.get("earth", 60000)).toBeNull();
     expect(cache.get("sun", 60000)).toBeNull();
   });
+
+  it("isDecoded is false until markDecoded is called for that key and url", () => {
+    const cache = new UrlCache();
+    expect(cache.isDecoded("earth", "https://example.com/a.jpg")).toBe(false);
+    cache.markDecoded("earth", "https://example.com/a.jpg");
+    expect(cache.isDecoded("earth", "https://example.com/a.jpg")).toBe(true);
+  });
+
+  it("isDecoded is false for a different url on the same key", () => {
+    const cache = new UrlCache();
+    cache.markDecoded("earth", "https://example.com/a.jpg");
+    expect(cache.isDecoded("earth", "https://example.com/b.jpg")).toBe(false);
+  });
+
+  it("decode state is independent per key", () => {
+    const cache = new UrlCache();
+    cache.markDecoded("earth", "https://example.com/a.jpg");
+    expect(cache.isDecoded("sun", "https://example.com/a.jpg")).toBe(false);
+  });
+
+  it("clear also resets decode state", () => {
+    const cache = new UrlCache();
+    cache.markDecoded("earth", "https://example.com/a.jpg");
+    cache.clear();
+    expect(cache.isDecoded("earth", "https://example.com/a.jpg")).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- Move decode-identity state (`_decodedUrl`) out of `SourceResolver` into `UrlCache`, alongside its TTL state — one module owns everything known about a source's freshness/idempotency, keyed by source.
- Move `refreshes++` from `ImageResolver.resolveAll()` into `SourceResolver.resolve()` — the counter now lives with the call it counts, instead of caller/callee staying in sync by convention.

Follow-up from the /improve-codebase-architecture review on this repo (candidates 1 & 2, both "Strong"). Replaces #117, which was built on pre-squash commits and hit spurious rename conflicts against main.

## Test plan
- [x] `npm run test:coverage` — 709 passed, 100% coverage
- [x] `npm run check:ci` — typecheck/lint/format clean
- [x] Added direct `UrlCache.isDecoded`/`markDecoded` tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)