### PR TITLE
fix: shorten sun resolver's post-recovery hold

### DIFF
--- a/src/card/gallery/source-resolver-sdo-sun.ts
+++ b/src/card/gallery/source-resolver-sdo-sun.ts
@@ -19,6 +19,12 @@ export const SDO_BROWSE_BASE_URL = "https://sdo.gsfc.nasa.gov/assets/img/browse"
 export const SUN_CACHE_TTL_MS = 15 * 60000;
 const SUN_PUBLISH_BUFFER_MS = 20 * 60000;
 const SUN_MAX_RETRIES = 3;
+// Shorter than SUN_CACHE_TTL_MS on purpose: a recovered slot means the primary guess 404'd
+// because real publish lag exceeded SUN_PUBLISH_BUFFER_MS, but that lag has been observed to
+// clear within a few minutes of the buffer window closing — holding the recovered slot for the
+// full 15-min primary cadence trades away freshness the real world doesn't need. Still bounded
+// (not 0) so a genuine multi-slot outage doesn't retry every single refresh_mins tick.
+export const SUN_RECOVERY_HOLD_MS = 5 * 60000;
 
 export class SdoSunResolver extends SourceResolver {
   readonly source = "sun" as const;
@@ -70,13 +76,14 @@ export class SdoSunResolver extends SourceResolver {
 // every following refresh tick straight back into recover()'s retry loop, hammering NASA with
 // the same still-unpublished primary slot every tick instead of waiting it out. So when a
 // commit's own fetchedAt already lands past its slot's anchor, fall back to a plain
-// fetchedAt+TTL hold from that commit instant — the same protection the old sliding TTL gave
-// every commit, now scoped to only the case that actually needs it.
+// fetchedAt+SUN_RECOVERY_HOLD_MS hold from that commit instant — protection against
+// hammering, scoped to only the case that actually needs it, sized shorter than the primary
+// TTL since real publish lag typically clears faster than that (see SUN_RECOVERY_HOLD_MS).
 function freshCachedSlot(cache: UrlCache): SourcedImage | null {
   const entry = cache.getEntry("sun");
   if (!entry) return null;
   const anchor = entry.image.date.getTime() + SUN_CACHE_TTL_MS + SUN_PUBLISH_BUFFER_MS;
-  const validUntil = entry.fetchedAt >= anchor ? entry.fetchedAt + SUN_CACHE_TTL_MS : anchor;
+  const validUntil = entry.fetchedAt >= anchor ? entry.fetchedAt + SUN_RECOVERY_HOLD_MS : anchor;
   return Date.now() < validUntil ? entry.image : null;
 }
 

--- a/test/card/gallery/source-resolver-sdo-sun.test.ts
+++ b/test/card/gallery/source-resolver-sdo-sun.test.ts
@@ -5,6 +5,7 @@ import {
   SDO_BROWSE_BASE_URL,
   SdoSunResolver,
   SUN_CACHE_TTL_MS,
+  SUN_RECOVERY_HOLD_MS,
 } from "../../../src/card/gallery/source-resolver-sdo-sun.js";
 import { UrlCache } from "../../../src/card/gallery/url-cache.js";
 
@@ -116,11 +117,30 @@ describe("source-resolver-sdo-sun", () => {
       const original = await new SdoSunResolver(cache).resolve(debug, debug);
       expect(original.date.toISOString()).toBe("2026-08-15T22:00:00.000Z"); // stepped back once
 
-      // Moments later — well within the 15-min cache TTL — a background refresh must see the
-      // corrected slot, not the original 22:15:00 guess that 404s.
+      // Moments later — well within the shorter recovery hold — a background refresh must see
+      // the corrected slot, not the original 22:15:00 guess that 404s.
       vi.spyOn(Date, "now").mockReturnValue(NOW + 60000);
       const refreshed = getSunImageUrl(cache);
       expect(refreshed).toEqual(original);
+    });
+
+    it("retries the primary slot once the shorter recovery hold elapses, not the full 15-min TTL", async () => {
+      // The bug this fixes: a recovered slot used to hold for a full 15 minutes (borrowed from
+      // the primary TTL) before retrying, even though real-world publish lag typically clears
+      // within a few minutes — so a card could sit on a stale recovered image long after the
+      // real slot published. The recovery hold is now its own, shorter window.
+      const NOW = Date.UTC(2026, 7, 15, 22, 42, 30);
+      vi.spyOn(Date, "now").mockReturnValue(NOW);
+      stubImageDecode(false, true); // primary slot 404s, one-step-back fallback loads
+
+      const debug = emptyDebugAccumulator();
+      const original = await new SdoSunResolver(cache).resolve(debug, debug);
+      expect(original.date.toISOString()).toBe("2026-08-15T22:00:00.000Z");
+
+      // Past the recovery hold, but well short of the old 15-min TTL that used to protect it.
+      vi.spyOn(Date, "now").mockReturnValue(NOW + SUN_RECOVERY_HOLD_MS + 1);
+      const refreshed = getSunImageUrl(cache);
+      expect(refreshed).not.toEqual(original);
     });
 
     it("never commits a failed intermediate guess to the cache", async () => {


### PR DESCRIPTION
## Summary
- Follow-up to #122. That fix anchored the sun cache's normal expiry to the slot grid, but kept the recovery-fallback path holding a 404-recovered slot for the full 15-min primary TTL to avoid hammering NASA.
- Observed live: real publish lag typically clears within a few minutes of the buffer window closing, so the 15-min hold left cards showing a stale recovered image long after the real slot had actually published.
- `SUN_RECOVERY_HOLD_MS` (5 min) now governs this case specifically, cutting typical post-recovery staleness from ~15m to ~5m.
- Trade-off: up to ~3x retry traffic vs. before during a genuine multi-slot NASA outage — accepted for the freshness win in the common case.

## Test plan
- [x] `npm run test:coverage` — 736 tests pass, 100% coverage
- [x] `npm run check:ci` — typecheck/lint/format clean
- [x] `/ponytail-review` — no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)