### PR TITLE
fix: offscreen markers inset from the card edges when height is not 100%

### DIFF
--- a/src/card/solar-view.ts
+++ b/src/card/solar-view.ts
@@ -10,7 +10,7 @@ import type { ZoomController } from "./zoom-controller.js";
 export class SolarView {
   private _zoom: ZoomController;
   private _svg: SVGSVGElement | null;
-  private _updateMarkers: ((viewState: PanZoomState) => void) | null;
+  private _updateMarkers: ((viewState: PanZoomState, aspect?: number) => void) | null;
 
   constructor(zoom: ZoomController) {
     this._zoom = zoom;
@@ -44,7 +44,11 @@ export class SolarView {
     const panZoomState = this._zoom.panZoomState;
     if (!panZoomState) return;
     if (this._svg) this._svg.setAttribute("viewBox", this._zoom.viewBox as string);
-    this._updateMarkers?.(panZoomState);
+    // Markers hug the card's edges, which the square viewBox no longer matches once
+    // config.height reshapes the box (#135). Measured here rather than cached: the
+    // element is the only thing that knows its rendered aspect.
+    const rect = this._svg?.getBoundingClientRect();
+    this._updateMarkers?.(panZoomState, rect?.height ? rect.width / rect.height : 1);
   }
 
   private _bindPointerEvents(svg: SVGSVGElement): void {

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -38,7 +38,7 @@ export function renderSolarSystem(
 ): {
   svg: SVGSVGElement;
   positions: ViewPosition[];
-  updateMarkers: (viewState: PanZoomState) => void;
+  updateMarkers: (viewState: PanZoomState, aspect?: number) => void;
 } {
   const eclipticViewDirection = eclipticView ? 1 : -1;
 
@@ -191,10 +191,10 @@ export function renderSolarSystem(
   // caller's current pan/zoom — cheap enough to call on every drag/zoom tick without rebuilding
   // the rest of the SVG. Owns the marker group's DOM lifecycle (replace-by-id) so callers never
   // need to know MARKER_GROUP_ID or reach into the SVG themselves.
-  function updateMarkers(viewState: PanZoomState): void {
+  function updateMarkers(viewState: PanZoomState, aspect?: number): void {
     const old = svg.getElementById(MARKER_GROUP_ID);
     if (old) old.remove();
-    svg.appendChild(renderOffscreenMarkers(positions, viewState));
+    svg.appendChild(renderOffscreenMarkers(positions, viewState, aspect));
   }
 
   return { svg, positions, updateMarkers };

--- a/src/renderer/offscreen-markers.ts
+++ b/src/renderer/offscreen-markers.ts
@@ -107,21 +107,34 @@ function createLabel(
 
 /**
  * Render off-screen markers for planets/Moon outside the current viewport.
- * @param {Array<{name: string, x: number, y: number, color: string}>} positions
- * @param {object} viewState - ViewState instance with centerX, centerY, width, height
- * @returns {SVGGElement} A <g> group containing all markers
+ *
+ * The viewBox is always square, but the card's box is not once `config.height`
+ * reshapes it. Under preserveAspectRatio="xMidYMid meet" the square content
+ * letterboxes, and the bands are still drawable — the outer <svg> clips to its
+ * element box, not to the viewBox. So the marker rect is the *visible* region in
+ * viewBox units, which decides both where a marker is drawn and whether a body
+ * counts as off-screen at all (#135).
+ *
+ * @param positions - bodies to consider, in viewBox coordinates
+ * @param viewState - pan/zoom state; `width` is the square viewBox extent
+ * @param aspect - the card element's width / height. Absent, non-finite or <= 0
+ *   (jsdom, and HA's pre-layout first paint, both measure 0x0) falls back to square.
  */
 export function renderOffscreenMarkers(
   positions: ViewPosition[],
-  viewState: PanZoomState
+  viewState: PanZoomState,
+  aspect = 1
 ): SVGGElement {
   const group = createSvgElement("g", { id: MARKER_GROUP_ID });
 
   const w = viewState.width;
-  const left = viewState.centerX - w / 2;
-  const top = viewState.centerY - w / 2;
-  const right = left + w;
-  const bottom = top + w;
+  const ratio = Number.isFinite(aspect) && aspect > 0 ? aspect : 1;
+  const halfW = (w / 2) * Math.max(1, ratio);
+  const halfH = (w / 2) * Math.max(1, 1 / ratio);
+  const left = viewState.centerX - halfW;
+  const top = viewState.centerY - halfH;
+  const right = viewState.centerX + halfW;
+  const bottom = viewState.centerY + halfH;
 
   for (const pos of positions) {
     // Skip bodies that opt out of offscreen markers (e.g. Moon)

--- a/test/card/solar-view.test.ts
+++ b/test/card/solar-view.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { SolarView } from "../../src/card/solar-view.js";
 import { ZoomController } from "../../src/card/zoom-controller.js";
+import { MARKER_GROUP_ID } from "../../src/renderer/offscreen-markers.js";
 
 function mountedView(): { view: SolarView; zoom: ZoomController; container: HTMLElement } {
   const zoom = new ZoomController(
@@ -48,6 +49,37 @@ describe("SolarView.applyViewState", () => {
     zoom.ensureInitialized();
     const view = new SolarView(zoom);
     expect(() => view.applyViewState()).not.toThrow();
+  });
+
+  it("widens the marker rect to the card's aspect ratio (#135)", () => {
+    // A 2:1 card letterboxes the square viewBox, so a body in the side band is
+    // on screen and must lose its marker; markers move out to the card edges.
+    const { view, container } = mountedView();
+    const svg = container.querySelector("svg") as SVGSVGElement;
+    const rectFor = (w: number, h: number) => () =>
+      ({ width: w, height: h, x: 0, y: 0, top: 0, left: 0 }) as DOMRect;
+
+    svg.getBoundingClientRect = rectFor(400, 400);
+    view.applyViewState();
+    const square = svg.getElementById(MARKER_GROUP_ID).children.length;
+
+    svg.getBoundingClientRect = rectFor(800, 400);
+    view.applyViewState();
+    const wide = svg.getElementById(MARKER_GROUP_ID).children.length;
+
+    expect(square).toBeGreaterThan(0);
+    expect(wide).toBeLessThan(square);
+  });
+
+  it("falls back to square when the element has not been laid out yet", () => {
+    // jsdom and HA's first paint both measure 0x0; width/height would be NaN.
+    const { view, container } = mountedView();
+    const svg = container.querySelector("svg") as SVGSVGElement;
+    svg.getBoundingClientRect = () =>
+      ({ width: 0, height: 0, x: 0, y: 0, top: 0, left: 0 }) as DOMRect;
+    view.applyViewState();
+    const points = svg.getElementById(MARKER_GROUP_ID).querySelector("polygon");
+    expect(points?.getAttribute("points")).not.toContain("NaN");
   });
 
   it("sets the svg viewBox from the zoom controller", () => {

--- a/test/renderer/offscreen-markers.test.ts
+++ b/test/renderer/offscreen-markers.test.ts
@@ -123,6 +123,59 @@ describe("renderOffscreenMarkers", () => {
   });
 });
 
+describe("renderOffscreenMarkers with a non-square card", () => {
+  // The SVG viewBox stays square; preserveAspectRatio="xMidYMid meet" letterboxes it
+  // inside a non-square element. The visible region in viewBox units is therefore
+  // wider (or taller) than viewState.width, and markers belong on ITS edges.
+  function markerPoint(polygon) {
+    const [tip, b1, b2] = polygon
+      .getAttribute("points")
+      .split(" ")
+      .map((pt) => pt.split(",").map(Number));
+    return { x: (tip[0] + (b1[0] + b2[0]) / 2) / 2, y: (tip[1] + (b1[1] + b2[1]) / 2) / 2 };
+  }
+
+  it("puts the marker on the card edge, not the square viewBox edge, when wide", () => {
+    // aspect 2 -> visible half-width is 800, so the inset left edge is at 400-800+10.
+    const vs = makeViewState(1); // 800x800 viewBox, centre (400,400)
+    const positions = [{ name: "Left", x: -5000, y: 400, color: "#ff0000" }];
+    const group = renderOffscreenMarkers(positions, vs, 2);
+    const { x, y } = markerPoint(group.querySelector("polygon"));
+    expect(x).toBeCloseTo(-390, 6);
+    expect(y).toBeCloseTo(400, 6);
+  });
+
+  it("puts the marker on the card edge when tall", () => {
+    // aspect 0.5 -> visible half-height is 800, so the inset top edge is at 400-800+10.
+    const vs = makeViewState(1);
+    const positions = [{ name: "Up", x: 400, y: -5000, color: "#ff0000" }];
+    const group = renderOffscreenMarkers(positions, vs, 0.5);
+    const { x, y } = markerPoint(group.querySelector("polygon"));
+    expect(x).toBeCloseTo(400, 6);
+    expect(y).toBeCloseTo(-390, 6);
+  });
+
+  it("draws no marker for a body visible in the letterbox band", () => {
+    // x=-200 is outside the square viewBox but inside the widened visible region,
+    // so the body is on screen and must not get an offscreen marker drawn over it.
+    const vs = makeViewState(1);
+    const positions = [{ name: "InBand", x: -200, y: 400, color: "#ff0000" }];
+    expect(renderOffscreenMarkers(positions, vs, 2).children.length).toBe(0);
+  });
+
+  it("treats a missing or degenerate aspect as square", () => {
+    const vs = makeViewState(1);
+    const positions = [{ name: "Left", x: -5000, y: 400, color: "#ff0000" }];
+    const square = markerPoint(renderOffscreenMarkers(positions, vs).querySelector("polygon"));
+    expect(square.x).toBeCloseTo(10, 6);
+    // 0x0 elements (jsdom, HA pre-layout) yield NaN/0 aspect; must not poison coordinates
+    for (const bad of [Number.NaN, 0]) {
+      const p = markerPoint(renderOffscreenMarkers(positions, vs, bad).querySelector("polygon"));
+      expect(p.x).toBeCloseTo(10, 6);
+    }
+  });
+});
+
 describe("renderSolarSystem().updateMarkers", () => {
   it("appends a marker group to the returned svg for the given pan/zoom", () => {
     const { svg, updateMarkers } = renderSolarSystem(new Date("2025-06-15"));


### PR DESCRIPTION
Fixes #135.

## Problem

`config.height` reshapes `#solar-view`'s box (`aspect-ratio` for a percent, `max-height` for a px value), but the SVG `viewBox` stays square and the default `preserveAspectRatio="xMidYMid meet"` letterboxes it. `renderOffscreenMarkers` derived its rect from `viewState.width` on **both** axes, so that rect no longer matched what the card shows.

Card 400px wide with `height: 50%` → box 400x200, scale `0.25`, **100px empty band each side**:

| | before | correct |
|---|---|---|
| marker at viewBox `x=10` | card `x = 102.5` | card `x ≈ 0` |
| marker at viewBox `y=10` | card `y = 2.5` | card `y = 2.5` ✓ |

Two defects, one bad rect: markers inset from the left/right edges (**where**), and a body sitting in a band is on screen yet still gets an off-screen marker drawn over it (**when**).

## Fix

Derive the rect from the element's measured aspect. Under `xMidYMid meet` the visible region in viewBox units is:

```ts
const halfW = (w / 2) * Math.max(1, ratio);
const halfH = (w / 2) * Math.max(1, 1 / ratio);
```

The limiting axis keeps `size`, the other grows. A square card returns `800x800` — today's behaviour, unchanged.

**No display change.** The `viewBox` is untouched, so orbits and bodies render exactly as before. This works because the bands are drawable: the outer `<svg>` clips to its *element* box, not to the `viewBox` rect.

## Tests

All four behavioral tests verified red against the old `src/` via `git stash`:

| Test | Red before |
|---|---|
| wide card → marker at `x = -390` | off by 400 |
| tall card → marker at `y = -390` | off by 400 |
| body in the band → no marker | drew 2 elements |
| `SolarView` wiring: 800x400 yields fewer markers than 400x400 | `4` vs `4` |

Plus a guard test: a 0x0 element (jsdom, and HA's pre-layout first paint) must not put `NaN` in the `points` attribute.

748 tests, 100% coverage, `check:ci` clean.

## Out of scope

`updateDrag` uses `scale = this._size / svgRect.width` (`card-view-state.ts:90`) where the true content scale is `_size / min(width, height)`, so panning **under**-travels by `width/height` on a non-square card (the scene lags the cursor). Same root cause, separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
