### PR TITLE
fix: apply default_zoom changes to an already-rendered view

### DIFF
--- a/src/card/zoom-controller.ts
+++ b/src/card/zoom-controller.ts
@@ -65,24 +65,24 @@ export class ZoomController {
     periodicZoomMax: number,
     animate: boolean
   ): void {
+    const defaultChanged = defaultZoomLevel !== this._defaultZoomLevel;
     this._defaultZoomLevel = defaultZoomLevel;
     this._periodicZoomChange = periodicZoomChange;
     this._periodicZoomMax = periodicZoomMax;
     this._animate = animate;
+    // ensureInitialized() won't move an already-built view, so a later setConfig (Lovelace
+    // editor preview) has to. Only on an actual change, so an unrelated config edit can't
+    // stomp a hand-set zoom; instant, not via _apply() — a config jump isn't a zoom gesture.
+    if (defaultChanged && this._viewState) {
+      this._viewState.setZoomLevel(defaultZoomLevel);
+      this._onChange();
+    }
   }
 
   ensureInitialized(): void {
     if (this._viewState) return;
     this._viewState = new ViewState(this._defaultZoomLevel);
     this._zoomAnimator = new ZoomAnimator(this._viewState, () => this._onViewBoxChange());
-  }
-
-  // ponytail: test-seeding only — forces the next ensureInitialized() to build a fresh
-  // ViewState (e.g. to verify a new default_zoom takes effect), which no production call
-  // site needs since the real view is only ever initialized once per connection.
-  reset(): void {
-    this._viewState = null;
-    this._zoomAnimator = null;
   }
 
   recenter(): void {

--- a/test/card/card.test.ts
+++ b/test/card/card.test.ts
@@ -1471,9 +1471,17 @@ describe("SolarViewCard", () => {
       document.body.appendChild(card);
       expect(parseViewBox(card).width).toBe(800);
       // Reconfigure with new default zoom — should re-render instantly
-      card._zoom.reset(); // force fresh ViewState on next render
       card.setConfig({ zoom_animate: true, default_zoom: 3 });
-      card._render();
+      expect(parseViewBox(card).width).toBe(480);
+      card.remove();
+    });
+
+    it("setConfig after the card has rendered moves the live view (issue #125)", () => {
+      const card = document.createElement("ha-planetary-solar-system-card-test");
+      document.body.appendChild(card);
+      expect(card._zoomLevel).toBe(1);
+      card.setConfig({ default_zoom: 3 });
+      expect(card._zoomLevel).toBe(3);
       expect(parseViewBox(card).width).toBe(480);
       card.remove();
     });

--- a/test/card/zoom-controller.test.ts
+++ b/test/card/zoom-controller.test.ts
@@ -54,23 +54,35 @@ describe("ZoomController.ensureInitialized", () => {
     zoom.configure(2, false, 4, false);
     zoom.ensureInitialized();
     expect(zoom.zoomLevel).toBe(2);
-    zoom.configure(4, false, 4, false); // shouldn't rebuild an already-initialized view
-    zoom.ensureInitialized();
+    zoom.ensureInitialized(); // shouldn't rebuild an already-initialized view
     expect(zoom.zoomLevel).toBe(2);
   });
+});
 
-  it("reset() forces the next ensureInitialized() to rebuild at the current default", () => {
-    const zoom = new ZoomController(
-      () => {},
-      () => {}
-    );
+describe("ZoomController.configure after initialization", () => {
+  it("applies a changed default_zoom to the live view and notifies once", () => {
+    const onChange = vi.fn();
+    const zoom = new ZoomController(onChange, () => {});
     zoom.configure(1, false, 4, false);
     zoom.ensureInitialized();
     expect(zoom.zoomLevel).toBe(1);
+
     zoom.configure(3, false, 4, false);
-    zoom.reset();
-    zoom.ensureInitialized();
     expect(zoom.zoomLevel).toBe(3);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves a hand-set zoom alone when default_zoom is unchanged", () => {
+    const onChange = vi.fn();
+    const zoom = new ZoomController(onChange, () => {});
+    zoom.configure(1, false, 4, false);
+    zoom.ensureInitialized();
+    zoom.zoomIn(); // user zoomed by hand
+    onChange.mockClear();
+
+    zoom.configure(1, true, 3, false); // unrelated config edit
+    expect(zoom.zoomLevel).toBe(2);
+    expect(onChange).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Problem

`ZoomController.configure()` stored `_defaultZoomLevel`, but only `ensureInitialized()` read it — and that returns early once `_viewState` exists. A `setConfig` after the first render updated config and never the live view. Lovelace's card editor preview would keep the old zoom while `default_zoom` was edited.

Fixes #125.

## Fix

`configure()` now pushes a *changed* `default_zoom` into the live `ViewState` and fires `onChange`:

- Guarded on an actual change, so an unrelated config edit (theme, gallery) can't stomp a zoom the user set by hand with +/-.
- Instant, not via `_apply()` — a config jump isn't a zoom gesture, so no animation.
- Pan left alone, same as `zoomIn`/`zoomOut`.

`reset()` deleted: a test-only seam that duplicated what production now does.

## Tests

- `configure()` after init applies the new default and notifies once.
- Unchanged default leaves a hand-set zoom alone, no notify.
- Card-level repro of the issue: append, then `setConfig({ default_zoom: 3 })` → level 3, viewBox 480.

743 tests pass, coverage 100%, `check:ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)