### PR TITLE
refactor: give SourceResolver an injectable UrlCache

### DIFF
--- a/src/card/source-resolver-dscovrearth.ts
+++ b/src/card/source-resolver-dscovrearth.ts
@@ -1,6 +1,6 @@
 import type { DebugAccumulator } from "./debug.js";
 import { FETCH_TIMEOUT_MS, SourceResolver, timedAttempt } from "./source-resolver.js";
-import type { SourcedImage } from "./url-cache.js";
+import type { SourcedImage, UrlCache } from "./url-cache.js";
 import { urlCache } from "./url-cache.js";
 
 export const EPIC_BASE_URL = "https://epic.gsfc.nasa.gov";
@@ -15,18 +15,19 @@ export class DscovrEarthResolver extends SourceResolver {
   readonly source = "earth" as const;
 
   protected getCached(): SourcedImage | null {
-    return urlCache.get("earth", EARTH_CACHE_TTL_MS);
+    return this.cache.get("earth", EARTH_CACHE_TTL_MS);
   }
 
   protected fetchCandidateUrl(debug: DebugAccumulator): Promise<SourcedImage> {
-    return timedAttempt(fetchLatestEarthImageUrl, debug);
+    return timedAttempt(() => fetchLatestEarthImageUrl(EARTH_CACHE_TTL_MS, this.cache), debug);
   }
 }
 
 export async function fetchLatestEarthImageUrl(
-  maxAgeMs = EARTH_CACHE_TTL_MS
+  maxAgeMs = EARTH_CACHE_TTL_MS,
+  cache: UrlCache = urlCache
 ): Promise<SourcedImage> {
-  const cached = urlCache.get("earth", maxAgeMs);
+  const cached = cache.get("earth", maxAgeMs);
   if (cached) return cached;
 
   const response = await fetch(`${EPIC_BASE_URL}/api/natural`, {
@@ -60,6 +61,6 @@ export async function fetchLatestEarthImageUrl(
       )
     ),
   };
-  urlCache.set("earth", image);
+  cache.set("earth", image);
   return image;
 }

--- a/src/card/source-resolver-sdosun.ts
+++ b/src/card/source-resolver-sdosun.ts
@@ -1,6 +1,6 @@
 import type { DebugAccumulator } from "./debug.js";
 import { SourceResolver, timedPreload } from "./source-resolver.js";
-import type { SourcedImage } from "./url-cache.js";
+import type { SourcedImage, UrlCache } from "./url-cache.js";
 import { urlCache } from "./url-cache.js";
 
 // SDO publishes HMI Continuum (visible-light sunspot disk) quicklook frames to a dated
@@ -24,11 +24,11 @@ export class SdoSunResolver extends SourceResolver {
   readonly source = "sun" as const;
 
   protected getCached(): SourcedImage | null {
-    return urlCache.get("sun", SUN_CACHE_TTL_MS);
+    return this.cache.get("sun", SUN_CACHE_TTL_MS);
   }
 
   protected fetchCandidateUrl(): Promise<SourcedImage> {
-    return Promise.resolve(getSunImageUrl());
+    return Promise.resolve(getSunImageUrl(SUN_CACHE_TTL_MS, this.cache));
   }
 
   protected async recover(
@@ -46,7 +46,7 @@ export class SdoSunResolver extends SourceResolver {
         // Committed only for the slot that actually loaded — an attempt that 404s never
         // touches the shared cache, so a concurrent reader (another refresh() tick racing
         // this retry loop) can never observe a still-unconfirmed guess between attempts.
-        urlCache.set("sun", slot);
+        this.cache.set("sun", slot);
         return slot;
       } catch (retryErr) {
         lastErr = retryErr;
@@ -56,14 +56,17 @@ export class SdoSunResolver extends SourceResolver {
   }
 }
 
-export function getSunImageUrl(maxAgeMs = SUN_CACHE_TTL_MS): SourcedImage {
-  const cached = urlCache.get("sun", maxAgeMs);
+export function getSunImageUrl(
+  maxAgeMs = SUN_CACHE_TTL_MS,
+  cache: UrlCache = urlCache
+): SourcedImage {
+  const cached = cache.get("sun", maxAgeMs);
   if (cached) return cached;
 
   const now = Date.now();
   const slotMs = Math.floor((now - SUN_PUBLISH_BUFFER_MS) / SUN_CACHE_TTL_MS) * SUN_CACHE_TTL_MS;
   const image = buildSunSlotImage(new Date(slotMs));
-  urlCache.set("sun", image);
+  cache.set("sun", image);
   return image;
 }
 

--- a/src/card/source-resolver.ts
+++ b/src/card/source-resolver.ts
@@ -1,6 +1,6 @@
 import type { ImageSource } from "./card-template.js";
 import type { DebugAccumulator } from "./debug.js";
-import type { SourcedImage } from "./url-cache.js";
+import type { SourcedImage, UrlCache } from "./url-cache.js";
 import { urlCache } from "./url-cache.js";
 
 // Bounds a hung network request — without it, a stalled fetch or image load has no
@@ -17,6 +17,13 @@ export const FETCH_TIMEOUT_MS = 15000;
 // extending this and providing those three, without touching the shared protocol.
 export abstract class SourceResolver {
   abstract readonly source: ImageSource;
+
+  // Defaults to the shared module-level cache so production (and any test that doesn't care
+  // about isolation) behaves exactly as before — HA remounting the card element rebuilds this
+  // resolver, but the module-level cache survives, which is what lets hydrate() below recover
+  // a still-fresh image instead of starting cold. Pass an explicit UrlCache only when a test
+  // needs its state isolated from every other test in the same file.
+  constructor(protected readonly cache: UrlCache = urlCache) {}
 
   protected abstract getCached(): SourcedImage | null;
   protected abstract fetchCandidateUrl(debug: DebugAccumulator): Promise<SourcedImage>;
@@ -37,7 +44,7 @@ export abstract class SourceResolver {
   // remount doesn't decode a URL the cache already confirmed current.
   hydrate(): SourcedImage | undefined {
     const cached = this.getCached();
-    if (cached) urlCache.markDecoded(this.source, cached.url);
+    if (cached) this.cache.markDecoded(this.source, cached.url);
     return cached ?? undefined;
   }
 
@@ -64,7 +71,7 @@ export abstract class SourceResolver {
     // when the TTL cache had just expired (`expired`): a real fetchCandidateUrl() call that
     // ended up confirming nothing changed. The cache-still-fresh case needs no counter of its
     // own — `cacheHits` already answers that question.
-    if (urlCache.isDecoded(this.source, candidate.url)) {
+    if (this.cache.isDecoded(this.source, candidate.url)) {
       if (!cached) urlDebug.expired++;
       return candidate;
     }
@@ -74,11 +81,11 @@ export abstract class SourceResolver {
     if (imgDebug !== urlDebug) imgDebug.refreshes++;
     try {
       await timedPreload(candidate.url, imgDebug);
-      urlCache.markDecoded(this.source, candidate.url);
+      this.cache.markDecoded(this.source, candidate.url);
       return candidate;
     } catch (err) {
       const recovered = await this.recover(err, candidate, imgDebug);
-      urlCache.markDecoded(this.source, recovered.url);
+      this.cache.markDecoded(this.source, recovered.url);
       return recovered;
     }
   }

--- a/test/card/card.test.ts
+++ b/test/card/card.test.ts
@@ -2,8 +2,8 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import { SolarViewCard } from "../../src/card/card.js";
 import { formatDate } from "../../src/card/card-template.js";
 import { EPIC_BASE_URL } from "../../src/card/source-resolver-dscovrearth.js";
-import { getSunImageUrl } from "../../src/card/source-resolver-sdosun.js";
-import { urlCache } from "../../src/card/url-cache.js";
+import { getSunImageUrl, SUN_CACHE_TTL_MS } from "../../src/card/source-resolver-sdosun.js";
+import { UrlCache, urlCache } from "../../src/card/url-cache.js";
 
 beforeAll(() => {
   if (!customElements.get("ha-planetary-solar-system-card-test")) {
@@ -1578,11 +1578,10 @@ describe("SolarViewCard", () => {
       // Retried once, on an earlier slot — thumbnail shows the fallback.
       const sunImg = card.shadowRoot.querySelector('.gallery-thumb[data-source="sun"] img');
       expect(sunImg.getAttribute("src")).not.toBe("");
-      // Retried slot is one 15-min step earlier than a fresh (un-retried) lookup would give
-      // — clear the cache first so this recomputes the primary slot instead of reading back
-      // the retried one the card just cached.
-      urlCache.clear();
-      const primarySlot = getSunImageUrl().date.getTime();
+      // Retried slot is one 15-min step earlier than a fresh (un-retried) lookup would give —
+      // recompute against a scratch cache so this reads the primary slot instead of the
+      // retried one the card just cached into the shared default.
+      const primarySlot = getSunImageUrl(SUN_CACHE_TTL_MS, new UrlCache()).date.getTime();
       expect(card._gallery.images.sun.date.getTime()).toBe(primarySlot - 15 * 60000);
       card.remove();
     });
@@ -1672,8 +1671,7 @@ describe("SolarViewCard", () => {
       card.shadowRoot.querySelector('.gallery-thumb[data-source="sun"]').click();
 
       expect(card._gallery.panelMode).toBe("sun");
-      urlCache.clear();
-      const primarySlot = getSunImageUrl().date.getTime();
+      const primarySlot = getSunImageUrl(SUN_CACHE_TTL_MS, new UrlCache()).date.getTime();
       expect(card._gallery.imageDate.getTime()).toBe(primarySlot - 15 * 60000);
       card.remove();
     });

--- a/test/card/source-resolver-dscovrearth.test.ts
+++ b/test/card/source-resolver-dscovrearth.test.ts
@@ -1,16 +1,22 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   DscovrEarthResolver,
   EPIC_BASE_URL,
   fetchLatestEarthImageUrl,
 } from "../../src/card/source-resolver-dscovrearth.js";
-import { urlCache } from "../../src/card/url-cache.js";
+import { UrlCache } from "../../src/card/url-cache.js";
 
 describe("source-resolver-dscovrearth", () => {
+  // Each test gets its own UrlCache, so nothing here shares state with the module-level
+  // default (which production relies on for remount survival, but tests don't need).
+  let cache: UrlCache;
+
+  beforeEach(() => {
+    cache = new UrlCache();
+  });
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
-    urlCache.clear();
   });
 
   describe("fetchLatestEarthImageUrl", () => {
@@ -22,7 +28,7 @@ describe("source-resolver-dscovrearth", () => {
       });
       vi.stubGlobal("fetch", fetchMock);
 
-      const { url, date } = await fetchLatestEarthImageUrl();
+      const { url, date } = await fetchLatestEarthImageUrl(undefined, cache);
 
       expect(fetchMock).toHaveBeenCalledWith(
         `${EPIC_BASE_URL}/api/natural`,
@@ -41,8 +47,8 @@ describe("source-resolver-dscovrearth", () => {
       });
       vi.stubGlobal("fetch", fetchMock);
 
-      const first = await fetchLatestEarthImageUrl();
-      const second = await fetchLatestEarthImageUrl();
+      const first = await fetchLatestEarthImageUrl(undefined, cache);
+      const second = await fetchLatestEarthImageUrl(undefined, cache);
 
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(second).toEqual(first);
@@ -55,8 +61,8 @@ describe("source-resolver-dscovrearth", () => {
       });
       vi.stubGlobal("fetch", fetchMock);
 
-      await fetchLatestEarthImageUrl();
-      await fetchLatestEarthImageUrl(0);
+      await fetchLatestEarthImageUrl(undefined, cache);
+      await fetchLatestEarthImageUrl(0, cache);
 
       expect(fetchMock).toHaveBeenCalledTimes(2);
     });
@@ -66,17 +72,17 @@ describe("source-resolver-dscovrearth", () => {
         "fetch",
         vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve([]) })
       );
-      await expect(fetchLatestEarthImageUrl()).rejects.toThrow();
+      await expect(fetchLatestEarthImageUrl(undefined, cache)).rejects.toThrow();
     });
 
     it("throws when the request fails", async () => {
       vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
-      await expect(fetchLatestEarthImageUrl()).rejects.toThrow();
+      await expect(fetchLatestEarthImageUrl(undefined, cache)).rejects.toThrow();
     });
 
     it("throws when the response is rate-limited (429), same as any other non-OK status", async () => {
       vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 429 }));
-      await expect(fetchLatestEarthImageUrl()).rejects.toThrow("429");
+      await expect(fetchLatestEarthImageUrl(undefined, cache)).rejects.toThrow("429");
     });
 
     it("aborts and rejects a request that hangs past the timeout, bounding an otherwise-indefinite stall", async () => {
@@ -92,13 +98,13 @@ describe("source-resolver-dscovrearth", () => {
         )
       );
 
-      await expect(fetchLatestEarthImageUrl()).rejects.toThrow("timeout");
+      await expect(fetchLatestEarthImageUrl(undefined, cache)).rejects.toThrow("timeout");
     });
   });
 
   describe("DscovrEarthResolver.hydrate", () => {
     it("returns undefined when nothing has ever been cached", () => {
-      expect(new DscovrEarthResolver().hydrate()).toBeUndefined();
+      expect(new DscovrEarthResolver(cache).hydrate()).toBeUndefined();
     });
 
     it("returns the cached earth image while its 1-hour TTL is still fresh", async () => {
@@ -109,8 +115,8 @@ describe("source-resolver-dscovrearth", () => {
           json: () => Promise.resolve([{ identifier: "20260810234950" }]),
         })
       );
-      const first = await fetchLatestEarthImageUrl();
-      expect(new DscovrEarthResolver().hydrate()).toEqual(first);
+      const first = await fetchLatestEarthImageUrl(undefined, cache);
+      expect(new DscovrEarthResolver(cache).hydrate()).toEqual(first);
     });
   });
 });

--- a/test/card/source-resolver-sdosun.test.ts
+++ b/test/card/source-resolver-sdosun.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { emptyDebugAccumulator } from "../../src/card/debug.js";
 import {
   getSunImageUrl,
@@ -6,7 +6,7 @@ import {
   SdoSunResolver,
   SUN_CACHE_TTL_MS,
 } from "../../src/card/source-resolver-sdosun.js";
-import { urlCache } from "../../src/card/url-cache.js";
+import { UrlCache } from "../../src/card/url-cache.js";
 
 // Same pattern as gallery-controller.test.ts's stubImagePreload: recover()'s retry loop goes
 // through a real off-DOM `new Image()` decode, so a failing-then-succeeding sequence needs
@@ -27,10 +27,17 @@ function stubImageDecode(...results: boolean[]) {
 }
 
 describe("source-resolver-sdosun", () => {
+  // Each test gets its own UrlCache — SdoSunResolver/getSunImageUrl accept one explicitly, so
+  // nothing here shares state with the module-level default (which production relies on for
+  // remount survival, but tests don't need).
+  let cache: UrlCache;
+
+  beforeEach(() => {
+    cache = new UrlCache();
+  });
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
-    urlCache.clear();
   });
 
   describe("getSunImageUrl", () => {
@@ -40,33 +47,33 @@ describe("source-resolver-sdosun", () => {
 
     it("computes the SDO browse-archive URL for the last published 15-min slot, buffered for publish latency", () => {
       vi.spyOn(Date, "now").mockReturnValue(NOW);
-      const { url, date } = getSunImageUrl();
+      const { url, date } = getSunImageUrl(SUN_CACHE_TTL_MS, cache);
       expect(url).toBe(`${SDO_BROWSE_BASE_URL}/2026/08/15/20260815_221500_1024_HMIIC.jpg`);
       expect(date.toISOString()).toBe("2026-08-15T22:15:00.000Z");
     });
 
     it("returns the cached result within the TTL instead of a fresh slot", () => {
       vi.spyOn(Date, "now").mockReturnValue(NOW);
-      const first = getSunImageUrl();
+      const first = getSunImageUrl(SUN_CACHE_TTL_MS, cache);
       vi.spyOn(Date, "now").mockReturnValue(NOW + 60000);
-      const second = getSunImageUrl();
+      const second = getSunImageUrl(SUN_CACHE_TTL_MS, cache);
       expect(second).toEqual(first);
     });
 
     it("recomputes with a fresh slot once the 15-min default TTL has elapsed", () => {
       vi.spyOn(Date, "now").mockReturnValue(NOW);
-      const first = getSunImageUrl();
+      const first = getSunImageUrl(SUN_CACHE_TTL_MS, cache);
       vi.spyOn(Date, "now").mockReturnValue(NOW + 15 * 60000 + 1);
-      const second = getSunImageUrl();
+      const second = getSunImageUrl(SUN_CACHE_TTL_MS, cache);
       expect(second).not.toEqual(first);
     });
 
     it("a shorter maxAgeMs expires the cache sooner", () => {
       vi.spyOn(Date, "now").mockReturnValue(NOW);
-      const first = getSunImageUrl();
+      const first = getSunImageUrl(SUN_CACHE_TTL_MS, cache);
       // 16 min later, guaranteed to cross into the next published 15-min slot.
       vi.spyOn(Date, "now").mockReturnValue(NOW + 16 * 60000);
-      const second = getSunImageUrl(1000);
+      const second = getSunImageUrl(1000, cache);
       expect(second).not.toEqual(first);
     });
   });
@@ -83,13 +90,13 @@ describe("source-resolver-sdosun", () => {
       stubImageDecode(false, true); // primary slot 404s, one-step-back fallback loads
 
       const debug = emptyDebugAccumulator();
-      const original = await new SdoSunResolver().resolve(debug, debug);
+      const original = await new SdoSunResolver(cache).resolve(debug, debug);
       expect(original.date.toISOString()).toBe("2026-08-15T22:00:00.000Z"); // stepped back once
 
       // Moments later — well within the 15-min cache TTL — a background refresh must see the
       // corrected slot, not the original 22:15:00 guess that 404s.
       vi.spyOn(Date, "now").mockReturnValue(NOW + 60000);
-      const refreshed = getSunImageUrl();
+      const refreshed = getSunImageUrl(SUN_CACHE_TTL_MS, cache);
       expect(refreshed).toEqual(original);
     });
 
@@ -99,37 +106,52 @@ describe("source-resolver-sdosun", () => {
       stubImageDecode(false, false, true); // two failed guesses before the fallback that loads
 
       const debug = emptyDebugAccumulator();
-      await new SdoSunResolver().resolve(debug, debug);
+      await new SdoSunResolver(cache).resolve(debug, debug);
 
       // If a failed attempt had ever written to the cache, this read (issued mid-retry in a
       // real concurrent tick) would have seen one of the two not-yet-published guesses.
-      expect(urlCache.get("sun", SUN_CACHE_TTL_MS)?.date.toISOString()).toBe(
+      expect(cache.get("sun", SUN_CACHE_TTL_MS)?.date.toISOString()).toBe(
         "2026-08-15T21:45:00.000Z"
       );
     });
   });
 
+  describe("cache isolation", () => {
+    it("two resolvers given their own UrlCache never see each other's state", () => {
+      const NOW = Date.UTC(2026, 7, 15, 22, 42, 30);
+      vi.spyOn(Date, "now").mockReturnValue(NOW);
+
+      const cacheA = new UrlCache();
+      const cacheB = new UrlCache();
+      const first = getSunImageUrl(SUN_CACHE_TTL_MS, cacheA);
+      cacheB.set("sun", { url: "https://example.com/other.jpg", date: new Date(NOW) });
+
+      expect(getSunImageUrl(SUN_CACHE_TTL_MS, cacheA)).toEqual(first);
+      expect(cacheB.get("sun", SUN_CACHE_TTL_MS)?.url).toBe("https://example.com/other.jpg");
+    });
+  });
+
   describe("SdoSunResolver.hydrate", () => {
     it("returns undefined when nothing has ever been cached", () => {
-      expect(new SdoSunResolver().hydrate()).toBeUndefined();
+      expect(new SdoSunResolver(cache).hydrate()).toBeUndefined();
     });
 
     it("returns the cached sun image while its 15-min slot TTL is still fresh", () => {
       const NOW = Date.UTC(2026, 7, 15, 22, 42, 30);
       vi.spyOn(Date, "now").mockReturnValue(NOW);
-      const first = getSunImageUrl();
+      const first = getSunImageUrl(SUN_CACHE_TTL_MS, cache);
 
       vi.spyOn(Date, "now").mockReturnValue(NOW + 60000);
-      expect(new SdoSunResolver().hydrate()).toEqual(first);
+      expect(new SdoSunResolver(cache).hydrate()).toEqual(first);
     });
 
     it("returns undefined once the sun slot's TTL has elapsed", () => {
       const NOW = Date.UTC(2026, 7, 15, 22, 42, 30);
       vi.spyOn(Date, "now").mockReturnValue(NOW);
-      getSunImageUrl();
+      getSunImageUrl(SUN_CACHE_TTL_MS, cache);
 
       vi.spyOn(Date, "now").mockReturnValue(NOW + 15 * 60000 + 1);
-      expect(new SdoSunResolver().hydrate()).toBeUndefined();
+      expect(new SdoSunResolver(cache).hydrate()).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Summary
- `UrlCache` was a module-level singleton, forcing four test files (`source-resolver-dscovrearth.test.ts`, `source-resolver-sdosun.test.ts`, `gallery-controller.test.ts`, `card.test.ts`) to manually `urlCache.clear()` between tests to avoid cross-test bleed.
- `SourceResolver`, `DscovrEarthResolver`/`SdoSunResolver`, and the free functions `fetchLatestEarthImageUrl`/`getSunImageUrl` now accept an explicit `UrlCache`, defaulting to the shared singleton — production behavior (and remount-survives-cache, which HA depends on) is unchanged.
- `source-resolver-*.test.ts` construct a fresh `UrlCache` per test and drop their `urlCache.clear()` afterEach entirely; added a test proving two resolvers with separate caches don't share state.
- `card.test.ts`'s two direct `getSunImageUrl()` probes use a scratch cache instead of clearing the shared one.
- `gallery-controller.test.ts` untouched — it correctly still exercises the shared default (the remount path).

## Test plan
- [x] `npm run test:coverage` — 711 tests pass, 100% coverage
- [x] `npm run check:ci` — typecheck/lint/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)