### PR TITLE
docs: correct where show_version renders

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ frame.
 | `theme`         | `"auto"` \| `"dark"` \| `"light"` | `"auto"`  | `"auto"` follows the HA theme. `"dark"`/`"light"` forces a built-in background/text pair regardless of the installed theme |
 | `colors`        | object                            | see below | Color overrides (see Colors)                                                                                               |
 | `ecliptic_view` | `"north"` \| `"south"`            | `"north"` | Viewing pole: `"north"` = counter-clockwise orbits; `"south"` = clockwise orbits                                           |
-| `show_version`  | boolean                           | `false`   | Show card version number centered in the top status bar                                                                    |
+| `show_version`  | boolean                           | `false`   | Show the card version number in the bottom navigation bar, right-aligned                                                   |
 | `debug`         | boolean                           | `false`   | Show a live overlay of gallery fetch/cache stats per NASA source (refreshes, cache hits, retries, failures)                |
 
 ### Colors


### PR DESCRIPTION
The README said the version number appears "centered in the top status bar". Both halves are wrong.

`card.ts:281` renders the span inside `.nav` — the bottom button row, not the status bar:

```ts
${this._config?.show_version ? html`<span class="card-version">v${__CARD_VERSION__}</span>` : nothing}
```

and `card-styles.ts:255` pins it to the right edge rather than centering it:

```css
.card-version {
  position: absolute;
  right: 8px;
  top: 50%;
  transform: translateY(-50%);
}
```

Docs-only, one line. Reported by @marcintk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)