### PR TITLE
fix: tie clock readouts to the configured location's timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,40 +158,17 @@ frame.
 | `location.longitude` | number (-180 to 180) | HA config | Overrides HA's longitude. Requires `location.latitude` too, else ignored                                     |
 | `location.timezone`  | string (IANA)        | estimated | Timezone for displayed clock times, e.g. `Europe/Warsaw`. Unrecognised values fall back to the estimate      |
 
-When `location.latitude`/`location.longitude` are set, displayed clock times (the `Next:` sunrise/
-sunset/twilight readout) stop following Home Assistant's timezone and follow the configured location
-instead. The status bar names the zone it used, so a time in a zone you are not sitting in can't be
-mistaken for your own clock:
+With `location.latitude`/`location.longitude` set, clock times (the `Next:` readout) follow the
+configured location instead of HA's timezone, and the status bar names the zone it used —
+`Next: Sunset (20:20 GMT+2)`.
 
-```yaml
-location:
-  name: Krakow, Poland
-  latitude: 50.0614
-  longitude: 19.9366
-  timezone: Europe/Warsaw
-```
+Set `location.timezone` to a canonical [IANA name][iana] (`Europe/Warsaw`, `America/Chicago` — not
+`CST6CDT`) for exact times, daylight saving included. Left unset, the zone is estimated from
+longitude alone: no DST and no half-hour zones, so Krakow runs an hour behind each summer,
+Montevideo an hour behind year-round, and Bangalore 30 minutes behind always.
 
-Set `location.timezone` to an [IANA zone name][iana] and times are exact, daylight saving included —
-`Next: Sunset (20:20 GMT+2)` in summer, `(16:37 GMT+1)` in winter. Use the canonical `Area/City`
-form (`America/Chicago`, not `CST6CDT` or `US/Central`); only the canonical names carry the full
-history of rule changes, which matters because the card navigates by month and year. A value the
-browser does not recognise is ignored in favour of the estimate below.
-
-**Without** `location.timezone`, the zone is _estimated_ from the longitude alone — one hour per
-15°. That is a rough guess, because real timezones follow borders rather than meridians:
-
-| Location                         | Estimated | Actual                | Error  |
-| -------------------------------- | --------- | --------------------- | ------ |
-| Krakow, Poland (lon 19.94)       | `GMT+1`   | `GMT+1` / `GMT+2` DST | 0–1 h  |
-| Montevideo, Uruguay (lon -56.16) | `GMT-4`   | `GMT-3` all year      | 1 h    |
-| Bangalore, India (lon 77.59)     | `GMT+5`   | `GMT+5:30`            | 30 min |
-
-The estimate has no daylight saving time, cannot express half-hour zones, and is worst in countries
-spanning several solar hours. Set `location.timezone` when the clock matters.
-
-Sky state, twilight bands and the observer needle are computed from latitude/longitude directly and
-are never affected by any of this. With no `location` override set, times use HA's own timezone
-exactly as before.
+Sky state, twilight bands and the observer needle come from latitude/longitude directly and are
+unaffected. With no `location` override set, times use HA's own timezone exactly as before.
 
 <!-- Reference links -->
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ location:
   latitude: 51.5074
   longitude: -0.1278
   name: London
+  timezone: Europe/London
 ```
 
 ## Horizon Twilight Zones
@@ -155,14 +156,42 @@ frame.
 | `location.name`      | string               | HA config | Overrides the location label shown in the status bar                                                         |
 | `location.latitude`  | number (-90 to 90)   | HA config | Overrides HA's latitude for hemisphere/season/twilight math. Requires `location.longitude` too, else ignored |
 | `location.longitude` | number (-180 to 180) | HA config | Overrides HA's longitude. Requires `location.latitude` too, else ignored                                     |
+| `location.timezone`  | string (IANA)        | estimated | Timezone for displayed clock times, e.g. `Europe/Warsaw`. Unrecognised values fall back to the estimate      |
 
 When `location.latitude`/`location.longitude` are set, displayed clock times (the `Next:` sunrise/
-sunset/twilight readout) switch from HA's timezone to a fixed UTC offset derived from the longitude
-(15° per hour), and the status bar appends that offset — e.g. `Next: Sunset (18:42 GMT+1)`. The
-offset is an approximation: it has no daylight saving time and is wrong near timezone borders or in
-countries spanning several solar hours. Sky state, twilight bands and the observer needle are
-computed from latitude/longitude directly and are unaffected. With no `location` override set, times
-use HA's own timezone exactly as before.
+sunset/twilight readout) stop following Home Assistant's timezone and follow the configured location
+instead. The status bar names the zone it used, so a time in a zone you are not sitting in can't be
+mistaken for your own clock:
+
+```yaml
+location:
+  name: Krakow, Poland
+  latitude: 50.0614
+  longitude: 19.9366
+  timezone: Europe/Warsaw
+```
+
+Set `location.timezone` to an [IANA zone name][iana] and times are exact, daylight saving included —
+`Next: Sunset (20:20 GMT+2)` in summer, `(16:37 GMT+1)` in winter. Use the canonical `Area/City`
+form (`America/Chicago`, not `CST6CDT` or `US/Central`); only the canonical names carry the full
+history of rule changes, which matters because the card navigates by month and year. A value the
+browser does not recognise is ignored in favour of the estimate below.
+
+**Without** `location.timezone`, the zone is _estimated_ from the longitude alone — one hour per
+15°. That is a rough guess, because real timezones follow borders rather than meridians:
+
+| Location                         | Estimated | Actual                | Error  |
+| -------------------------------- | --------- | --------------------- | ------ |
+| Krakow, Poland (lon 19.94)       | `GMT+1`   | `GMT+1` / `GMT+2` DST | 0–1 h  |
+| Montevideo, Uruguay (lon -56.16) | `GMT-4`   | `GMT-3` all year      | 1 h    |
+| Bangalore, India (lon 77.59)     | `GMT+5`   | `GMT+5:30`            | 30 min |
+
+The estimate has no daylight saving time, cannot express half-hour zones, and is worst in countries
+spanning several solar hours. Set `location.timezone` when the clock matters.
+
+Sky state, twilight bands and the observer needle are computed from latitude/longitude directly and
+are never affected by any of this. With no `location` override set, times use HA's own timezone
+exactly as before.
 
 <!-- Reference links -->
 
@@ -173,6 +202,7 @@ use HA's own timezone exactly as before.
 [sdo]: https://sdo.gsfc.nasa.gov/
 [repo]: https://github.com/marcintk/ha-planetary-solar-system-card
 [license]: https://github.com/marcintk/ha-planetary-solar-system-card/blob/main/LICENSE
+[iana]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 [demo-gif]:
   https://raw.githubusercontent.com/marcintk/ha-planetary-solar-system-card/main/docs/demo.gif
 [releases]: https://github.com/marcintk/ha-planetary-solar-system-card/releases

--- a/README.md
+++ b/README.md
@@ -151,24 +151,12 @@ frame.
 
 `location` (object, unset by default) — overrides HA's configured location:
 
-| Key                  | Type                 | Default   | Description                                                                                                  |
-| -------------------- | -------------------- | --------- | ------------------------------------------------------------------------------------------------------------ |
-| `location.name`      | string               | HA config | Overrides the location label shown in the status bar                                                         |
-| `location.latitude`  | number (-90 to 90)   | HA config | Overrides HA's latitude for hemisphere/season/twilight math. Requires `location.longitude` too, else ignored |
-| `location.longitude` | number (-180 to 180) | HA config | Overrides HA's longitude. Requires `location.latitude` too, else ignored                                     |
-| `location.timezone`  | string (IANA)        | estimated | Timezone for displayed clock times, e.g. `Europe/Warsaw`. Unrecognised values fall back to the estimate      |
-
-With `location.latitude`/`location.longitude` set, clock times (the `Next:` readout) follow the
-configured location instead of HA's timezone, and the status bar names the zone it used —
-`Next: Sunset (20:20 GMT+2)`.
-
-Set `location.timezone` to a canonical [IANA name][iana] (`Europe/Warsaw`, `America/Chicago` — not
-`CST6CDT`) for exact times, daylight saving included. Left unset, the zone is estimated from
-longitude alone: no DST and no half-hour zones, so Krakow runs an hour behind each summer,
-Montevideo an hour behind year-round, and Bangalore 30 minutes behind always.
-
-Sky state, twilight bands and the observer needle come from latitude/longitude directly and are
-unaffected. With no `location` override set, times use HA's own timezone exactly as before.
+| Key                  | Type                 | Default   | Description                                                                                                                                                                                          |
+| -------------------- | -------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `location.name`      | string               | HA config | Overrides the location label shown in the status bar                                                                                                                                                 |
+| `location.latitude`  | number (-90 to 90)   | HA config | Overrides HA's latitude for hemisphere/season/twilight math. Requires `location.longitude` too, else ignored                                                                                         |
+| `location.longitude` | number (-180 to 180) | HA config | Overrides HA's longitude. Requires `location.latitude` too, else ignored                                                                                                                             |
+| `location.timezone`  | string (IANA)        | estimated | Timezone for the clock times in the status bar — [find the name here][iana], e.g. `Europe/Warsaw`. Unset or unrecognised, it is estimated from the longitude: no daylight saving, no half-hour zones |
 
 <!-- Reference links -->
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,14 @@ frame.
 | `location.latitude`  | number (-90 to 90)   | HA config | Overrides HA's latitude for hemisphere/season/twilight math. Requires `location.longitude` too, else ignored |
 | `location.longitude` | number (-180 to 180) | HA config | Overrides HA's longitude. Requires `location.latitude` too, else ignored                                     |
 
+When `location.latitude`/`location.longitude` are set, displayed clock times (the `Next:` sunrise/
+sunset/twilight readout) switch from HA's timezone to a fixed UTC offset derived from the longitude
+(15° per hour), and the status bar appends that offset — e.g. `Next: Sunset (18:42 GMT+1)`. The
+offset is an approximation: it has no daylight saving time and is wrong near timezone borders or in
+countries spanning several solar hours. Sky state, twilight bands and the observer needle are
+computed from latitude/longitude directly and are unaffected. With no `location` override set, times
+use HA's own timezone exactly as before.
+
 <!-- Reference links -->
 
 [my-hacs]:

--- a/src/card/card-config.ts
+++ b/src/card/card-config.ts
@@ -49,6 +49,22 @@ function offsetZoneFromLongitude(lon: number): string {
   return `Etc/GMT${offset <= 0 ? "+" : "-"}${Math.abs(offset)}`;
 }
 
+// An explicit IANA zone beats the longitude estimate outright — it carries DST and the full
+// historical rule set, which matters because the card navigates by month and year. No zone
+// database is needed to check one: Intl already ships the whole thing and throws RangeError on
+// anything it doesn't know, so a typo degrades to the estimate instead of breaking the card.
+function resolveOverrideTimezone(timezone: string | undefined, lon: number): string {
+  if (timezone) {
+    try {
+      new Intl.DateTimeFormat("en-US", { timeZone: timezone });
+      return timezone;
+    } catch {
+      // Unknown zone — fall through to the longitude estimate.
+    }
+  }
+  return offsetZoneFromLongitude(lon);
+}
+
 // Pure validate/default pass over CardConfig — the single place each field's fallback and
 // range-check rule lives. card.ts's setConfig hands the result straight to _zoom.configure()/
 // _gallery.configure() and its own remaining fields, instead of parsing inline.
@@ -80,7 +96,11 @@ export function parseCardConfig(config: CardConfig): ParsedCardConfig {
     overrideLon >= -180 &&
     overrideLon <= 180;
   const locationOverride = hasOverride
-    ? { lat: overrideLat, lon: overrideLon, timezone: offsetZoneFromLongitude(overrideLon) }
+    ? {
+        lat: overrideLat,
+        lon: overrideLon,
+        timezone: resolveOverrideTimezone(config.location?.timezone, overrideLon),
+      }
     : null;
   const locationNameOverride = config.location?.name || null;
 

--- a/src/card/card-config.ts
+++ b/src/card/card-config.ts
@@ -12,7 +12,7 @@ export interface ParsedCardConfig {
   colors: Colors;
   theme: "auto" | "dark" | "light";
   eclipticView: boolean;
-  locationOverride: { lat: number; lon: number } | null;
+  locationOverride: { lat: number; lon: number; timezone: string } | null;
   locationNameOverride: string | null;
   heightStyle: string;
   galleryMode: GalleryMode;
@@ -37,6 +37,16 @@ function resolveHeightStyle(height: CardConfig["height"]): string {
     }
   }
   return "";
+}
+
+// An overridden location must not keep reading clocks in HA's timezone, but no IANA timezone
+// database ships in the bundle. Etc/GMT±N zones are built into every browser's Intl data, so a
+// fixed UTC offset from longitude (15° per hour) needs zero deps. No DST, and wrong near zone
+// borders — acceptable: the card shows sky state, not appointment times.
+// The sign is POSIX-inverted: Etc/GMT+6 means UTC-6.
+function offsetZoneFromLongitude(lon: number): string {
+  const offset = Math.round(lon / 15);
+  return `Etc/GMT${offset <= 0 ? "+" : "-"}${Math.abs(offset)}`;
 }
 
 // Pure validate/default pass over CardConfig — the single place each field's fallback and
@@ -69,7 +79,9 @@ export function parseCardConfig(config: CardConfig): ParsedCardConfig {
     overrideLat <= 90 &&
     overrideLon >= -180 &&
     overrideLon <= 180;
-  const locationOverride = hasOverride ? { lat: overrideLat, lon: overrideLon } : null;
+  const locationOverride = hasOverride
+    ? { lat: overrideLat, lon: overrideLon, timezone: offsetZoneFromLongitude(overrideLon) }
+    : null;
   const locationNameOverride = config.location?.name || null;
 
   const heightStyle = resolveHeightStyle(config.height);

--- a/src/card/card-template.ts
+++ b/src/card/card-template.ts
@@ -35,9 +35,11 @@ export function buildStatusBar(
         hour: "2-digit",
         minute: "2-digit",
         hour12: false,
-        // A longitude-derived zone isn't HA's own, so name it — "18:42" alone would read as
-        // local time to someone whose HA sits in a different zone.
-        timeZoneName: locationData.zoneDerived ? "shortOffset" : undefined,
+        // An overridden zone isn't HA's own, so name it — "18:42" alone would read as local
+        // time to someone whose HA sits in a different zone. "short" prefers a real abbreviation
+        // (CDT) where the locale has one and falls back to an offset (GMT+5:30) where it doesn't,
+        // which covers both a named IANA zone and a longitude-estimated Etc/GMT±N.
+        timeZoneName: locationData.zoneOverride ? "short" : undefined,
       })
     : null;
 

--- a/src/card/card-template.ts
+++ b/src/card/card-template.ts
@@ -35,6 +35,9 @@ export function buildStatusBar(
         hour: "2-digit",
         minute: "2-digit",
         hour12: false,
+        // A longitude-derived zone isn't HA's own, so name it — "18:42" alone would read as
+        // local time to someone whose HA sits in a different zone.
+        timeZoneName: locationData.zoneDerived ? "shortOffset" : undefined,
       })
     : null;
 

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -34,6 +34,7 @@ interface HassLocation {
 interface LocationOverride {
   lat: number;
   lon: number;
+  timezone: string;
 }
 
 export class SolarViewCard extends LitElement {
@@ -84,10 +85,16 @@ export class SolarViewCard extends LitElement {
   // Proxy getters
   // ---------------------------------------------------------------------------
   get _locationData(): LocationData | null {
-    const lat = this._locationOverride?.lat ?? this._hassLocation.lat;
-    const lon = this._locationOverride?.lon ?? this._hassLocation.lon;
+    const override = this._locationOverride;
+    const lat = override?.lat ?? this._hassLocation.lat;
+    const lon = override?.lon ?? this._hassLocation.lon;
     return lat != null && lon != null
-      ? { lat, lon, timezone: this._hassLocation.timezone ?? "UTC" }
+      ? {
+          lat,
+          lon,
+          timezone: override?.timezone ?? this._hassLocation.timezone ?? "UTC",
+          zoneDerived: override != null,
+        }
       : null;
   }
   get _effectiveLocationName(): string | null {

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -93,7 +93,7 @@ export class SolarViewCard extends LitElement {
           lat,
           lon,
           timezone: override?.timezone ?? this._hassLocation.timezone ?? "UTC",
-          zoneDerived: override != null,
+          zoneOverride: override != null,
         }
       : null;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,10 @@ export interface LocationData {
   lat: number;
   lon: number;
   timezone: string;
+  // True when `timezone` was derived from an overridden longitude rather than taken from HA's
+  // own config — the status bar labels the zone in that case, so a readout in a zone the user
+  // isn't sitting in can't be mistaken for local time.
+  zoneDerived: boolean;
 }
 
 export interface Colors {

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,10 +34,10 @@ export interface LocationData {
   lat: number;
   lon: number;
   timezone: string;
-  // True when `timezone` was derived from an overridden longitude rather than taken from HA's
-  // own config — the status bar labels the zone in that case, so a readout in a zone the user
-  // isn't sitting in can't be mistaken for local time.
-  zoneDerived: boolean;
+  // True when `timezone` came from config.location rather than HA's own config — either an
+  // explicit location.timezone or the longitude estimate. The status bar labels the zone in that
+  // case, so a readout in a zone the user isn't sitting in can't be mistaken for local time.
+  zoneOverride: boolean;
 }
 
 export interface Colors {
@@ -119,5 +119,5 @@ export interface CardConfig {
   show_version?: boolean;
   debug?: boolean;
   gallery?: { mode?: string; slide_interval_secs?: number };
-  location?: { latitude?: number; longitude?: number; name?: string };
+  location?: { latitude?: number; longitude?: number; name?: string; timezone?: string };
 }

--- a/test/card/card-config.test.ts
+++ b/test/card/card-config.test.ts
@@ -111,6 +111,32 @@ describe("parseCardConfig", () => {
         parseCardConfig({ location: { latitude: 51.5, longitude: -0.1278 } }).locationOverride
       ).toEqual({ lat: 51.5, lon: -0.1278, timezone: "Etc/GMT+0" });
     });
+    it("prefers an explicit IANA location.timezone over the longitude estimate", () => {
+      expect(
+        parseCardConfig({
+          location: { latitude: 50.0614, longitude: 19.9366, timezone: "Europe/Warsaw" },
+        }).locationOverride
+      ).toEqual({ lat: 50.0614, lon: 19.9366, timezone: "Europe/Warsaw" });
+    });
+    it("falls back to the longitude estimate when location.timezone is unusable", () => {
+      // Krakow's longitude estimates to UTC+1 — right in winter, an hour off in summer.
+      const derived = { lat: 50.0614, lon: 19.9366, timezone: "Etc/GMT-1" };
+      expect(
+        parseCardConfig({
+          location: { latitude: 50.0614, longitude: 19.9366, timezone: "Not/AZone" },
+        }).locationOverride
+      ).toEqual(derived);
+      expect(
+        parseCardConfig({ location: { latitude: 50.0614, longitude: 19.9366, timezone: "" } })
+          .locationOverride
+      ).toEqual(derived);
+      // camelCase is not the key — silently ignored, like any unknown HA card option.
+      expect(
+        parseCardConfig({
+          location: { latitude: 50.0614, longitude: 19.9366, timeZone: "Europe/Warsaw" },
+        } as never).locationOverride
+      ).toEqual(derived);
+    });
     it("parses locationNameOverride independently", () => {
       expect(parseCardConfig({ location: { name: "Home" } }).locationNameOverride).toBe("Home");
     });

--- a/test/card/card-config.test.ts
+++ b/test/card/card-config.test.ts
@@ -87,6 +87,7 @@ describe("parseCardConfig", () => {
       ).toEqual({
         lat: 10,
         lon: 20,
+        timezone: "Etc/GMT-1",
       });
     });
     it("rejects out-of-range or missing values", () => {
@@ -97,6 +98,18 @@ describe("parseCardConfig", () => {
         parseCardConfig({ location: { latitude: 10, longitude: 181 } }).locationOverride
       ).toBeNull();
       expect(parseCardConfig({ location: { latitude: 10 } }).locationOverride).toBeNull();
+    });
+    it("derives a longitude-based fixed-offset timezone", () => {
+      // Etc/GMT sign is POSIX-inverted: Etc/GMT+6 is UTC-6.
+      expect(
+        parseCardConfig({ location: { latitude: 30, longitude: -90 } }).locationOverride
+      ).toEqual({ lat: 30, lon: -90, timezone: "Etc/GMT+6" });
+      expect(
+        parseCardConfig({ location: { latitude: 35, longitude: 139.7 } }).locationOverride
+      ).toEqual({ lat: 35, lon: 139.7, timezone: "Etc/GMT-9" });
+      expect(
+        parseCardConfig({ location: { latitude: 51.5, longitude: -0.1278 } }).locationOverride
+      ).toEqual({ lat: 51.5, lon: -0.1278, timezone: "Etc/GMT+0" });
     });
     it("parses locationNameOverride independently", () => {
       expect(parseCardConfig({ location: { name: "Home" } }).locationNameOverride).toBe("Home");

--- a/test/card/card-template.test.ts
+++ b/test/card/card-template.test.ts
@@ -49,7 +49,7 @@ describe("buildStatusBar", () => {
 
   it("returns a truthy value when locationData is provided", () => {
     const result = buildStatusBar(
-      { lat: 51.5, lon: -0.1, timezone: "Europe/London", zoneDerived: false },
+      { lat: 51.5, lon: -0.1, timezone: "Europe/London", zoneOverride: false },
       "London",
       new Date("2026-03-05T12:00:00Z")
     );
@@ -59,7 +59,7 @@ describe("buildStatusBar", () => {
   it("contains a .status-bar element when locationData is provided", () => {
     const root = renderToDOM(
       buildStatusBar(
-        { lat: 51.5, lon: -0.1, timezone: "Europe/London", zoneDerived: false },
+        { lat: 51.5, lon: -0.1, timezone: "Europe/London", zoneOverride: false },
         "London",
         new Date("2026-03-05T12:00:00Z")
       )
@@ -70,7 +70,7 @@ describe("buildStatusBar", () => {
   it("left span includes location name, sky mode, and elevation", () => {
     const root = renderToDOM(
       buildStatusBar(
-        { lat: 51.5, lon: -0.1, timezone: "Europe/London", zoneDerived: false },
+        { lat: 51.5, lon: -0.1, timezone: "Europe/London", zoneOverride: false },
         "London",
         new Date("2026-03-05T12:00:00Z")
       )
@@ -82,7 +82,7 @@ describe("buildStatusBar", () => {
   it("includes Next: span when a transition exists within 24h", () => {
     const root = renderToDOM(
       buildStatusBar(
-        { lat: 51.5, lon: -0.1, timezone: "Europe/London", zoneDerived: false },
+        { lat: 51.5, lon: -0.1, timezone: "Europe/London", zoneOverride: false },
         "London",
         new Date("2026-03-05T12:00:00Z")
       )
@@ -95,7 +95,7 @@ describe("buildStatusBar", () => {
   it("appends the zone offset to the Next span when the zone is longitude-derived", () => {
     const root = renderToDOM(
       buildStatusBar(
-        { lat: 30, lon: -90, timezone: "Etc/GMT+6", zoneDerived: true },
+        { lat: 30, lon: -90, timezone: "Etc/GMT+6", zoneOverride: true },
         "New Orleans",
         new Date("2026-03-05T12:00:00Z")
       )
@@ -107,7 +107,7 @@ describe("buildStatusBar", () => {
   it("omits the zone offset when the zone came from HA config", () => {
     const root = renderToDOM(
       buildStatusBar(
-        { lat: 51.5, lon: -0.1, timezone: "Europe/London", zoneDerived: false },
+        { lat: 51.5, lon: -0.1, timezone: "Europe/London", zoneOverride: false },
         "London",
         new Date("2026-03-05T12:00:00Z")
       )
@@ -119,7 +119,7 @@ describe("buildStatusBar", () => {
   it("renders only one span when no transition found (polar night)", () => {
     const root = renderToDOM(
       buildStatusBar(
-        { lat: 89, lon: 0, timezone: "UTC", zoneDerived: false },
+        { lat: 89, lon: 0, timezone: "UTC", zoneOverride: false },
         "Arctic",
         new Date("2026-12-21T12:00:00Z")
       )
@@ -131,7 +131,7 @@ describe("buildStatusBar", () => {
   it("works with null locationName (empty name before pipe)", () => {
     const root = renderToDOM(
       buildStatusBar(
-        { lat: 0, lon: 0, timezone: "UTC", zoneDerived: false },
+        { lat: 0, lon: 0, timezone: "UTC", zoneOverride: false },
         null,
         new Date("2026-03-20T12:00:00Z")
       )
@@ -143,7 +143,7 @@ describe("buildStatusBar", () => {
   it("formats the Next span using UTC when timezone is null", () => {
     const root = renderToDOM(
       buildStatusBar(
-        { lat: 51.5, lon: -0.1, timezone: null, zoneDerived: false },
+        { lat: 51.5, lon: -0.1, timezone: null, zoneOverride: false },
         "Somewhere",
         new Date("2026-03-05T12:00:00Z")
       )
@@ -204,7 +204,7 @@ describe("formatDate", () => {
 });
 
 describe("buildStatusBarView", () => {
-  const locationData = { lat: 51.5, lon: -0.1, timezone: "Europe/London", zoneDerived: false };
+  const locationData = { lat: 51.5, lon: -0.1, timezone: "Europe/London", zoneOverride: false };
   const currentDate = new Date("2026-03-05T12:00:00Z");
 
   it("shows the gallery error when one is present, regardless of panelSource", () => {

--- a/test/card/card-template.test.ts
+++ b/test/card/card-template.test.ts
@@ -49,7 +49,7 @@ describe("buildStatusBar", () => {
 
   it("returns a truthy value when locationData is provided", () => {
     const result = buildStatusBar(
-      { lat: 51.5, lon: -0.1, timezone: "Europe/London" },
+      { lat: 51.5, lon: -0.1, timezone: "Europe/London", zoneDerived: false },
       "London",
       new Date("2026-03-05T12:00:00Z")
     );
@@ -59,7 +59,7 @@ describe("buildStatusBar", () => {
   it("contains a .status-bar element when locationData is provided", () => {
     const root = renderToDOM(
       buildStatusBar(
-        { lat: 51.5, lon: -0.1, timezone: "Europe/London" },
+        { lat: 51.5, lon: -0.1, timezone: "Europe/London", zoneDerived: false },
         "London",
         new Date("2026-03-05T12:00:00Z")
       )
@@ -70,7 +70,7 @@ describe("buildStatusBar", () => {
   it("left span includes location name, sky mode, and elevation", () => {
     const root = renderToDOM(
       buildStatusBar(
-        { lat: 51.5, lon: -0.1, timezone: "Europe/London" },
+        { lat: 51.5, lon: -0.1, timezone: "Europe/London", zoneDerived: false },
         "London",
         new Date("2026-03-05T12:00:00Z")
       )
@@ -82,7 +82,7 @@ describe("buildStatusBar", () => {
   it("includes Next: span when a transition exists within 24h", () => {
     const root = renderToDOM(
       buildStatusBar(
-        { lat: 51.5, lon: -0.1, timezone: "Europe/London" },
+        { lat: 51.5, lon: -0.1, timezone: "Europe/London", zoneDerived: false },
         "London",
         new Date("2026-03-05T12:00:00Z")
       )
@@ -92,10 +92,34 @@ describe("buildStatusBar", () => {
     expect(spans[1].textContent).toMatch(/^Next: .+ \(\d{2}:\d{2}\)$/);
   });
 
+  it("appends the zone offset to the Next span when the zone is longitude-derived", () => {
+    const root = renderToDOM(
+      buildStatusBar(
+        { lat: 30, lon: -90, timezone: "Etc/GMT+6", zoneDerived: true },
+        "New Orleans",
+        new Date("2026-03-05T12:00:00Z")
+      )
+    );
+    const spans = root.querySelectorAll(".status-bar span");
+    expect(spans[1].textContent).toMatch(/^Next: .+ \(\d{2}:\d{2} GMT-6\)$/);
+  });
+
+  it("omits the zone offset when the zone came from HA config", () => {
+    const root = renderToDOM(
+      buildStatusBar(
+        { lat: 51.5, lon: -0.1, timezone: "Europe/London", zoneDerived: false },
+        "London",
+        new Date("2026-03-05T12:00:00Z")
+      )
+    );
+    const spans = root.querySelectorAll(".status-bar span");
+    expect(spans[1].textContent).toMatch(/^Next: .+ \(\d{2}:\d{2}\)$/);
+  });
+
   it("renders only one span when no transition found (polar night)", () => {
     const root = renderToDOM(
       buildStatusBar(
-        { lat: 89, lon: 0, timezone: "UTC" },
+        { lat: 89, lon: 0, timezone: "UTC", zoneDerived: false },
         "Arctic",
         new Date("2026-12-21T12:00:00Z")
       )
@@ -106,7 +130,11 @@ describe("buildStatusBar", () => {
 
   it("works with null locationName (empty name before pipe)", () => {
     const root = renderToDOM(
-      buildStatusBar({ lat: 0, lon: 0, timezone: "UTC" }, null, new Date("2026-03-20T12:00:00Z"))
+      buildStatusBar(
+        { lat: 0, lon: 0, timezone: "UTC", zoneDerived: false },
+        null,
+        new Date("2026-03-20T12:00:00Z")
+      )
     );
     const leftSpan = root.querySelector(".status-bar span:first-child");
     expect(leftSpan.textContent).toContain("|");
@@ -115,7 +143,7 @@ describe("buildStatusBar", () => {
   it("formats the Next span using UTC when timezone is null", () => {
     const root = renderToDOM(
       buildStatusBar(
-        { lat: 51.5, lon: -0.1, timezone: null },
+        { lat: 51.5, lon: -0.1, timezone: null, zoneDerived: false },
         "Somewhere",
         new Date("2026-03-05T12:00:00Z")
       )
@@ -176,7 +204,7 @@ describe("formatDate", () => {
 });
 
 describe("buildStatusBarView", () => {
-  const locationData = { lat: 51.5, lon: -0.1, timezone: "Europe/London" };
+  const locationData = { lat: 51.5, lon: -0.1, timezone: "Europe/London", zoneDerived: false };
   const currentDate = new Date("2026-03-05T12:00:00Z");
 
   it("shows the gallery error when one is present, regardless of panelSource", () => {

--- a/test/card/card.test.ts
+++ b/test/card/card.test.ts
@@ -659,6 +659,26 @@ describe("SolarViewCard", () => {
       card.remove();
     });
 
+    it("config.location override switches timezone to a longitude-derived offset zone", () => {
+      const card = createAndMount();
+      card.hass = { config: { latitude: 41.9, longitude: -87.6, time_zone: "America/Chicago" } };
+      card.setConfig({ location: { latitude: 51.5, longitude: -0.1278, name: "London" } });
+      card._render();
+      expect(card._locationData?.timezone).toBe("Etc/GMT+0");
+      expect(card._locationData?.zoneDerived).toBe(true);
+      card.remove();
+    });
+
+    it("no config.location keeps HA's timezone", () => {
+      const card = createAndMount();
+      card.hass = { config: { latitude: 41.9, longitude: -87.6, time_zone: "America/Chicago" } };
+      card.setConfig({});
+      card._render();
+      expect(card._locationData?.timezone).toBe("America/Chicago");
+      expect(card._locationData?.zoneDerived).toBe(false);
+      card.remove();
+    });
+
     it("no config.location falls back to HA lat/lon/name", () => {
       const card = createAndMount();
       card.hass = { config: { latitude: 51.5, longitude: -0.1, location_name: "London" } };

--- a/test/card/card.test.ts
+++ b/test/card/card.test.ts
@@ -665,7 +665,7 @@ describe("SolarViewCard", () => {
       card.setConfig({ location: { latitude: 51.5, longitude: -0.1278, name: "London" } });
       card._render();
       expect(card._locationData?.timezone).toBe("Etc/GMT+0");
-      expect(card._locationData?.zoneDerived).toBe(true);
+      expect(card._locationData?.zoneOverride).toBe(true);
       card.remove();
     });
 
@@ -675,7 +675,7 @@ describe("SolarViewCard", () => {
       card.setConfig({});
       card._render();
       expect(card._locationData?.timezone).toBe("America/Chicago");
-      expect(card._locationData?.zoneDerived).toBe(false);
+      expect(card._locationData?.zoneOverride).toBe(false);
       card.remove();
     });
 
@@ -1432,6 +1432,77 @@ describe("SolarViewCard", () => {
       const spans = bar.querySelectorAll("span");
       expect(spans[1].textContent).toMatch(/^Next: .+ \(\d{2}:\d{2}\)$/);
       card.remove();
+    });
+
+    // The clock in the "Next:" readout must follow the *observed* location, not the box Home
+    // Assistant runs on. Every case below mounts a card whose HA is in America/Chicago, so any
+    // leak of HA's zone shows up as a Chicago clock. Expected offsets are facts about each
+    // country, independent of anything the card computes: Poland is UTC+1 / UTC+2 under DST,
+    // Uruguay is UTC-3 year-round, India is UTC+5:30 and never shifts.
+    function nextSpan(location, date) {
+      const card = document.createElement("ha-planetary-solar-system-card-test");
+      card.setConfig({ location });
+      card.hass = {
+        config: {
+          latitude: 41.8781,
+          longitude: -87.6298,
+          time_zone: "America/Chicago",
+          location_name: "Chicago",
+        },
+      };
+      card._dateNav.currentDate = date;
+      document.body.appendChild(card);
+      card._render();
+      const spans = card.shadowRoot.querySelectorAll(".status-bar span");
+      const text = spans[1].textContent;
+      card.remove();
+      const m = /\((\d{2}):(\d{2}) (.+)\)$/.exec(text);
+      if (!m) throw new Error(`unexpected Next span: ${text}`);
+      return { text, minutes: Number(m[1]) * 60 + Number(m[2]), zone: m[3] };
+    }
+
+    const KRAKOW = { name: "Krakow, Poland", latitude: 50.0614, longitude: 19.9366 };
+    const MONTEVIDEO = { name: "Montevideo, Uruguay", latitude: -34.9011, longitude: -56.1645 };
+    const BANGALORE = { name: "Bangalore, India", latitude: 12.9716, longitude: 77.5946 };
+    const SUMMER = new Date("2026-08-20T18:00:00Z");
+    const WINTER = new Date("2026-01-20T15:00:00Z");
+
+    it("Krakow with timezone: Europe/Warsaw follows Poland's DST, not HA's Chicago clock", () => {
+      expect(nextSpan({ ...KRAKOW, timezone: "Europe/Warsaw" }, SUMMER).zone).toBe("GMT+2");
+      expect(nextSpan({ ...KRAKOW, timezone: "Europe/Warsaw" }, WINTER).zone).toBe("GMT+1");
+    });
+
+    it("Krakow without a timezone estimates UTC+1 — right in winter, an hour off in summer", () => {
+      const summerEstimate = nextSpan(KRAKOW, SUMMER);
+      const summerTruth = nextSpan({ ...KRAKOW, timezone: "Europe/Warsaw" }, SUMMER);
+      expect(summerEstimate.zone).toBe("GMT+1");
+      expect(summerTruth.minutes - summerEstimate.minutes).toBe(60);
+
+      const winterEstimate = nextSpan(KRAKOW, WINTER);
+      const winterTruth = nextSpan({ ...KRAKOW, timezone: "Europe/Warsaw" }, WINTER);
+      expect(winterEstimate.zone).toBe("GMT+1");
+      expect(winterTruth.minutes - winterEstimate.minutes).toBe(0);
+    });
+
+    it("Montevideo without a timezone estimates UTC-4, an hour behind Uruguay's fixed UTC-3", () => {
+      const estimate = nextSpan(MONTEVIDEO, SUMMER);
+      const truth = nextSpan({ ...MONTEVIDEO, timezone: "America/Montevideo" }, SUMMER);
+      expect(estimate.zone).toBe("GMT-4");
+      expect(truth.zone).toBe("GMT-3");
+      expect(truth.minutes - estimate.minutes).toBe(60);
+    });
+
+    it("Bangalore needs the explicit zone — a longitude offset cannot express UTC+5:30", () => {
+      const estimate = nextSpan(BANGALORE, SUMMER);
+      const truth = nextSpan({ ...BANGALORE, timezone: "Asia/Kolkata" }, SUMMER);
+      expect(estimate.zone).toBe("GMT+5");
+      expect(truth.zone).toBe("GMT+5:30");
+      expect(truth.minutes - estimate.minutes).toBe(30);
+    });
+
+    it("names a US zone by its abbreviation rather than a bare offset", () => {
+      expect(nextSpan({ ...KRAKOW, timezone: "America/Chicago" }, SUMMER).zone).toBe("CDT");
+      expect(nextSpan({ ...KRAKOW, timezone: "America/Chicago" }, WINTER).zone).toBe("CST");
     });
 
     it("only one span rendered when no transition found within 24h (polar night)", () => {


### PR DESCRIPTION
Closes #133. Closes #138.

## What & why

`_locationData` took `lat`/`lon` from `config.location` but always took `timezone` from
`hass.config.time_zone`. A card configured for Kraków on a Chicago HA computed Kraków's sunset
correctly, then printed it on a Chicago clock.

Two commits, in order:

1. **`fix:`** — the override carries its own timezone, estimated from longitude
   (`round(lon / 15)` → `Etc/GMT±N`, built into `Intl`). Zero deps, zero config, zero bundle growth.
2. **`feat:`** — optional `location.timezone` (IANA) for when the estimate isn't good enough.

## The estimate isn't good enough surprisingly often

| Location | Estimated | Actual | Error |
| --- | --- | --- | --- |
| Kraków, Poland (lon 19.94) | `GMT+1` | `GMT+1` / `GMT+2` DST | 0–1 h |
| Montevideo, Uruguay (lon -56.16) | `GMT-4` | `GMT-3` all year | 1 h |
| Bangalore, India (lon 77.59) | `GMT+5` | `GMT+5:30` | 30 min |

No DST, no half-hour zones, and wrong wherever a border ignores the meridian. Hence the explicit
key:

```yaml
location:
  name: Krakow, Poland
  latitude: 50.0614
  longitude: 19.9366
  timezone: Europe/Warsaw
```

→ `Next: Sunset (20:20 GMT+2)` in summer, `(16:37 GMT+1)` in winter. No dependency: `Intl` already
carries the tz database, it just can't be searched by coordinate. Validation is
`new Intl.DateTimeFormat("en-US", { timeZone })` — it throws `RangeError` on anything unknown, so a
typo degrades to the estimate rather than breaking the card.

## Change map

| Theme | Where | Substance |
| --- | --- | --- |
| Estimate a zone from longitude | `src/card/card-config.ts:42` | `round(lon/15)` → `Etc/GMT±N`, POSIX-inverted sign |
| Accept an explicit zone | `src/card/card-config.ts:52` | `location.timezone` validated via `Intl`, else the estimate |
| Resolve precedence | `src/card/card.ts:87` | `override?.timezone ?? hassLocation.timezone ?? "UTC"`; sets `zoneOverride` |
| Name the zone in the readout | `src/card/card-template.ts:38` | `timeZoneName: "short"` when `zoneOverride` |

`"short"` rather than `"shortOffset"` so a named zone reads `CDT` where the locale has an
abbreviation, while an estimated `Etc/GMT±N` still reads `GMT+1`. One option covers both, no
branching.

## Behavior changes

- Override + `timezone` → exact local clock, DST and history included.
- Override only → longitude estimate, labelled so the approximation is visible not silent.
- No override → byte-identical to before: HA timezone, bare `(18:42)`.
- Unaffected: twilight bands, observer needle, solar elevation — computed from lat/lon in UTC, they
  never touch a zone. This was always a display-only bug.

## Review focus

**Sign inversion** (`card-config.ts:44`) — `Etc/GMT+6` means UTC−6. A flipped ternary shifts every
readout by 2N hours and still type-checks.

**`zoneDerived` → `zoneOverride`** — the flag now means "not HA's zone", covering both an explicit
zone and an estimated one. The old name would have been a lie for the explicit case.

## Tests

TDD throughout, red before green. End-to-end cases mount a card whose HA sits in
`America/Chicago`, so any leak of HA's zone shows up as a Chicago clock. Expected offsets are facts
about each country (Poland UTC+1/+2, Uruguay UTC−3 fixed, India UTC+5:30 fixed), independent of
anything the card computes — and each city asserts the exact gap between the estimate and the truth
(60, 60, and 30 minutes).

760 tests pass, coverage stays at 100%, `check:ci` clean, CI green. README documents the key, the
canonical-name guidance, and the accuracy table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)