### PR TITLE
chore: drop dead .active styling and the _zoomLevel proxy

### DIFF
--- a/src/card/card-styles.ts
+++ b/src/card/card-styles.ts
@@ -172,16 +172,6 @@ export const cardStyles = css`
     border-color: var(--accent-color, #f59e0b);
     color: #fff;
   }
-  button[data-action="show-earth"].active {
-    background: #3b82f6;
-    border-color: #3b82f6;
-    color: #fff;
-  }
-  button[data-action="show-sun"].active {
-    background: #f97316;
-    border-color: #f97316;
-    color: #fff;
-  }
   .btn-group {
     display: flex;
     flex-wrap: wrap;

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -1,12 +1,5 @@
 import { html, LitElement, nothing } from "lit";
-import type {
-  CardConfig,
-  Colors,
-  HASSConfig,
-  Hemisphere,
-  LocationData,
-  ZoomLevel,
-} from "../types.js";
+import type { CardConfig, Colors, HASSConfig, Hemisphere, LocationData } from "../types.js";
 import { parseCardConfig } from "./card-config.js";
 import { cardStyles } from "./card-styles.js";
 import type { ImageSource } from "./card-template.js";
@@ -111,9 +104,6 @@ export class SolarViewCard extends LitElement {
   }
   get _effectiveLocationName(): string | null {
     return this._locationNameOverride ?? this._hassLocation.name;
-  }
-  get _zoomLevel(): ZoomLevel | null {
-    return this._zoom.zoomLevel;
   }
 
   set hass(hass: HASSConfig) {
@@ -282,7 +272,6 @@ export class SolarViewCard extends LitElement {
                     <button
                       data-action="gallery"
                       title="Show image gallery"
-                      class=${gallery.navButtonActive ? "active" : ""}
                       @click=${this._onNavClick}
                     >
                       <span class="icon">☷</span>

--- a/src/card/gallery/gallery-controller.ts
+++ b/src/card/gallery/gallery-controller.ts
@@ -23,7 +23,6 @@ export interface GalleryViewModel {
   showStrip: boolean;
   thumbnails: { source: ImageSource; url: string | null; date: Date | null }[];
   navButtonVisible: boolean;
-  navButtonActive: boolean;
   debugStats: Record<DebugRowId, SourceDebugStats>;
   debugStartedAt: number;
 }
@@ -129,7 +128,6 @@ export class GalleryController {
         date: this._images[source]?.date ?? null,
       })),
       navButtonVisible: this._mode !== "none",
-      navButtonActive: this._open,
       debugStats: this.debugStats,
       debugStartedAt: this._debugStartedAt,
     };

--- a/test/__snapshots__/snapshot.test.ts.snap
+++ b/test/__snapshots__/snapshot.test.ts.snap
@@ -194,16 +194,6 @@ exports[`cardStyles > matches snapshot 1`] = `
     border-color: var(--accent-color, #f59e0b);
     color: #fff;
   }
-  button[data-action="show-earth"].active {
-    background: #3b82f6;
-    border-color: #3b82f6;
-    color: #fff;
-  }
-  button[data-action="show-sun"].active {
-    background: #f97316;
-    border-color: #f97316;
-    color: #fff;
-  }
   .btn-group {
     display: flex;
     flex-wrap: wrap;

--- a/test/card/card-template.test.ts
+++ b/test/card/card-template.test.ts
@@ -29,7 +29,6 @@ function galleryViewModel(overrides: Partial<GalleryViewModel> = {}): GalleryVie
     showStrip: false,
     thumbnails: [],
     navButtonVisible: false,
-    navButtonActive: false,
     debugStats: { earth: zeroDebugStats, sun: zeroDebugStats },
     debugStartedAt: Date.now(),
     ...overrides,

--- a/test/card/card.auto-behaviour.test.ts
+++ b/test/card/card.auto-behaviour.test.ts
@@ -29,11 +29,11 @@ describe("SolarViewCard automatic behaviour", () => {
     // Both behaviours are observed through what one refresh tick does, never through a flag:
     // auto_cycle is alive if the tick pulled the date to now, auto_zoom if it moved the level.
     function runOneTick(card) {
-      const zoomBefore = card._zoomLevel;
+      const zoomBefore = card._zoom.zoomLevel;
       vi.advanceTimersByTime(TICK_MS);
       return {
         autoCycleAlive: card._dateNav.currentDate.getTime() === Date.now(),
-        autoZoomAlive: card._zoomLevel !== zoomBefore,
+        autoZoomAlive: card._zoom.zoomLevel !== zoomBefore,
       };
     }
 
@@ -114,7 +114,7 @@ describe("SolarViewCard automatic behaviour", () => {
         startReplayJustBeforeATick(card);
 
         expect(card._dateNav.isReplaying).toBe(true);
-        expect(card._zoomLevel).toBe(1); // the cycle must not zoom mid-animation
+        expect(card._zoom.zoomLevel).toBe(1); // the cycle must not zoom mid-animation
         // The date belongs to the replay while it runs, not to the refresh tick.
         expect(card._dateNav.currentDate.getTime()).toBeLessThan(START.getTime());
         card.remove();
@@ -128,7 +128,7 @@ describe("SolarViewCard automatic behaviour", () => {
         vi.advanceTimersByTime(59900); // lands exactly on the next tick, replay long finished
         expect(card._dateNav.isReplaying).toBe(false);
         expect(card._dateNav.currentDate.getTime()).toBe(Date.now());
-        expect(card._zoomLevel).not.toBe(1);
+        expect(card._zoom.zoomLevel).not.toBe(1);
         card.remove();
       });
     });

--- a/test/card/card.auto-zoom.test.ts
+++ b/test/card/card.auto-zoom.test.ts
@@ -31,9 +31,9 @@ describe("SolarViewCard auto_zoom", () => {
       const card = document.createElement("ha-planetary-solar-system-card-test");
       card.setConfig({ periodic_zoom_change: false });
       document.body.appendChild(card);
-      expect(card._zoomLevel).toBe(1);
+      expect(card._zoom.zoomLevel).toBe(1);
       vi.advanceTimersByTime(60000);
-      expect(card._zoomLevel).toBe(1);
+      expect(card._zoom.zoomLevel).toBe(1);
       card.remove();
     });
 
@@ -42,11 +42,11 @@ describe("SolarViewCard auto_zoom", () => {
       const card = document.createElement("ha-planetary-solar-system-card-test");
       card.setConfig({ periodic_zoom_change: true });
       document.body.appendChild(card);
-      expect(card._zoomLevel).toBe(1);
+      expect(card._zoom.zoomLevel).toBe(1);
       vi.advanceTimersByTime(60000);
-      expect(card._zoomLevel).toBe(2);
+      expect(card._zoom.zoomLevel).toBe(2);
       vi.advanceTimersByTime(60000);
-      expect(card._zoomLevel).toBe(3);
+      expect(card._zoom.zoomLevel).toBe(3);
       card.remove();
     });
 
@@ -55,9 +55,9 @@ describe("SolarViewCard auto_zoom", () => {
       const card = document.createElement("ha-planetary-solar-system-card-test");
       card.setConfig({ periodic_zoom_change: true, default_zoom: 4 });
       document.body.appendChild(card);
-      expect(card._zoomLevel).toBe(4);
+      expect(card._zoom.zoomLevel).toBe(4);
       vi.advanceTimersByTime(60000);
-      expect(card._zoomLevel).toBe(1);
+      expect(card._zoom.zoomLevel).toBe(1);
       card.remove();
     });
 
@@ -79,12 +79,12 @@ describe("SolarViewCard auto_zoom", () => {
       card.setConfig({ periodic_zoom_change: true });
       document.body.appendChild(card);
       clickButton(card, "zoom-in");
-      expect(card._zoomLevel).toBe(2);
+      expect(card._zoom.zoomLevel).toBe(2);
 
       vi.advanceTimersByTime(60000);
-      expect(card._zoomLevel).toBe(2);
+      expect(card._zoom.zoomLevel).toBe(2);
       vi.advanceTimersByTime(60000);
-      expect(card._zoomLevel).toBe(2);
+      expect(card._zoom.zoomLevel).toBe(2);
       card.remove();
     });
 
@@ -96,12 +96,12 @@ describe("SolarViewCard auto_zoom", () => {
       clickButton(card, "zoom-in");
       clickButton(card, "zoom-in");
       vi.advanceTimersByTime(60000);
-      expect(card._zoomLevel).toBe(3); // suspended by the manual zooms
+      expect(card._zoom.zoomLevel).toBe(3); // suspended by the manual zooms
 
       clickButton(card, "today");
-      expect(card._zoomLevel).toBe(1);
+      expect(card._zoom.zoomLevel).toBe(1);
       vi.advanceTimersByTime(60000);
-      expect(card._zoomLevel).toBe(2);
+      expect(card._zoom.zoomLevel).toBe(2);
       card.remove();
     });
   });
@@ -131,11 +131,11 @@ describe("SolarViewCard auto_zoom", () => {
         const card = mountCycling();
         clickButton(card, action);
         vi.advanceTimersByTime(60000);
-        expect(card._zoomLevel).toBe(1);
+        expect(card._zoom.zoomLevel).toBe(1);
 
         clickButton(card, "today");
         vi.advanceTimersByTime(60000);
-        expect(card._zoomLevel).toBe(2);
+        expect(card._zoom.zoomLevel).toBe(2);
         card.remove();
       });
     }
@@ -146,7 +146,7 @@ describe("SolarViewCard auto_zoom", () => {
       dragView(card, 50, 0);
 
       vi.advanceTimersByTime(60000);
-      expect(card._zoomLevel).toBe(1);
+      expect(card._zoom.zoomLevel).toBe(1);
       card.remove();
     });
 
@@ -155,7 +155,7 @@ describe("SolarViewCard auto_zoom", () => {
       const card = mountCycling();
       clickButton(card, "replay");
       vi.advanceTimersByTime(60000);
-      expect(card._zoomLevel).toBe(2);
+      expect(card._zoom.zoomLevel).toBe(2);
       card.remove();
     });
 
@@ -166,7 +166,7 @@ describe("SolarViewCard auto_zoom", () => {
       document.body.appendChild(card);
       clickButton(card, "gallery");
       vi.advanceTimersByTime(60000);
-      expect(card._zoomLevel).toBe(2);
+      expect(card._zoom.zoomLevel).toBe(2);
       card.remove();
     });
   });
@@ -181,13 +181,13 @@ describe("SolarViewCard auto_zoom", () => {
       const card = document.createElement("ha-planetary-solar-system-card-test");
       card.setConfig({ periodic_zoom_change: true, periodic_zoom_max: 3 });
       document.body.appendChild(card);
-      expect(card._zoomLevel).toBe(1);
+      expect(card._zoom.zoomLevel).toBe(1);
       vi.advanceTimersByTime(60000);
-      expect(card._zoomLevel).toBe(2);
+      expect(card._zoom.zoomLevel).toBe(2);
       vi.advanceTimersByTime(60000);
-      expect(card._zoomLevel).toBe(3);
+      expect(card._zoom.zoomLevel).toBe(3);
       vi.advanceTimersByTime(60000);
-      expect(card._zoomLevel).toBe(1);
+      expect(card._zoom.zoomLevel).toBe(1);
       card.remove();
     });
 
@@ -199,9 +199,9 @@ describe("SolarViewCard auto_zoom", () => {
       vi.advanceTimersByTime(60000);
       vi.advanceTimersByTime(60000);
       vi.advanceTimersByTime(60000);
-      expect(card._zoomLevel).toBe(4);
+      expect(card._zoom.zoomLevel).toBe(4);
       vi.advanceTimersByTime(60000);
-      expect(card._zoomLevel).toBe(1);
+      expect(card._zoom.zoomLevel).toBe(1);
       card.remove();
     });
 
@@ -222,9 +222,9 @@ describe("SolarViewCard auto_zoom", () => {
       const card = document.createElement("ha-planetary-solar-system-card-test");
       card.setConfig({ periodic_zoom_change: false, periodic_zoom_max: 3 });
       document.body.appendChild(card);
-      expect(card._zoomLevel).toBe(1);
+      expect(card._zoom.zoomLevel).toBe(1);
       vi.advanceTimersByTime(60000);
-      expect(card._zoomLevel).toBe(1);
+      expect(card._zoom.zoomLevel).toBe(1);
       card.remove();
     });
   });

--- a/test/card/card.gallery.test.ts
+++ b/test/card/card.gallery.test.ts
@@ -55,9 +55,6 @@ describe("SolarViewCard gallery", () => {
     it("gallery button shows and strip is open by default when gallery.mode: both", () => {
       const card = mountWithGallery();
       expect(card.shadowRoot.querySelector('button[data-action="gallery"]')).toBeTruthy();
-      expect(
-        card.shadowRoot.querySelector('button[data-action="gallery"]').classList.contains("active")
-      ).toBe(true);
       expect(card.shadowRoot.querySelector(".gallery")).toBeTruthy();
       card.remove();
     });
@@ -130,15 +127,9 @@ describe("SolarViewCard gallery", () => {
       clickButton(card, "gallery");
       await flush();
       expect(card.shadowRoot.querySelector(".gallery")).toBeNull();
-      expect(
-        card.shadowRoot.querySelector('button[data-action="gallery"]').classList.contains("active")
-      ).toBe(false);
       clickButton(card, "gallery");
       await flush();
       expect(card.shadowRoot.querySelector(".gallery")).toBeTruthy();
-      expect(
-        card.shadowRoot.querySelector('button[data-action="gallery"]').classList.contains("active")
-      ).toBe(true);
       card.remove();
     });
 

--- a/test/card/card.test.ts
+++ b/test/card/card.test.ts
@@ -334,7 +334,7 @@ describe("SolarViewCard", () => {
     it("return safe defaults when _viewState is null", () => {
       const card = document.createElement("ha-planetary-solar-system-card-test");
       // Card created but never mounted — _viewState is null
-      expect(card._zoomLevel).toBeNull();
+      expect(card._zoom.zoomLevel).toBeNull();
     });
   });
 

--- a/test/card/card.view.test.ts
+++ b/test/card/card.view.test.ts
@@ -46,9 +46,9 @@ describe("SolarViewCard view", () => {
     it("zoom in steps to next level", () => {
       const card = createAndMount();
       // Default is level 1 (800)
-      expect(card._zoomLevel).toBe(1);
+      expect(card._zoom.zoomLevel).toBe(1);
       clickButton(card, "zoom-in");
-      expect(card._zoomLevel).toBe(2);
+      expect(card._zoom.zoomLevel).toBe(2);
       const { width } = parseViewBox(card);
       expect(width).toBe(640);
       card.remove();
@@ -58,9 +58,9 @@ describe("SolarViewCard view", () => {
       const card = createAndMount();
       // Default is level 1, zoom in first then zoom out
       clickButton(card, "zoom-in");
-      expect(card._zoomLevel).toBe(2);
+      expect(card._zoom.zoomLevel).toBe(2);
       clickButton(card, "zoom-out");
-      expect(card._zoomLevel).toBe(1);
+      expect(card._zoom.zoomLevel).toBe(1);
       const { width } = parseViewBox(card);
       expect(width).toBe(800);
       card.remove();
@@ -69,7 +69,7 @@ describe("SolarViewCard view", () => {
     it("zoom in is clamped at level 4 (viewBox 320)", () => {
       const card = createAndMount();
       for (let i = 0; i < 20; i++) clickButton(card, "zoom-in");
-      expect(card._zoomLevel).toBe(4);
+      expect(card._zoom.zoomLevel).toBe(4);
       const { width, height } = parseViewBox(card);
       expect(width).toBe(320);
       expect(height).toBe(320);
@@ -79,7 +79,7 @@ describe("SolarViewCard view", () => {
     it("zoom out is clamped at level 1 (viewBox 800)", () => {
       const card = createAndMount();
       for (let i = 0; i < 20; i++) clickButton(card, "zoom-out");
-      expect(card._zoomLevel).toBe(1);
+      expect(card._zoom.zoomLevel).toBe(1);
       const { width } = parseViewBox(card);
       expect(width).toBe(800);
       card.remove();
@@ -204,10 +204,10 @@ describe("SolarViewCard view", () => {
       const card = createAndMount();
       clickButton(card, "zoom-in");
       clickButton(card, "zoom-in");
-      expect(card._zoomLevel).toBe(3);
+      expect(card._zoom.zoomLevel).toBe(3);
       clickButton(card, "today");
       const after = parseViewBox(card);
-      expect(card._zoomLevel).toBe(1);
+      expect(card._zoom.zoomLevel).toBe(1);
       expect(after.width).toBe(800);
       card.remove();
     });
@@ -230,7 +230,7 @@ describe("SolarViewCard view", () => {
       const card = document.createElement("ha-planetary-solar-system-card-test");
       card.setConfig({ default_zoom: 4 });
       document.body.appendChild(card);
-      expect(card._zoomLevel).toBe(4);
+      expect(card._zoom.zoomLevel).toBe(4);
       const { width } = parseViewBox(card);
       expect(width).toBe(320);
       card.remove();
@@ -240,7 +240,7 @@ describe("SolarViewCard view", () => {
       const card = document.createElement("ha-planetary-solar-system-card-test");
       card.setConfig({});
       document.body.appendChild(card);
-      expect(card._zoomLevel).toBe(1);
+      expect(card._zoom.zoomLevel).toBe(1);
       const { width } = parseViewBox(card);
       expect(width).toBe(800);
       card.remove();
@@ -252,9 +252,9 @@ describe("SolarViewCard view", () => {
       document.body.appendChild(card);
       clickButton(card, "zoom-in");
       clickButton(card, "zoom-in");
-      expect(card._zoomLevel).toBe(4);
+      expect(card._zoom.zoomLevel).toBe(4);
       clickButton(card, "today");
-      expect(card._zoomLevel).toBe(2);
+      expect(card._zoom.zoomLevel).toBe(2);
       const { width } = parseViewBox(card);
       expect(width).toBe(640);
       card.remove();
@@ -466,9 +466,9 @@ describe("SolarViewCard view", () => {
     it("setConfig after the card has rendered moves the live view (issue #125)", () => {
       const card = document.createElement("ha-planetary-solar-system-card-test");
       document.body.appendChild(card);
-      expect(card._zoomLevel).toBe(1);
+      expect(card._zoom.zoomLevel).toBe(1);
       card.setConfig({ default_zoom: 3 });
-      expect(card._zoomLevel).toBe(3);
+      expect(card._zoom.zoomLevel).toBe(3);
       expect(parseViewBox(card).width).toBe(480);
       card.remove();
     });

--- a/test/card/gallery/gallery-controller.test.ts
+++ b/test/card/gallery/gallery-controller.test.ts
@@ -294,7 +294,6 @@ describe("GalleryController.viewModel", () => {
     expect(vm.error).toBeNull();
     expect(vm.panelSource).toBe("none");
     expect(vm.navButtonVisible).toBe(true);
-    expect(vm.navButtonActive).toBe(false);
   });
 
   it("reflects an open strip with no panel", () => {
@@ -303,7 +302,6 @@ describe("GalleryController.viewModel", () => {
     const vm = gallery.viewModel();
     expect(vm.showStrip).toBe(true);
     expect(vm.panelSource).toBe("none");
-    expect(vm.navButtonActive).toBe(true);
     expect(vm.thumbnails.map((t) => t.source)).toEqual(["earth", "sun"]);
   });
 


### PR DESCRIPTION
Three cuts from the repo-wide `/ponytail-audit`. No behaviour change — one of the three deletions is *provably* invisible, and the other two have no runtime effect at all.

## 1. `.active` rules for buttons that don't exist

`button[data-action="show-earth"].active` and `show-sun` were added in #93 and orphaned when the gallery panel replaced those buttons with the `gallery` toggle and `.gallery-thumb` elements. Nothing in `src/` has rendered either `data-action` since.

## 2. The gallery button's `active` class matched no CSS

`card.ts` computed `class=${gallery.navButtonActive ? "active" : ""}`, fed by `GalleryViewModel.navButtonActive` — but there was no `button[data-action="gallery"].active` rule anywhere in `card-styles.ts`. The class was set, asserted by tests, and rendered identically either way.

Resolved by deleting the class and the view-model field rather than adding the missing rule. The three tests asserting it each sat directly beside an assertion on the `.gallery` strip's presence — the behaviour a user can actually see — so nothing is left uncovered:

```js
expect(card.shadowRoot.querySelector(".gallery")).toBeTruthy();
// the .active assertion that used to follow this line proved nothing extra
```

If you'd rather the gallery button *did* light up when open, that's the other resolution — say so and I'll add the rule instead.

## 3. `SolarViewCard._zoomLevel`

A proxy getter with zero callers in `src/`. It existed so tests could write `card._zoomLevel` instead of `card._zoom.zoomLevel`, which they already do for `card._zoom` and `card._dateNav` elsewhere. 45 call sites rewritten; its `ZoomLevel` type import went with it.

## Not taken

The audit's fourth finding — `UrlCache`'s four pass-through methods to `Backoff` — is left alone per review.

## Verification

801 tests pass, coverage 100% (statements / branches / functions / lines), `npm run check:ci` clean. The `cardStyles` snapshot loses exactly the 10 dead lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)