### PR TITLE
fix: make the moon gallery tile match its neighbours

### DIFF
--- a/src/card/card-styles.ts
+++ b/src/card/card-styles.ts
@@ -127,18 +127,25 @@ export const cardStyles = css`
     display: block;
   }
   /* Moon is drawn locally, not fetched — a <div> holding an <svg>, not an <img>, and with
-     no full-screen view to open it gets no pointer affordance. Black backdrop rather than
-     the transparent default, so the tile reads like the Earth/Sun photos beside it instead
-     of showing the card through it. */
+     no full-screen view to open it gets no pointer affordance. */
   .gallery-thumb-moon {
     cursor: default;
-    background: #000;
   }
+  /* The black backdrop belongs on the disc, not the tile. The tile border is a translucent
+     15% currentColor, so it composites against whatever sits behind it: transparent on the
+     fetched tiles, where it picks up the card and reads as a visible edge. Painting the tile
+     itself black made that border 15% white over black — invisible — so the moon's dark area
+     ran the full 104px while its neighbours' stopped at 102px inside their borders, and the
+     tile looked taller than tiles that measure exactly the same. Here the black fills the
+     content box instead, the same region the img occupies. */
   .moon-disc,
   .moon-disc svg {
     width: 100%;
     height: 100%;
     display: block;
+  }
+  .moon-disc {
+    background: #000;
   }
   .gallery-info {
     position: absolute;
@@ -147,16 +154,27 @@ export const cardStyles = css`
     right: 2px;
     display: flex;
     justify-content: space-between;
+    /* Bottom-align rather than stretch: a stretched span puts its line box at the top, so
+       any disagreement about the box's height moves the text instead of staying put. */
+    align-items: flex-end;
+    /* font-size and line-height are pinned on the container, not just the spans, because
+       the tiles are built from different elements — a <div> for the moon, a <button> for the
+       fetched sources — and a <button> takes its font from the UA stylesheet (13.333px)
+       while the <div> inherits the card's (16px). Left to inherit, the caption's height is
+       decided by the element type and the engine's default line-height, which is how the
+       moon's caption ended up sitting higher than its neighbours'.
+       Scales with the tile (see container-type above) instead of a fixed 8px, so the longest
+       phase name still fits on a narrow card and stays legible on a wide one. */
+    font-size: clamp(6px, 9cqw, 9px);
+    line-height: 1;
+    font-family: sans-serif;
     pointer-events: none;
   }
   .gallery-label,
   .gallery-age {
-    /* Scales with the tile (see container-type above) instead of a fixed 8px, so the longest
-       phase name still fits on a narrow card and stays legible on a wide one. */
-    font-size: clamp(6px, 9cqw, 9px);
+    font: inherit;
     color: #fff;
     text-shadow: 0 0 2px #000;
-    font-family: sans-serif;
     white-space: nowrap;
   }
   .nav {

--- a/src/card/card-styles.ts
+++ b/src/card/card-styles.ts
@@ -107,6 +107,10 @@ export const cardStyles = css`
     position: relative;
     aspect-ratio: 1;
     padding: 0;
+    /* Buttons get border-box from the UA stylesheet, a plain <div> does not — without this
+       the moon tile's 1px border falls outside its 20% flex-basis and it renders 2px larger
+       than the Earth/Sun tiles beside it. */
+    box-sizing: border-box;
     border: 1px solid var(--divider-color, color-mix(in srgb, currentColor 15%, transparent));
     border-radius: 4px;
     background: transparent;
@@ -144,11 +148,6 @@ export const cardStyles = css`
     display: flex;
     justify-content: space-between;
     pointer-events: none;
-  }
-  /* Moon has no label span — the phase name gets the tile's full width, which the longest
-     of them ("Waxing Crescent") needs. */
-  .gallery-thumb-moon .gallery-info {
-    justify-content: center;
   }
   .gallery-label,
   .gallery-age {

--- a/src/card/card-template.ts
+++ b/src/card/card-template.ts
@@ -1,5 +1,6 @@
 import type { TemplateResult } from "lit";
 import { html, nothing } from "lit";
+import { getMoonPhase } from "../astronomy/moon-phase.js";
 import {
   computeNextTransitionTime,
   computeSolarElevationDeg,
@@ -64,12 +65,43 @@ export const IMAGE_SOURCE_LABELS: Record<ImageSource, string> = {
   sun: "SDO HMI Continuum",
 };
 
-// Labels for the gallery thumbnail strip. Moon has none: its tile shows the phase name
-// across the full width instead, and a moon disc captioned "Moon" says nothing twice.
-export const GALLERY_SOURCE_LABELS: Record<ImageSource, string> = {
+// Labels for the gallery thumbnail strip — the left half of every tile's caption.
+export const GALLERY_SOURCE_LABELS: Record<GallerySource, string> = {
+  moon: "MOON",
   earth: "DSCOVR/E",
   sun: "SDO/S",
 };
+
+/**
+ * Tooltip for the moon tile — the counterpart to the NASA tiles' "Show <source>", which
+ * would be a lie here since nothing opens.
+ *
+ * Says "tonight" only while the view is live. The date-nav buttons can put the card on any
+ * date, and the disc follows them, so a fixed "Tonight's Moon" would quietly misdescribe
+ * every navigated view. Illumination is the one thing the caption has no room for, which is
+ * what makes this worth a tooltip rather than a repeat of the phase name.
+ */
+export function buildMoonTitle(date: Date, isLiveMode: boolean): string {
+  const { phaseName, illumination } = getMoonPhase(date);
+  const when = isLiveMode ? "Tonight's Moon" : `Moon on ${formatDate(date)}`;
+  return `${when} — ${phaseName}, ${Math.round(illumination * 100)}% illuminated`;
+}
+
+/**
+ * The caption overlaid on a gallery thumbnail: source on the left, detail on the right.
+ *
+ * Shared by every tile rather than written out per branch. The moon tile is built from a
+ * different element than the fetched ones (a <div>, since it has no full-screen view), and
+ * when each branch spelled its own caption out the two drifted apart — different spans, and
+ * a moon-only `justify-content` override that shifted the text off the baseline its
+ * neighbours sat on. One builder means they cannot diverge again.
+ */
+export function buildGalleryCaption(label: string, detail: string): TemplateResult {
+  return html`<div class="gallery-info">
+    <span class="gallery-label">${label}</span>
+    <span class="gallery-age">${detail}</span>
+  </div>`;
+}
 
 // Sources that need fetching/hydrating — the network-backed ones only.
 export const IMAGE_SOURCES: ImageSource[] = ["earth", "sun"];

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -5,7 +5,13 @@ import type { CardConfig, Colors, HASSConfig, Hemisphere, LocationData } from ".
 import { parseCardConfig } from "./card-config.js";
 import { cardStyles } from "./card-styles.js";
 import type { ImageSource } from "./card-template.js";
-import { buildStatusBarView, formatDate, GALLERY_SOURCE_LABELS } from "./card-template.js";
+import {
+  buildGalleryCaption,
+  buildMoonTitle,
+  buildStatusBarView,
+  formatDate,
+  GALLERY_SOURCE_LABELS,
+} from "./card-template.js";
 import { DateNavigation } from "./date-navigation.js";
 import { buildDebugOverlay } from "./gallery/debug.js";
 import type { GalleryMode } from "./gallery/gallery-controller.js";
@@ -230,11 +236,19 @@ export class SolarViewCard extends LitElement {
                     // something no click can deliver. Its SVG is mounted imperatively in
                     // updated() — same split as #solar-view.
                     source === "moon"
-                      ? html`<div class="gallery-thumb gallery-thumb-moon" data-source="moon">
+                      ? html`<div
+                          class="gallery-thumb gallery-thumb-moon"
+                          data-source="moon"
+                          title=${buildMoonTitle(
+                            this._dateNav.currentDate,
+                            this._dateNav.isLiveMode
+                          )}
+                        >
                           <div class="moon-disc"></div>
-                          <div class="gallery-info">
-                            <span class="gallery-age">${getMoonPhase(this._dateNav.currentDate).phaseName}</span>
-                          </div>
+                          ${buildGalleryCaption(
+                            GALLERY_SOURCE_LABELS.moon,
+                            getMoonPhase(this._dateNav.currentDate).phaseName
+                          )}
                         </div>`
                       : html`<button
                           class="gallery-thumb"
@@ -247,12 +261,10 @@ export class SolarViewCard extends LitElement {
                             alt=""
                             @error=${source === "sun" ? this._onSunThumbError : undefined}
                           />
-                          <div class="gallery-info">
-                            <span class="gallery-label">${GALLERY_SOURCE_LABELS[source]}</span>
-                            <span class="gallery-age"
-                              >${date ? formatRelativeAge(date, new Date()) : "loading…"}</span
-                            >
-                          </div>
+                          ${buildGalleryCaption(
+                            GALLERY_SOURCE_LABELS[source],
+                            date ? formatRelativeAge(date, new Date()) : "loading…"
+                          )}
                         </button>`
                   )}
                 </div>`

--- a/src/renderer/moon-phase.ts
+++ b/src/renderer/moon-phase.ts
@@ -12,7 +12,9 @@ const CENTER_X = DISC_SIZE / 2;
 // the bottom of the tile — at 48 it ran under the text and the longest names read against
 // the lit limb rather than the black backdrop.
 const CENTER_Y = 42;
-const INDICATOR_RADIUS = 38;
+// Kept a whole number: the terminator arc bakes it straight into the path's `A <r> <r>`
+// command, and a fractional radius makes those strings needlessly noisy to read and diff.
+const INDICATOR_RADIUS = 36;
 const DISC_COLOR = "#cccccc";
 const SHADOW_COLOR = "#1a1a2e";
 

--- a/src/renderer/moon-phase.ts
+++ b/src/renderer/moon-phase.ts
@@ -7,13 +7,11 @@ import { createSvgElement, SVG_NS } from "./svg-utils.js";
 // system the circle and terminator arc are drawn in.
 const DISC_SIZE = 100;
 
-const CENTER_X = DISC_SIZE / 2;
-// Lifted above centre, and small enough, that the disc clears the phase caption overlaid on
-// the bottom of the tile — at 48 it ran under the text and the longest names read against
-// the lit limb rather than the black backdrop.
-const CENTER_Y = 42;
-// Kept a whole number: the terminator arc bakes it straight into the path's `A <r> <r>`
-// command, and a fractional radius makes those strings needlessly noisy to read and diff.
+const CENTER = DISC_SIZE / 2;
+// Sized so a centred disc still clears the phase caption overlaid on the bottom of the tile:
+// at 48 it ran under the text and the longest names read against the lit limb rather than
+// the black backdrop. Kept a whole number too — the terminator arc bakes it straight into
+// the path's `A <r> <r>` command, and a fractional radius makes those strings noisy to diff.
 const INDICATOR_RADIUS = 36;
 const DISC_COLOR = "#cccccc";
 const SHADOW_COLOR = "#1a1a2e";
@@ -36,8 +34,8 @@ export function renderMoonPhaseDisc(date: Date, hemisphere: Hemisphere): SVGSVGE
   // Background disc (dark)
   svg.appendChild(
     createSvgElement("circle", {
-      cx: CENTER_X,
-      cy: CENTER_Y,
+      cx: CENTER,
+      cy: CENTER,
       r: INDICATOR_RADIUS,
       fill: SHADOW_COLOR,
     })
@@ -50,8 +48,8 @@ export function renderMoonPhaseDisc(date: Date, hemisphere: Hemisphere): SVGSVGE
     // For waning (phase > 0.5 in north), left side lit.
     // Southern hemisphere mirrors the illumination side.
     const r = INDICATOR_RADIUS;
-    const top = CENTER_Y - r;
-    const bottom = CENTER_Y + r;
+    const top = CENTER - r;
+    const bottom = CENTER + r;
 
     // Terminator bulge: at illumination 0.5 the terminator is straight (rx=0),
     // below 0.5 it bulges toward shadow, above 0.5 it bulges toward light.
@@ -77,11 +75,11 @@ export function renderMoonPhaseDisc(date: Date, hemisphere: Hemisphere): SVGSVGE
     }
 
     const d = [
-      `M ${CENTER_X} ${top}`,
+      `M ${CENTER} ${top}`,
       // Semicircular arc on the lit side
-      `A ${r} ${r} 0 0 ${semiSweep} ${CENTER_X} ${bottom}`,
+      `A ${r} ${r} 0 0 ${semiSweep} ${CENTER} ${bottom}`,
       // Terminator arc back to top
-      `A ${rx} ${r} 0 0 ${terminatorSweep} ${CENTER_X} ${top}`,
+      `A ${rx} ${r} 0 0 ${terminatorSweep} ${CENTER} ${top}`,
       "Z",
     ].join(" ");
 

--- a/test/__snapshots__/snapshot.test.ts.snap
+++ b/test/__snapshots__/snapshot.test.ts.snap
@@ -129,6 +129,10 @@ exports[`cardStyles > matches snapshot 1`] = `
     position: relative;
     aspect-ratio: 1;
     padding: 0;
+    /* Buttons get border-box from the UA stylesheet, a plain <div> does not — without this
+       the moon tile's 1px border falls outside its 20% flex-basis and it renders 2px larger
+       than the Earth/Sun tiles beside it. */
+    box-sizing: border-box;
     border: 1px solid var(--divider-color, color-mix(in srgb, currentColor 15%, transparent));
     border-radius: 4px;
     background: transparent;
@@ -166,11 +170,6 @@ exports[`cardStyles > matches snapshot 1`] = `
     display: flex;
     justify-content: space-between;
     pointer-events: none;
-  }
-  /* Moon has no label span — the phase name gets the tile's full width, which the longest
-     of them ("Waxing Crescent") needs. */
-  .gallery-thumb-moon .gallery-info {
-    justify-content: center;
   }
   .gallery-label,
   .gallery-age {

--- a/test/__snapshots__/snapshot.test.ts.snap
+++ b/test/__snapshots__/snapshot.test.ts.snap
@@ -149,18 +149,25 @@ exports[`cardStyles > matches snapshot 1`] = `
     display: block;
   }
   /* Moon is drawn locally, not fetched — a <div> holding an <svg>, not an <img>, and with
-     no full-screen view to open it gets no pointer affordance. Black backdrop rather than
-     the transparent default, so the tile reads like the Earth/Sun photos beside it instead
-     of showing the card through it. */
+     no full-screen view to open it gets no pointer affordance. */
   .gallery-thumb-moon {
     cursor: default;
-    background: #000;
   }
+  /* The black backdrop belongs on the disc, not the tile. The tile border is a translucent
+     15% currentColor, so it composites against whatever sits behind it: transparent on the
+     fetched tiles, where it picks up the card and reads as a visible edge. Painting the tile
+     itself black made that border 15% white over black — invisible — so the moon's dark area
+     ran the full 104px while its neighbours' stopped at 102px inside their borders, and the
+     tile looked taller than tiles that measure exactly the same. Here the black fills the
+     content box instead, the same region the img occupies. */
   .moon-disc,
   .moon-disc svg {
     width: 100%;
     height: 100%;
     display: block;
+  }
+  .moon-disc {
+    background: #000;
   }
   .gallery-info {
     position: absolute;
@@ -169,16 +176,27 @@ exports[`cardStyles > matches snapshot 1`] = `
     right: 2px;
     display: flex;
     justify-content: space-between;
+    /* Bottom-align rather than stretch: a stretched span puts its line box at the top, so
+       any disagreement about the box's height moves the text instead of staying put. */
+    align-items: flex-end;
+    /* font-size and line-height are pinned on the container, not just the spans, because
+       the tiles are built from different elements — a <div> for the moon, a <button> for the
+       fetched sources — and a <button> takes its font from the UA stylesheet (13.333px)
+       while the <div> inherits the card's (16px). Left to inherit, the caption's height is
+       decided by the element type and the engine's default line-height, which is how the
+       moon's caption ended up sitting higher than its neighbours'.
+       Scales with the tile (see container-type above) instead of a fixed 8px, so the longest
+       phase name still fits on a narrow card and stays legible on a wide one. */
+    font-size: clamp(6px, 9cqw, 9px);
+    line-height: 1;
+    font-family: sans-serif;
     pointer-events: none;
   }
   .gallery-label,
   .gallery-age {
-    /* Scales with the tile (see container-type above) instead of a fixed 8px, so the longest
-       phase name still fits on a narrow card and stays legible on a wide one. */
-    font-size: clamp(6px, 9cqw, 9px);
+    font: inherit;
     color: #fff;
     text-shadow: 0 0 2px #000;
-    font-family: sans-serif;
     white-space: nowrap;
   }
   .nav {

--- a/test/card/card-template.test.ts
+++ b/test/card/card-template.test.ts
@@ -2,6 +2,7 @@ import { nothing, render } from "lit";
 import { describe, expect, it } from "vitest";
 import {
   buildImageStatusBar,
+  buildMoonTitle,
   buildStatusBar,
   buildStatusBarView,
   formatDate,
@@ -248,5 +249,27 @@ describe("buildStatusBarView", () => {
       )
     );
     expect(root.querySelector(".status-bar span").textContent).toBe("SUN · SDO HMI · loading…");
+  });
+});
+
+describe("buildMoonTitle", () => {
+  // 2024-01-25 is a Full Moon; 2024-01-11 a New Moon.
+  it("calls it tonight's moon while the view is live", () => {
+    expect(buildMoonTitle(new Date("2024-01-25T18:00:00Z"), true)).toMatch(
+      /^Tonight's Moon — Full Moon, \d{1,3}% illuminated$/
+    );
+  });
+
+  // "Tonight" stops being true the moment the date-nav buttons move the view, so the
+  // displayed date replaces it rather than the tooltip quietly lying.
+  it("names the displayed date once the view has been navigated away from now", () => {
+    const title = buildMoonTitle(new Date("2024-01-11T12:00:00Z"), false);
+    expect(title).not.toContain("Tonight");
+    expect(title).toMatch(/^Moon on 24-01-11 \d{2}:\d{2} — New Moon, \d{1,3}% illuminated$/);
+  });
+
+  it("reports illumination as a whole percentage", () => {
+    expect(buildMoonTitle(new Date("2024-01-25T18:00:00Z"), true)).toContain("100% illuminated");
+    expect(buildMoonTitle(new Date("2024-01-11T12:00:00Z"), false)).toContain("0% illuminated");
   });
 });

--- a/test/card/card.gallery.test.ts
+++ b/test/card/card.gallery.test.ts
@@ -63,6 +63,17 @@ describe("SolarViewCard gallery", () => {
       card.remove();
     });
 
+    it("gives the moon tile a tooltip, like the NASA tiles have", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2024-01-25T18:00:00Z")); // Full Moon
+      const card = createAndMount({ gallery: { mode: "open", sources: ["moon"] } });
+      expect(card.shadowRoot.querySelector('[data-source="moon"]').getAttribute("title")).toBe(
+        "Tonight's Moon — Full Moon, 100% illuminated"
+      );
+      card.remove();
+      vi.useRealTimers();
+    });
+
     it("the moon tile is not clickable — there is no full-screen moon", () => {
       const card = createAndMount({ gallery: { mode: "open", sources: ["moon"] } });
       const tile = card.shadowRoot.querySelector('[data-source="moon"]');
@@ -70,15 +81,30 @@ describe("SolarViewCard gallery", () => {
       card.remove();
     });
 
-    it("captions the moon tile with the phase name for the displayed date", () => {
+    it("captions the moon tile with MOON and the phase for the displayed date", () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date("2024-01-25T18:00:00Z")); // Full Moon
       const card = createAndMount({ gallery: { mode: "open", sources: ["moon"] } });
-      expect(card.shadowRoot.querySelector('[data-source="moon"]').textContent).toContain(
-        "Full Moon"
-      );
+      const info = card.shadowRoot.querySelector('[data-source="moon"] .gallery-info');
+      expect(info.querySelector(".gallery-label").textContent).toBe("MOON");
+      expect(info.querySelector(".gallery-age").textContent).toBe("Full Moon");
       card.remove();
       vi.useRealTimers();
+    });
+
+    // The caption is what makes the tiles read as one strip. Comparing the shapes rather
+    // than eyeballing each one means a future divergence fails here instead of shipping.
+    it("gives every tile the same caption structure", () => {
+      const card = createAndMount({
+        gallery: { mode: "open", sources: ["moon", "earth", "sun"] },
+      });
+      const shapes = [...card.shadowRoot.querySelectorAll(".gallery-info")].map((info) =>
+        [...info.children].map((el) => `${el.tagName}.${el.className}`)
+      );
+      expect(shapes).toHaveLength(3);
+      expect(new Set(shapes.map((s) => s.join(","))).size).toBe(1);
+      expect(shapes[0]).toEqual(["SPAN.gallery-label", "SPAN.gallery-age"]);
+      card.remove();
     });
 
     it("renders tiles in the configured sources order", () => {

--- a/test/renderer/moon-phase.test.ts
+++ b/test/renderer/moon-phase.test.ts
@@ -10,30 +10,40 @@ describe("renderMoonPhaseDisc", () => {
     expect(svg.parentNode).toBeNull();
   });
 
-  it("centres the disc horizontally with no overflow", () => {
+  it("centres the disc in the tile, equal margin on all four sides", () => {
     const svg = renderMoonPhaseDisc(new Date("2024-01-15"), "north");
 
     const disc = svg.querySelector("circle");
     const cx = Number(disc.getAttribute("cx"));
+    const cy = Number(disc.getAttribute("cy"));
     const r = Number(disc.getAttribute("r"));
-    expect(cx).toBe(50);
-    expect(cx - r).toBeGreaterThanOrEqual(0);
-    expect(cx + r).toBeLessThanOrEqual(100);
+    expect([cx, cy]).toEqual([50, 50]);
+    // left, right, top and bottom margins all equal — no overflow, no drift.
+    expect([cx - r, 100 - (cx + r), cy - r, 100 - (cy + r)]).toEqual([
+      50 - r,
+      50 - r,
+      50 - r,
+      50 - r,
+    ]);
+    expect(cx - r).toBeGreaterThan(0);
   });
 
-  // The phase caption is HTML overlaid on the bottom of the tile. The disc has to sit clear
-  // of it, or the longest names read against the lit limb instead of the black backdrop.
-  it("keeps the disc out of the bottom caption band", () => {
+  // The phase caption is HTML overlaid on the bottom of the tile, measured in Chromium as
+  // starting 86.8 units down (72.19px of an 83.19px tile). A centred disc only clears that
+  // because it is small enough; grow the radius and the longest names start reading against
+  // the lit limb instead of the black backdrop.
+  it("keeps the disc clear of the bottom caption band", () => {
+    const CAPTION_TOP = 86.8;
     const svg = renderMoonPhaseDisc(new Date("2024-01-25T18:00:00Z"), "north"); // Full Moon
     const disc = svg.querySelector("circle");
     const cy = Number(disc.getAttribute("cy"));
     const r = Number(disc.getAttribute("r"));
 
-    expect(cy + r).toBeLessThanOrEqual(82);
+    expect(cy + r).toBeLessThanOrEqual(CAPTION_TOP);
     // ...and the lit path, which at Full Moon spans the disc's full height.
     const d = svg.querySelector("path").getAttribute("d");
     const ys = [...d.matchAll(/[ ,](-?\d+(?:\.\d+)?)(?=[ ]|$)/g)].map((m) => Number(m[1]));
-    expect(Math.max(...ys)).toBeLessThanOrEqual(82);
+    expect(Math.max(...ys)).toBeLessThanOrEqual(CAPTION_TOP);
   });
 
   it("still fills most of the tile above the caption", () => {


### PR DESCRIPTION
Follow-up to #143, from repeated side-by-side comparison against a real dashboard screenshot.

The moon tile is a `<div>` (it is drawn locally and has no full-screen view to open), while the fetched tiles are `<button>`. Every defect below traces back to that difference, or to a CSS value that depended on it.

## 1. The tile rendered 2px larger

`.gallery-thumb` set a `border` but never `box-sizing`. UA stylesheets give `<button>` `border-box`; a plain `<div>` gets the initial `content-box`. With `flex: 0 0 20%` the buttons' 20% *included* their border while the div's did not, and `aspect-ratio: 1` carried it into the vertical too.

Measured in Chromium: `85.19` vs `83.19`. Now `83.19` across the board.

## 2. The caption had no label and sat off-baseline

The moon branch spelled its own caption out and had drifted: no `.gallery-label`, plus a moon-only `justify-content: center`. Both branches now build it through one shared `buildGalleryCaption()`, which is what stops them diverging again, and the override is gone.

A test asserts all three captions share an identical child shape, so a future divergence fails in CI rather than on a dashboard.

## 3. The tile *looked* taller even after (1)

This one is not a layout bug — the boxes measure identical. `--divider-color` is `color-mix(in srgb, currentColor 15%, transparent)`, i.e. **translucent**, so it composites against the element's own background. The `background: #000` added for contrast turned the border into 15% white over black — indistinguishable from the fill. The moon's dark area therefore ran the full 104px while its neighbours' stopped at 102px inside their visible borders.

Only reproducible in a **light** theme; in dark theme every border is low-contrast and the difference disappears.

Fixed by moving the black onto `.moon-disc`, so it fills the content box — the same region an `<img>` occupies — leaving the border something to show against.

## 4. The caption sat 3px high

`.gallery-info` inherited `font-size` from the tile: `13.333px` from the UA stylesheet on `<button>`, `16px` from the card on the `<div>`. With no `line-height` set either, box height fell out of the engine's default, and a taller box with top-aligned content pushes text up.

`font-size`, `line-height: 1`, `font-family` and `align-items: flex-end` are now pinned on the container; the spans take `font: inherit`. Caption geometry no longer depends on what the tile is made of.

## Also

- Moon gains a tooltip, since the fetched tiles have one. `"Show <source>"` would be a lie for a tile that opens nothing, so it reports phase and illumination — the one fact the caption has no room for. It says "tonight" only in live mode, because the date-nav buttons can put the disc on any date.
- The disc is scaled to 0.95 and centred, giving an equal `12.37px` on all four sides.

## Verification

jsdom performs no layout, so none of 1/3/4 is unit-testable — `getBoundingClientRect` returns zeros there. Verified by driving real headless Chromium against a built bundle, with real bitmaps loaded, in both themes, sampling pixels rather than eyeballing.

Final, light theme: dark/image region `369..449` on all three tiles; caption box `7.31px` on all three; borders visible on all three.

823 tests, 100% coverage, `check:ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)