### PR TITLE
feat: replace the drawn moon tile with NASA imagery

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 [![Planetary Solar System Card][demo-gif]](https://marcintk.github.io/ha-planetary-solar-system-card/)
 
 Home Assistant custom Lovelace card showing all 8 planets, Moon and comet Halley aligned around the
-Sun, with live NASA imagery of Earth and the Sun. Navigate time, zoom, and pan interactively.
+Sun, with live NASA imagery of the Moon, Earth and the Sun — including the Moon turned to match your
+own sky. Navigate time, zoom, and pan interactively.
 
 [![Try the interactive demo](https://img.shields.io/badge/▶%20Try%20the%20interactive%20demo-41BDF5?style=for-the-badge)](https://marcintk.github.io/ha-planetary-solar-system-card/)
 
@@ -51,8 +52,16 @@ colors:
 type: custom:ha-planetary-solar-system-card
 gallery:
   mode: slide
-  sources: [moon, earth, sun]
+  sources: [mymoon, moon, earth, sun]
   slide_interval_secs: 30
+```
+
+```yaml
+type: custom:ha-planetary-solar-system-card
+gallery:
+  mode: open
+  position: below
+  sources: [mymoon, earth]
 ```
 
 ```yaml
@@ -106,25 +115,48 @@ A thumbnail strip beside the solar view. ☷ toggles it; clicking a NASA thumbna
 full-screen. Which tiles appear — and in what left-to-right order — is `gallery.sources` (see
 [Gallery](#gallery)).
 
-| Thumbnail | Source            | Watches                      | We poll  | Typical age |
-| --------- | ----------------- | ---------------------------- | -------- | ----------- |
-| Moon      | Drawn locally     | Tonight's moon phase         | No fetch | Live        |
-| DSCOVR/E  | [NASA EPIC][epic] | Earth's sunlit side, from L1 | Hourly   | 1-2 days    |
-| SDO/S     | [NASA SDO][sdo]   | The Sun, from geosync orbit  | 15 min   | 20-55 min   |
+| Thumbnail | Source            | Shows                                   | We fetch   | Age of what you see |
+| --------- | ----------------- | --------------------------------------- | ---------- | ------------------- |
+| MY SKY    | [NASA SVS][svs]   | The Moon at 22:00 your time, your sky   | Once a day | Tonight, not yet    |
+| MOON      | [NASA SVS][svs]   | The Moon this hour, from Earth's centre | Hourly     | Under an hour       |
+| DSCOVR/E  | [NASA EPIC][epic] | Earth's sunlit side, from L1            | Hourly     | 1-2 days            |
+| SDO/S     | [NASA SDO][sdo]   | The Sun, from geosync orbit             | 15 min     | 25-55 min           |
+| DRAWN     | Drawn locally     | The phase, computed on your dashboard   | No fetch   | Live                |
 
-The moon tile is computed on your dashboard from the displayed date, so it costs no network request
-and cannot fail — which is why it is the only source shown by default. The NASA sources are opt-in.
-The moon tile has no full-screen view; its caption is the phase name.
+### The two Moon tiles
 
-Both lags are NASA's publish pipeline, not the card holding images back: EPIC processes a day or two
-behind, and SDO's archive often posts a 15-min frame 30+ minutes late, so the card falls back one
-frame.
+One body, two questions, so two tiles.
+
+**MOON** is NASA's frame exactly as published: rendered from the centre of the Earth with celestial
+north up, the way every Moon photograph you have ever seen is framed. It is never wrong and it looks
+the same for everyone.
+
+**MY SKY** is the same frame turned to match _your_ sky — rotated by the parallactic angle for your
+latitude, longitude and clock, for 22:00 local tonight. That rotation is the single biggest
+difference between a picture of the Moon and the Moon you will actually see: it swings through
+roughly ±90° depending on where you stand and when you look. Its caption counts down to 22:00, and
+says `below horizon` on the nights the Moon is not up then — which is about half of them, at every
+latitude, because the Moon keeps its own hours rather than the Sun's.
+
+Both are renders, not photographs: NASA builds them from LOLA laser altimetry and the LROC
+wide-angle colour mosaic, positioned by the JPL DE421 ephemeris, and publishes the whole year in
+advance at one frame per hour. So unlike Earth and Sun there is no publish delay to wait out.
+
+Because the product is published a year at a time under an id that changes each December, both Moon
+tiles go blank on 1 January of a year the installed version does not know about, until a release
+ships with it. **DRAWN** is the tile that cannot: computed on your dashboard, no network request, no
+way to fail — but a diagram rather than a picture, which is why it is opt-in rather than shown by
+default.
+
+Earth's and Sun's lags are NASA's publish pipeline, not the card holding images back: EPIC processes
+a day or two behind, and SDO's archive often posts a 15-min frame 30+ minutes late, so the card
+falls back one frame.
 
 > **Thumbnails stuck on "unavailable"?** The browser fetches these images straight from NASA, so a
 > reverse proxy in front of Home Assistant (Nginx Proxy Manager, Cloudflare Tunnel, Traefik) can
-> block them with a strict `Content-Security-Policy`. Add `epic.gsfc.nasa.gov` and
-> `sdo.gsfc.nasa.gov` to that policy's `img-src`. Nothing card-side can work around it — the block
-> happens before the card sees a response.
+> block them with a strict `Content-Security-Policy`. Add `svs.gsfc.nasa.gov`, `epic.gsfc.nasa.gov`
+> and `sdo.gsfc.nasa.gov` to that policy's `img-src`. Nothing card-side can work around it — the
+> block happens before the card sees a response.
 
 ## Configuration
 
@@ -179,23 +211,62 @@ the cycle resumes. Replay and the gallery don't pause it.
 
 `gallery` (object, unset by default) — Live Imagery gallery options:
 
-| Key                           | Type     | Default    | Description                                                                                                          |
-| ----------------------------- | -------- | ---------- | -------------------------------------------------------------------------------------------------------------------- |
-| `gallery.mode`                | string   | `"closed"` | `"closed"` starts the strip collapsed, `"open"` shows it, `"slide"` shows one tile at a time and rotates             |
-| `gallery.sources`             | string[] | `["moon"]` | Which tiles to show, in left-to-right order. Any of `moon`, `earth`, `sun`. Unknown names and duplicates are dropped |
-| `gallery.slide_interval_secs` | number   | `60`       | How often `slide` mode advances to the next source                                                                   |
+| Key                           | Type     | Default        | Description                                                                                                     |
+| ----------------------------- | -------- | -------------- | --------------------------------------------------------------------------------------------------------------- |
+| `gallery.mode`                | string   | `"off"`        | `"off"` starts the strip collapsed, `"open"` shows it, `"slide"` shows one tile at a time and rotates           |
+| `gallery.sources`             | string[] | the four below | Which tiles to show, in left-to-right order. Unknown names and duplicates are dropped                           |
+| `gallery.position`            | string   | `"overlay"`    | `"overlay"` floats the strip over the solar view, `"below"` puts it underneath and grows the card by its height |
+| `gallery.shape`               | string   | `"square"`     | `"square"` shows the frame as its source publishes it, `"circle"` crops each tile to the body itself            |
+| `gallery.slide_interval_secs` | number   | `60`           | How often `slide` mode advances to the next source                                                              |
 
-The ☷ button is always available; `mode` only decides whether the strip starts open. Only `earth`
-and `sun` hit the network, so the default gallery makes no requests at all.
+Source names:
+
+| Name        | Tile     | Fetches |
+| ----------- | -------- | ------- |
+| `mymoon`    | MY SKY   | Yes     |
+| `moon`      | MOON     | Yes     |
+| `earth`     | DSCOVR/E | Yes     |
+| `sun`       | SDO/S    | Yes     |
+| `drawnmoon` | DRAWN    | No      |
+
+Omit `sources` and you get the four fetched tiles in that order. `drawnmoon` is opt-in — it is a
+diagram, and it does not belong in a strip of photographs unless you ask for it.
+
+The ☷ button is always available; `mode` only decides whether the strip starts open.
 
 ```yaml
 gallery:
   mode: open
-  sources: [moon, earth, sun]
+  position: below
+  shape: circle
+  sources: [mymoon, earth, sun]
 ```
 
-Configs written before `sources` existed keep working: `mode: none` stays collapsed on moon,
-`earth`/`sun`/`both` open on those sources, and `slide` rotates earth and sun as before.
+`shape: circle` crops away each frame's black margin so the bodies float on the card, all at the
+same size. It is not purely cosmetic: the default `square` keeps the margin, and because each source
+frames its subject differently — Earth fills about three quarters of its frame, the Moon and Sun
+closer to all of it — the bodies then render at visibly different sizes.
+
+MY SKY takes a slightly different route to the same look, because a rotated square is not a square —
+the tile clips the corners that swing outside it while the card shows through where the image's own
+corners swing in, so a rotated frame renders as an octagon at every angle except 0° and 90°. Instead
+of its own frame it gets a black backdrop from the tile, with the body clipped to a circle inside
+it. Every source renders its body on black, so the result is framed exactly like its neighbours,
+with a turned Moon inside.
+
+Older configs keep working. `mode: none` and `mode: closed` both mean `off`; `earth`, `sun` and
+`both` open the strip; `slide` is unchanged. Source names are unchanged too — the one shift is that
+`moon` now resolves to NASA's render rather than the locally drawn disc, which is `drawnmoon`.
+
+#### Adding a source later
+
+Source names describe **what the tile shows**, not which instrument produced it. When one body gains
+a second source, name the difference: the two Moon tiles are `moon` and `mymoon` — viewpoint, not
+instrument — and a SOHO coronagraph beside SDO would be `corona`, because that is what it shows.
+
+Only if nothing else distinguishes two sources does the instrument earn a place in the name, and
+even then the incumbent keeps its name and the newcomer takes the qualified one (`earth` stays,
+`goes-earth` joins it). Nobody's dashboard should have to be edited because the card grew a tile.
 
 ### Location
 
@@ -215,6 +286,7 @@ Configs written before `sources` existed keep working: `mode: none` stays collap
 [my-hacs-shield]: https://my.home-assistant.io/badges/hacs_repository.svg
 [epic]: https://epic.gsfc.nasa.gov/
 [sdo]: https://sdo.gsfc.nasa.gov/
+[svs]: https://svs.gsfc.nasa.gov/5587/
 [repo]: https://github.com/marcintk/ha-planetary-solar-system-card
 [license]: https://github.com/marcintk/ha-planetary-solar-system-card/blob/main/LICENSE
 [iana]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones

--- a/src/astronomy/moon-position.ts
+++ b/src/astronomy/moon-position.ts
@@ -1,0 +1,125 @@
+/**
+ * The Moon's equatorial coordinates *of date* (Meeus, *Astronomical Algorithms*, ch. 47),
+ * plus Greenwich mean sidereal time.
+ *
+ * Separate from moon-phase.ts on purpose. That module answers "how lit is it", which the
+ * three largest periodic terms settle to well inside a phase-name segment. This one answers
+ * "where is it on the sky", which feeds a parallactic angle — and there the same three terms
+ * leave up to 6.07° of orientation error, against 0.62° for the series below. The phase
+ * module keeps its cheaper approximation; nothing here replaces it.
+ *
+ * Coordinates are *of date*, not J2000. A local hour angle is measured against the true
+ * equinox of the moment, so precessing back to J2000 would introduce the ~0.4° error it
+ * looks like it removes. (NASA's Dial-a-Moon reports J2000, which is why the two differ by
+ * that much; de-precessed, this series agrees with it to 0.034° in right ascension.)
+ */
+
+const DEG = Math.PI / 180;
+const sin = (degrees: number) => Math.sin(degrees * DEG);
+const cos = (degrees: number) => Math.cos(degrees * DEG);
+const tan = (degrees: number) => Math.tan(degrees * DEG);
+const norm360 = (degrees: number) => ((degrees % 360) + 360) % 360;
+
+export interface MoonEquatorial {
+  /** Right ascension of date, degrees in [0, 360). */
+  raDeg: number;
+  /** Declination of date, degrees in [-90, 90]. */
+  decDeg: number;
+}
+
+// Meeus 47.A / 47.B, leading terms: [D, M, M', F, coefficient in 1e-6 degrees]. Truncated
+// where the remaining rows stop moving the result by more than a few arc-seconds — far below
+// the sub-pixel budget a 104 px thumbnail works to. The eccentricity factor E that scales the
+// M-dependent rows is omitted for the same reason (it shifts them by ~0.2%).
+type Term = readonly [number, number, number, number, number];
+
+const LONGITUDE_TERMS: readonly Term[] = [
+  [0, 0, 1, 0, 6288774],
+  [2, 0, -1, 0, 1274027],
+  [2, 0, 0, 0, 658314],
+  [0, 0, 2, 0, 213618],
+  [0, 1, 0, 0, -185116],
+  [0, 0, 0, 2, -114332],
+  [2, 0, -2, 0, 58793],
+  [2, -1, -1, 0, 57066],
+  [2, 0, 1, 0, 53322],
+  [2, -1, 0, 0, 45758],
+  [0, 1, -1, 0, -40923],
+  [1, 0, 0, 0, -34720],
+  [0, 1, 1, 0, -30383],
+  [2, 0, 0, -2, 15327],
+  [0, 0, 1, 2, -12528],
+  [0, 0, 1, -2, 10980],
+  [4, 0, -1, 0, 10675],
+  [0, 0, 3, 0, 10034],
+  [4, 0, -2, 0, 8548],
+];
+
+const LATITUDE_TERMS: readonly Term[] = [
+  [0, 0, 0, 1, 5128122],
+  [0, 0, 1, 1, 280602],
+  [0, 0, 1, -1, 277693],
+  [2, 0, 0, -1, 173237],
+  [2, 0, -1, 1, 55413],
+  [2, 0, -1, -1, 46271],
+  [2, 0, 0, 1, 32573],
+  [0, 0, 2, 1, 17198],
+  [2, 0, 1, -1, 9266],
+  [0, 0, 2, -1, 8822],
+  [2, -1, 0, -1, 8216],
+];
+
+function daysSinceJ2000(date: Date): number {
+  // 2440587.5 converts a Unix epoch day count to a Julian Day; 2451545 is JD at J2000.0.
+  return date.getTime() / 86400000 + 2440587.5 - 2451545;
+}
+
+/**
+ * Greenwich mean sidereal time in degrees — the angle Earth's rotation has carried the prime
+ * meridian past the equinox. Subtracting a body's right ascension from it (plus the
+ * observer's longitude) gives the local hour angle every horizon calculation is built on.
+ */
+export function greenwichSiderealDeg(date: Date): number {
+  return norm360(280.46061837 + 360.98564736629 * daysSinceJ2000(date));
+}
+
+export function getMoonEquatorial(date: Date): MoonEquatorial {
+  const d = daysSinceJ2000(date);
+  const T = d / 36525;
+
+  // Mean arguments (Meeus 47.1–47.5)
+  const meanLongitude = 218.3164477 + 481267.88123421 * T;
+  const elongation = 297.8501921 + 445267.1114034 * T;
+  const sunAnomaly = 357.5291092 + 35999.0502909 * T;
+  const moonAnomaly = 134.9633964 + 477198.8675055 * T;
+  const argumentOfLatitude = 93.272095 + 483202.0175233 * T;
+
+  const sumTerms = (terms: readonly Term[]) =>
+    terms.reduce(
+      (total, [dD, dM, dMp, dF, coefficient]) =>
+        total +
+        coefficient *
+          1e-6 *
+          sin(dD * elongation + dM * sunAnomaly + dMp * moonAnomaly + dF * argumentOfLatitude),
+      0
+    );
+
+  const eclipticLon = meanLongitude + sumTerms(LONGITUDE_TERMS);
+  const eclipticLat = sumTerms(LATITUDE_TERMS);
+  // Mean obliquity, linear term only — it drifts 0.013° per century, so higher orders cannot
+  // reach the sub-pixel budget within any date this card will be asked about.
+  const obliquity = 23.4393 - 3.563e-7 * d;
+
+  return {
+    raDeg: norm360(
+      Math.atan2(
+        sin(eclipticLon) * cos(obliquity) - tan(eclipticLat) * sin(obliquity),
+        cos(eclipticLon)
+      ) / DEG
+    ),
+    decDeg:
+      Math.asin(
+        sin(eclipticLat) * cos(obliquity) + cos(eclipticLat) * sin(obliquity) * sin(eclipticLon)
+      ) / DEG,
+  };
+}

--- a/src/astronomy/parallactic.ts
+++ b/src/astronomy/parallactic.ts
@@ -1,0 +1,56 @@
+/**
+ * How the Moon hangs in one observer's sky.
+ *
+ * NASA renders the Moon from the centre of the Earth with celestial north up. That frame is
+ * within ~1° of correct for everyone alive — the Moon is 384,400 km away and Earth's radius
+ * is only 6,378 km — but it says nothing about *which way up* the Moon appears, and that
+ * varies by up to ±90° with latitude, longitude and the hour.
+ *
+ * The parallactic angle is the missing rotation: the angle at the Moon between the direction
+ * to the celestial pole (which the render puts at the top) and the direction to the
+ * observer's zenith (which is up when you actually look). Rotating the frame clockwise by it
+ * turns a geocentric portrait into the observer's own view.
+ *
+ * This replaces the hemisphere flip outright rather than refining it. A southern observer's
+ * angle simply lands near 180° from a northern one's at the same instant, so no latitude
+ * branch is needed anywhere — and the equator, where a sign test on latitude swings the
+ * rendering by 180° over a fifth of a degree of travel, stops being a special case.
+ */
+
+import { getMoonEquatorial, greenwichSiderealDeg } from "./moon-position.js";
+
+const DEG = Math.PI / 180;
+const sin = (degrees: number) => Math.sin(degrees * DEG);
+const cos = (degrees: number) => Math.cos(degrees * DEG);
+const tan = (degrees: number) => Math.tan(degrees * DEG);
+
+export interface MoonSkyAngles {
+  /**
+   * Parallactic angle in degrees, (-180, 180]. Rotate a celestial-north-up frame clockwise
+   * by this to match the observer's sky.
+   */
+  parallacticDeg: number;
+  /**
+   * The Moon's altitude above the observer's horizon, degrees. Negative means it is not in
+   * their sky at all — which happens on roughly half of any given hour's worth of nights,
+   * at every latitude, because the Moon keeps its own hours rather than the Sun's.
+   */
+  altitudeDeg: number;
+}
+
+/**
+ * Both angles come out of one hour-angle calculation, so they are returned together rather
+ * than recomputed by two callers — the caption needs the altitude for exactly the moments
+ * the rotation describes.
+ */
+export function getMoonSkyAngles(date: Date, latDeg: number, lonDeg: number): MoonSkyAngles {
+  const { raDeg, decDeg } = getMoonEquatorial(date);
+  const hourAngle = greenwichSiderealDeg(date) + lonDeg - raDeg;
+
+  return {
+    parallacticDeg:
+      Math.atan2(sin(hourAngle), tan(latDeg) * cos(decDeg) - sin(decDeg) * cos(hourAngle)) / DEG,
+    altitudeDeg:
+      Math.asin(sin(latDeg) * sin(decDeg) + cos(latDeg) * cos(decDeg) * cos(hourAngle)) / DEG,
+  };
+}

--- a/src/astronomy/solar-position.ts
+++ b/src/astronomy/solar-position.ts
@@ -28,6 +28,71 @@ export function getLocalTimeInZone(
   }
 }
 
+/**
+ * How far a zone's wall clock runs ahead of UTC at one instant, in milliseconds.
+ *
+ * Reads the instant back through `Intl` and re-assembles the parts as if they were UTC — the
+ * gap between that and the real instant *is* the offset. No timezone database ships in the
+ * bundle, and none needs to: Intl already carries the whole thing.
+ */
+function zoneOffsetMs(date: Date, timezone: string): number {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  }).formatToParts(date);
+  const value = (type: string) => Number(parts.find((p) => p.type === type)?.value);
+  const hours = value("hour");
+  return (
+    Date.UTC(
+      value("year"),
+      value("month") - 1,
+      value("day"),
+      hours === 24 ? 0 : hours, // some engines return 24 for midnight
+      value("minute"),
+      value("second")
+    ) - date.getTime()
+  );
+}
+
+/**
+ * The instant at which a zone's wall clock reads `hour:00` on the local calendar day that
+ * `date` falls in. The inverse of getLocalTimeInZone, which reads a local hour *out* of an
+ * instant.
+ *
+ * Everything a "tonight at 22:00" reference needs falls out of this one function: before the
+ * hour it is in the future, between the hour and local midnight it is in the recent past, and
+ * at local midnight the calendar day advances and it becomes tomorrow's. No hold window or
+ * rollover rule has to be written separately.
+ *
+ * Two offset passes, not one. The zone offset in force when we ask is not always the offset
+ * in force at the hour we are asking about — on a DST transition day they differ, and a
+ * single pass lands an hour out.
+ */
+export function getLocalHourInstant(date: Date, timezone: string, hour: number): Date {
+  try {
+    const offsetNow = zoneOffsetMs(date, timezone);
+    const localNow = new Date(date.getTime() + offsetNow);
+    const wallClock = Date.UTC(
+      localNow.getUTCFullYear(),
+      localNow.getUTCMonth(),
+      localNow.getUTCDate(),
+      hour
+    );
+    const offsetThen = zoneOffsetMs(new Date(wallClock - offsetNow), timezone);
+    return new Date(wallClock - offsetThen);
+  } catch {
+    const utc = new Date(date);
+    utc.setUTCHours(hour, 0, 0, 0);
+    return utc;
+  }
+}
+
 const OBLIQUITY_DEG = 23.45;
 const OBLIQUITY_RAD = (OBLIQUITY_DEG * Math.PI) / 180;
 

--- a/src/card/card-config.ts
+++ b/src/card/card-config.ts
@@ -2,7 +2,7 @@ import type { CardConfig, Colors, ZoomLevel } from "../types.js";
 import type { GallerySource } from "./card-template.js";
 import { GALLERY_SOURCES } from "./card-template.js";
 import { DEFAULT_ZOOM_LEVEL, MAX_ZOOM, MIN_ZOOM } from "./card-view-state.js";
-import type { GalleryMode } from "./gallery/gallery-controller.js";
+import type { GalleryMode, GalleryPosition, GalleryShape } from "./gallery/gallery-controller.js";
 import {
   DEFAULT_GALLERY_INTERVAL_MS,
   DEFAULT_GALLERY_SOURCES,
@@ -22,6 +22,8 @@ export interface ParsedCardConfig {
   locationNameOverride: string | null;
   heightStyle: string;
   galleryMode: GalleryMode;
+  galleryPosition: GalleryPosition;
+  galleryShape: GalleryShape;
   gallerySources: GallerySource[];
   galleryIntervalMs: number;
 }
@@ -75,43 +77,31 @@ function resolveOverrideTimezone(timezone: string | undefined, lon: number): str
 // Pure validate/default pass over CardConfig — the single place each field's fallback and
 // range-check rule lives. card.ts's setConfig hands the result straight to _zoom.configure()/
 // _gallery.configure() and its own remaining fields, instead of parsing inline.
-// Pre-#140 `gallery.mode` was a single string conflating presentation ("is the strip open")
-// with source selection ("which thumbnails"), which needed one union member per combination.
-// Each legacy value maps to the equivalent {mode, sources} pair so existing dashboards keep
-// showing exactly what they showed before — without this they'd fail the GALLERY_MODES check
-// and silently drop to the default, which now also means gaining a moon thumbnail they never
-// asked for.
-const LEGACY_GALLERY_MODES: Record<string, { mode: GalleryMode; sources: GallerySource[] }> = {
-  none: { mode: "closed", sources: ["moon"] },
-  earth: { mode: "open", sources: ["earth"] },
-  sun: { mode: "open", sources: ["sun"] },
-  both: { mode: "open", sources: ["earth", "sun"] },
-  slide: { mode: "slide", sources: ["earth", "sun"] },
-};
 
 // Unknown names are dropped rather than rejecting the whole list, and duplicates collapse to
 // their first position — a typo costs the user that one thumbnail, not their entire gallery.
 // Order is preserved because it *is* the layout: sources[0] renders leftmost.
 function resolveSources(raw: unknown): GallerySource[] | null {
   if (!Array.isArray(raw)) return null;
-  const kept = [...new Set(raw)].filter((s): s is GallerySource =>
-    GALLERY_SOURCES.includes(s as GallerySource)
-  );
+  const kept = [...new Set(raw as GallerySource[])].filter((s) => GALLERY_SOURCES.includes(s));
   return kept.length ? kept : null;
 }
 
-function resolveGallery(gallery: CardConfig["gallery"]): {
-  mode: GalleryMode;
-  sources: GallerySource[];
-} {
-  const legacy = LEGACY_GALLERY_MODES[gallery?.mode as string];
-  const mode = GALLERY_MODES.includes(gallery?.mode as GalleryMode)
-    ? (gallery?.mode as GalleryMode)
-    : (legacy?.mode ?? "closed");
-  // An explicit list always wins: a user who wrote `sources` means it, even alongside a
-  // legacy mode string they haven't migrated yet.
-  const sources = resolveSources(gallery?.sources) ?? legacy?.sources ?? DEFAULT_GALLERY_SOURCES;
-  return { mode, sources };
+// Two generations of `gallery.mode` values map onto the current three. The pre-#140 names
+// picked sources as well as presentation ("earth", "both"); source selection is gone, so all
+// of them collapse to whether the strip is open. "closed" is #140's own spelling of "off".
+const LEGACY_GALLERY_MODES: Record<string, GalleryMode> = {
+  none: "off",
+  closed: "off",
+  earth: "open",
+  sun: "open",
+  both: "open",
+};
+
+function resolveGalleryMode(gallery: CardConfig["gallery"]): GalleryMode {
+  const raw = gallery?.mode as string;
+  if (GALLERY_MODES.includes(raw as GalleryMode)) return raw as GalleryMode;
+  return LEGACY_GALLERY_MODES[raw] ?? "off";
 }
 
 export function parseCardConfig(config: CardConfig): ParsedCardConfig {
@@ -152,7 +142,11 @@ export function parseCardConfig(config: CardConfig): ParsedCardConfig {
 
   const heightStyle = resolveHeightStyle(config.height);
 
-  const { mode: galleryMode, sources: gallerySources } = resolveGallery(config.gallery);
+  const galleryMode = resolveGalleryMode(config.gallery);
+  const galleryPosition: GalleryPosition =
+    config.gallery?.position === "below" ? "below" : "overlay";
+  const galleryShape: GalleryShape = config.gallery?.shape === "circle" ? "circle" : "square";
+  const gallerySources = resolveSources(config.gallery?.sources) ?? DEFAULT_GALLERY_SOURCES;
   const rawInterval = Number(config.gallery?.slide_interval_secs);
   const galleryIntervalMs =
     Number.isFinite(rawInterval) && rawInterval >= 0.1
@@ -172,6 +166,8 @@ export function parseCardConfig(config: CardConfig): ParsedCardConfig {
     locationNameOverride,
     heightStyle,
     galleryMode,
+    galleryPosition,
+    galleryShape,
     gallerySources,
     galleryIntervalMs,
   };

--- a/src/card/card-styles.ts
+++ b/src/card/card-styles.ts
@@ -90,11 +90,15 @@ export const cardStyles = css`
   .image-view.visible {
     display: block;
   }
+  /* The full-screen sky view rotates its frame into the observer's orientation, and a rotated
+     square sweeps its corners outside its own box — at thumbnail size they are black on black,
+     but here they ride up over the status bar. Clipping to the inscribed circle fixes it: the
+     disc never reaches the edge, and a circle is rotation-invariant, so nothing can escape at
+     any angle. Thumbnails get the tighter, per-source crop from discStyle() instead. */
+  .sky-rotated {
+    clip-path: circle(50%);
+  }
   .gallery {
-    position: absolute;
-    left: 0;
-    right: 0;
-    bottom: 0;
     display: flex;
     align-items: flex-end;
     justify-content: flex-end;
@@ -102,8 +106,24 @@ export const cardStyles = css`
     padding: 2px;
     box-sizing: border-box;
   }
+  /* Floats over the bottom of the solar view: costs no card height, covers the outer orbits. */
+  .gallery-overlay {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+  }
+  /* A plain flex item of .solar-view-wrapper instead, so the card grows by the strip's own
+     height and nothing is hidden behind it. Only flex-shrink needs stating — everything else
+     is already the default now that .gallery itself no longer positions. */
+  .gallery-below {
+    flex-shrink: 0;
+  }
   .gallery-thumb {
-    flex: 0 0 20%;
+    /* Shares the row rather than claiming a fixed 20%: four tiles ship, and debug:true adds a
+       fifth, which at a fixed basis overflows once gaps and padding are counted. */
+    flex: 1 1 0;
+    max-width: 20%;
     position: relative;
     aspect-ratio: 1;
     padding: 0;
@@ -111,8 +131,9 @@ export const cardStyles = css`
        the moon tile's 1px border falls outside its 20% flex-basis and it renders 2px larger
        than the Earth/Sun tiles beside it. */
     box-sizing: border-box;
-    border: 1px solid var(--divider-color, color-mix(in srgb, currentColor 15%, transparent));
-    border-radius: 4px;
+    /* Explicit, not omitted: .gallery-thumb is a <button> on the fetched tiles, and dropping
+       the rule entirely hands it back the UA stylesheet's 2px outset ButtonBorder. */
+    border: 0;
     background: transparent;
     overflow: hidden;
     cursor: pointer;
@@ -126,18 +147,28 @@ export const cardStyles = css`
     object-fit: cover;
     display: block;
   }
-  /* Moon is drawn locally, not fetched — a <div> holding an <svg>, not an <img>, and with
-     no full-screen view to open it gets no pointer affordance. */
+  /* Square shape, rotating tile: the image has to be clipped to a circle or the rotation turns
+     its frame into an octagon, so the black square its neighbours get from their own frame has
+     to come from the tile instead. Sources render their body on pure black, and in square mode
+     the image is unscaled — so the clip lands at the tile edge, outside the body, and the body
+     ends up exactly the size it is on the tiles either side of it. */
+  .gallery-thumb-boxed {
+    background: #000;
+  }
+  /* The drawn disc is the one tile that is still a square plate, so it is the one tile that
+     still wants a frame. The fetched tiles are clipped to the body itself (see discStyle) and
+     a rounded-rectangle outline around a floating disc reads as a leftover box — but the
+     border cannot simply follow the clip, because .gallery-thumb also carries the caption
+     across its full width, and overflow:hidden would crop the ends off a circular one. */
   .gallery-thumb-moon {
     cursor: default;
+    border: 1px solid var(--divider-color, color-mix(in srgb, currentColor 15%, transparent));
+    border-radius: 4px;
   }
-  /* The black backdrop belongs on the disc, not the tile. The tile border is a translucent
-     15% currentColor, so it composites against whatever sits behind it: transparent on the
-     fetched tiles, where it picks up the card and reads as a visible edge. Painting the tile
-     itself black made that border 15% white over black — invisible — so the moon's dark area
-     ran the full 104px while its neighbours' stopped at 102px inside their borders, and the
-     tile looked taller than tiles that measure exactly the same. Here the black fills the
-     content box instead, the same region the img occupies. */
+  /* The black backdrop belongs on the disc, not the tile: painting .gallery-thumb-moon itself
+     black would put its 15%-currentColor border over black, where it disappears, and the
+     drawn moon would then run the full 104px while its neighbours stopped inside their own
+     edge. Filling the content box instead keeps it to the region the img occupies. */
   .moon-disc,
   .moon-disc svg {
     width: 100%;
@@ -149,14 +180,16 @@ export const cardStyles = css`
   }
   .gallery-info {
     position: absolute;
-    bottom: 1px;
-    left: 2px;
-    right: 2px;
+    /* Spans the whole tile so the two lines can take its top and bottom edges. Stacked and
+       centred rather than a single row split left/right: once the thumbnails are clipped to
+       the body, a full-width row runs off the disc at both ends, and centring on the tile
+       centres on the body too — the sources all sit their subject dead centre in frame. */
+    inset: 2px;
     display: flex;
+    flex-direction: column;
     justify-content: space-between;
-    /* Bottom-align rather than stretch: a stretched span puts its line box at the top, so
-       any disagreement about the box's height moves the text instead of staying put. */
-    align-items: flex-end;
+    align-items: center;
+    text-align: center;
     /* font-size and line-height are pinned on the container, not just the spans, because
        the tiles are built from different elements — a <div> for the moon, a <button> for the
        fetched sources — and a <button> takes its font from the UA stylesheet (13.333px)
@@ -174,7 +207,15 @@ export const cardStyles = css`
   .gallery-age {
     font: inherit;
     color: #fff;
-    text-shadow: 0 0 2px #000;
+    /* Three stacked shadows, not one. The caption used to sit entirely on the image's black
+       margin; now the thumbnails are clipped to the body itself, so its ends overhang the
+       card — white on a light theme's white. A single 2px glow was not enough contrast to
+       survive that, and the caption also has to stay readable where it crosses a sunlit limb,
+       so a solid backdrop is out: it would put a dark bar under a floating disc. */
+    text-shadow:
+      0 0 2px #000,
+      0 0 3px #000,
+      0 1px 2px #000;
     white-space: nowrap;
   }
   .nav {

--- a/src/card/card-template.ts
+++ b/src/card/card-template.ts
@@ -7,8 +7,8 @@ import {
   getSkyMode,
 } from "../astronomy/solar-position.js";
 import type { LocationData } from "../types.js";
-import type { GalleryViewModel } from "./gallery/gallery-controller.js";
-import { formatRelativeAge } from "./relative-time.js";
+import type { GalleryShape, GalleryViewModel } from "./gallery/gallery-controller.js";
+import { formatRelativeWhen } from "./relative-time.js";
 
 export function formatDate(date: Date): string {
   const y = String(date.getFullYear()).slice(-2);
@@ -51,25 +51,34 @@ export function buildStatusBar(
   </div>`;
 }
 
-// Sources backed by a fetched NASA image: they have a URL, a capture date, a cache/backoff
-// cycle, and can open full-screen. Every Record<ImageSource, ...> below is keyed on exactly
-// these, which is why moon — drawn locally, never fetched, never full-screen — is NOT one.
-export type ImageSource = "earth" | "sun";
+// Every source in the gallery: a fetched NASA image with a URL, a capture date, a
+// cache/backoff cycle, and a full-screen view. Since the moon tiles became NASA imagery
+// too there is no display-only source left, so this is also the whole strip — the separate
+// GallerySource union that existed to carry the locally drawn disc is gone.
+//
+// "moon" and "moon-sky" are the same NASA render at different instants: the object tile
+// follows the current hour, the sky tile pins to 22:00 local and is rotated into the
+// observer's own orientation.
+export type ImageSource = "mymoon" | "moon" | "earth" | "sun";
 
-// Anything that can occupy a slot in the gallery strip. Moon is display-only: it has no URL
-// and no panel, so it appears here and nowhere else.
-export type GallerySource = ImageSource | "moon";
+// Everything that can occupy a slot in the strip. drawnmoon is display-only: computed
+// locally, so it has no URL, no cache, no failure mode and no full-screen view.
+export type GallerySource = ImageSource | "drawnmoon";
 
 export const IMAGE_SOURCE_LABELS: Record<ImageSource, string> = {
+  mymoon: "NASA SVS Moon",
+  moon: "NASA SVS Moon",
   earth: "DSCOVR Earth",
   sun: "SDO HMI Continuum",
 };
 
-// Labels for the gallery thumbnail strip — the left half of every tile's caption.
+// Labels for the gallery thumbnail strip — the top line of every tile's caption.
 export const GALLERY_SOURCE_LABELS: Record<GallerySource, string> = {
+  mymoon: "MY SKY",
   moon: "MOON",
   earth: "DSCOVR/E",
   sun: "SDO/S",
+  drawnmoon: "DRAWN",
 };
 
 /**
@@ -88,6 +97,56 @@ export function buildMoonTitle(date: Date, isLiveMode: boolean): string {
 }
 
 /**
+ * The fraction of its own frame each source's disc spans **at its largest**.
+ *
+ * Every source ships a disc centred on black, but each leaves a different margin, and the
+ * margin is not constant: apparent size changes as the geometry does. Measured from the
+ * imagery — Moon 96.3% at perigee (from SVS's own `diameter` arcsec, anchored on a measured
+ * full-moon frame), Sun 94.3% at perihelion, Earth 74.4-82.2% across DSCOVR's Lissajous orbit
+ * around L1, which is much the widest swing of the three.
+ *
+ * Earth is deliberately set above its largest measurement: four sampled dates are not the
+ * whole orbit, and the failure modes are asymmetric — too small leaves a thin black ring, too
+ * large slices the limb off.
+ */
+const DISC_FRACTION: Record<ImageSource, number> = {
+  mymoon: 0.963,
+  moon: 0.963,
+  earth: 0.88,
+  sun: 0.943,
+};
+
+/**
+ * Crops a thumbnail down to the body itself, so the frame's black surround drops out and the
+ * card shows through instead.
+ *
+ * Two coupled numbers from one measurement: clip to the disc's own radius, then scale by the
+ * inverse so that radius reaches the edge of the tile. They must stay coupled — `clip-path`
+ * resolves in the element's own coordinates and `transform` applies to the result, so scaling
+ * without shrinking the clip by the same factor pushes the circle back outside the tile,
+ * which is the overflow this exists to prevent.
+ */
+export function discStyle(source: ImageSource, shape: GalleryShape, rotationDeg = 0): string {
+  // Square keeps the frame as published — except for the sky tile, which cannot have one: a
+  // rotated square is not a square. The tile clips the corners that swing outside it while the
+  // card shows through where the image's own corners swing in, so an unclipped rotated frame
+  // renders as an octagon at every angle but 0 and 90. Scaling it down by 1/(|cos|+|sin|)
+  // would keep all four corners, at the cost of a tilted diamond up to 29% smaller than its
+  // neighbours. A circle is the one shape rotation leaves alone, so the sky tile takes one
+  // whatever the setting — a looser crop than circle mode's, 50% of the frame rather than 48%,
+  // so it still shows more of the surround than its cropped neighbours do.
+  if (shape === "square") {
+    return rotationDeg
+      ? `clip-path: circle(50%); transform: rotate(${rotationDeg.toFixed(1)}deg)`
+      : "";
+  }
+  const fraction = DISC_FRACTION[source];
+  const scale = `scale(${(1 / fraction).toFixed(3)})`;
+  const transform = rotationDeg ? `rotate(${rotationDeg.toFixed(1)}deg) ${scale}` : scale;
+  return `clip-path: circle(${(fraction * 50).toFixed(1)}%); transform: ${transform}`;
+}
+
+/**
  * The caption overlaid on a gallery thumbnail: source on the left, detail on the right.
  *
  * Shared by every tile rather than written out per branch. The moon tile is built from a
@@ -103,21 +162,38 @@ export function buildGalleryCaption(label: string, detail: string): TemplateResu
   </div>`;
 }
 
-// Sources that need fetching/hydrating — the network-backed ones only.
-export const IMAGE_SOURCES: ImageSource[] = ["earth", "sun"];
+// The gallery strip, in render order. Fixed rather than configurable: `gallery.sources` was
+// one knob too many for three tiles that each answer a different question, and a user who
+// wanted fewer of them wanted the strip closed, not pruned.
+// Fetched sources, in the order they render when `gallery.sources` says nothing. The drawn
+// disc is deliberately absent: it is a diagram, and it does not belong in a strip of
+// photographs unless someone asks for it by name.
+export const IMAGE_SOURCES: ImageSource[] = ["mymoon", "moon", "earth", "sun"];
 
-// Every name accepted in `gallery.sources`. Order here is only the validation set; the
-// user's own list order is what decides layout.
-export const GALLERY_SOURCES: GallerySource[] = ["moon", "earth", "sun"];
+// Every name `gallery.sources` accepts. Order here is only the validation set — the user's
+// own list order is what decides layout.
+export const GALLERY_SOURCES: GallerySource[] = [...IMAGE_SOURCES, "drawnmoon"];
 
 // Full-screen status bar leads with the target body, the probe name follows (e.g.
 // "EARTH · DSCOVR · captured ..."). Kept separate from IMAGE_SOURCE_LABELS, which stays
 // fuller for the error banner ("SDO HMI Continuum image unavailable").
 const IMAGE_STATUS_TARGET: Record<ImageSource, string> = {
+  mymoon: "MOON",
+  moon: "MOON",
   earth: "EARTH",
   sun: "SUN",
 };
+// Earth and Sun tiles show photographs; the Moon tiles show renders, and the sky one is for
+// an hour that has usually not happened yet. "captured … 3h ago" is wrong on both counts.
+const IMAGE_STATUS_VERB: Record<ImageSource, string> = {
+  mymoon: "rendered for",
+  moon: "rendered",
+  earth: "captured",
+  sun: "captured",
+};
 const IMAGE_STATUS_INSTRUMENT: Record<ImageSource, string> = {
+  mymoon: "NASA SVS",
+  moon: "NASA SVS",
   earth: "DSCOVR",
   sun: "SDO HMI",
 };
@@ -130,7 +206,7 @@ export function buildImageStatusBar(
   loaded: boolean
 ): TemplateResult {
   const status = loaded
-    ? `captured ${dateText} · ${formatRelativeAge(imageDate, now)}`
+    ? `${IMAGE_STATUS_VERB[mode]} ${dateText} · ${formatRelativeWhen(imageDate, now)}`
     : "loading…";
   return html`<div class="status-bar">
     <span>${IMAGE_STATUS_TARGET[mode]} · ${IMAGE_STATUS_INSTRUMENT[mode]} · ${status}</span>

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -1,22 +1,32 @@
+import type { TemplateResult } from "lit";
 import { html, LitElement, nothing } from "lit";
 import { getMoonPhase } from "../astronomy/moon-phase.js";
+import { getMoonSkyAngles } from "../astronomy/parallactic.js";
+import { getLocalHourInstant } from "../astronomy/solar-position.js";
 import { renderMoonPhaseDisc } from "../renderer/moon-phase.js";
 import type { CardConfig, Colors, HASSConfig, Hemisphere, LocationData } from "../types.js";
 import { parseCardConfig } from "./card-config.js";
 import { cardStyles } from "./card-styles.js";
-import type { ImageSource } from "./card-template.js";
+import type { GallerySource, ImageSource } from "./card-template.js";
 import {
   buildGalleryCaption,
   buildMoonTitle,
   buildStatusBarView,
+  discStyle,
   formatDate,
   GALLERY_SOURCE_LABELS,
 } from "./card-template.js";
 import { DateNavigation } from "./date-navigation.js";
 import { buildDebugOverlay } from "./gallery/debug.js";
-import type { GalleryMode } from "./gallery/gallery-controller.js";
+import type {
+  GalleryMode,
+  GalleryPosition,
+  GalleryShape,
+  ImagePanelMode,
+} from "./gallery/gallery-controller.js";
 import { GalleryController } from "./gallery/gallery-controller.js";
-import { formatRelativeAge } from "./relative-time.js";
+import { fullSizeMoonUrl, SKY_REFERENCE_HOUR } from "./gallery/source-resolver-svs-moon.js";
+import { formatRelativeWhen } from "./relative-time.js";
 import { SolarView } from "./solar-view.js";
 import { resolveTheme, THEME_OVERRIDE_VARS } from "./theme.js";
 import { ZoomController } from "./zoom-controller.js";
@@ -61,6 +71,8 @@ export class SolarViewCard extends LitElement {
   private _locationNameOverride: string | null;
   private _autoUpdateTimer: number | null;
   private _debugTimer: number | null;
+  private _galleryPosition: GalleryPosition;
+  private _galleryShape: GalleryShape;
   private _colors: Colors;
   private _refreshMs: number;
   private _eclipticView: boolean;
@@ -84,6 +96,8 @@ export class SolarViewCard extends LitElement {
     this._locationNameOverride = null;
     this._autoUpdateTimer = null;
     this._debugTimer = null;
+    this._galleryPosition = "overlay";
+    this._galleryShape = "square";
     this._colors = {};
     this._refreshMs = 60000;
     this._eclipticView = false;
@@ -91,7 +105,10 @@ export class SolarViewCard extends LitElement {
     this._heightStyle = "";
     this._solarView = new SolarView(this._zoom);
     this._onVisibilityChange = null;
-    this._gallery = new GalleryController(() => this._render());
+    this._gallery = new GalleryController(
+      () => this._render(),
+      () => this._locationData?.timezone ?? "UTC"
+    );
   }
 
   // ---------------------------------------------------------------------------
@@ -150,6 +167,8 @@ export class SolarViewCard extends LitElement {
     this._locationOverride = parsed.locationOverride;
     this._locationNameOverride = parsed.locationNameOverride;
     this._heightStyle = parsed.heightStyle;
+    this._galleryPosition = parsed.galleryPosition;
+    this._galleryShape = parsed.galleryShape;
     this._gallery.configure(parsed.galleryMode, parsed.gallerySources, parsed.galleryIntervalMs);
 
     if (this._autoUpdateTimer != null) {
@@ -219,9 +238,11 @@ export class SolarViewCard extends LitElement {
           ></div>
           <img
             id="image-view"
-            class="image-view ${gallery.panelSource === "none" ? "" : "visible"}"
-            style=${this._heightStyle || nothing}
-            src=${gallery.imageUrl ?? nothing}
+            class="image-view ${gallery.panelSource === "none" ? "" : "visible"} ${
+              gallery.panelSource === "mymoon" ? "sky-rotated" : ""
+            }"
+            style=${this._panelStyle(gallery.panelSource)}
+            src=${gallery.imageUrl ? fullSizeMoonUrl(gallery.imageUrl) : nothing}
             alt=""
             @click=${this._onImageClick}
             @load=${this._onImageLoad}
@@ -229,43 +250,9 @@ export class SolarViewCard extends LitElement {
           />
           ${
             gallery.showStrip
-              ? html`<div class="gallery">
+              ? html`<div class="gallery gallery-${this._galleryPosition}">
                   ${gallery.thumbnails.map(({ source, url, date }) =>
-                    // Moon is a <div>, not a <button>: it is drawn locally and has no
-                    // full-screen view to open, so making it look clickable would promise
-                    // something no click can deliver. Its SVG is mounted imperatively in
-                    // updated() — same split as #solar-view.
-                    source === "moon"
-                      ? html`<div
-                          class="gallery-thumb gallery-thumb-moon"
-                          data-source="moon"
-                          title=${buildMoonTitle(
-                            this._dateNav.currentDate,
-                            this._dateNav.isLiveMode
-                          )}
-                        >
-                          <div class="moon-disc"></div>
-                          ${buildGalleryCaption(
-                            GALLERY_SOURCE_LABELS.moon,
-                            getMoonPhase(this._dateNav.currentDate).phaseName
-                          )}
-                        </div>`
-                      : html`<button
-                          class="gallery-thumb"
-                          data-source=${source}
-                          title=${`Show ${GALLERY_SOURCE_LABELS[source]}`}
-                          @click=${this._onGalleryClick}
-                        >
-                          <img
-                            src=${url ?? nothing}
-                            alt=""
-                            @error=${source === "sun" ? this._onSunThumbError : undefined}
-                          />
-                          ${buildGalleryCaption(
-                            GALLERY_SOURCE_LABELS[source],
-                            date ? formatRelativeAge(date, new Date()) : "loading…"
-                          )}
-                        </button>`
+                    this._renderGalleryTile(source, url, date)
                   )}
                 </div>`
               : nothing
@@ -330,6 +317,96 @@ export class SolarViewCard extends LitElement {
         this.style.setProperty(varName, theme.vars[varName]);
       }
     }
+  }
+
+  /**
+   * One gallery tile. Every source is a fetched NASA image now, so there is one shape rather
+   * than a moon branch and an everything-else branch.
+   *
+   * The sky tile is the only one that differs, and only by two things: it is rotated into the
+   * observer's own orientation, and its caption points at 22:00 rather than at the past. Both
+   * come from the same hour-angle calculation, so both are computed here in one call.
+   */
+  private _renderGalleryTile(
+    source: GallerySource,
+    url: string | null,
+    date: Date | null
+  ): TemplateResult {
+    // The locally drawn disc is the one tile with nothing behind it to fetch: a <div>, not a
+    // <button>, because it has no full-screen view and looking clickable would promise
+    // something no click can deliver. Its SVG is mounted imperatively in updated().
+    if (source === "drawnmoon") {
+      return html`<div
+        class="gallery-thumb gallery-thumb-moon"
+        data-source="drawnmoon"
+        title=${buildMoonTitle(this._dateNav.currentDate, this._dateNav.isLiveMode)}
+      >
+        <div class="moon-disc"></div>
+        ${buildGalleryCaption(
+          GALLERY_SOURCE_LABELS.drawnmoon,
+          getMoonPhase(this._dateNav.currentDate).phaseName
+        )}
+      </div>`;
+    }
+    const sky = source === "mymoon" ? this._skyView() : null;
+    // Only the rotating tile in square shape needs a backdrop of its own — see the
+    // .gallery-thumb-boxed comment for why its frame cannot survive the rotation.
+    const boxed = sky && this._galleryShape === "square" ? " gallery-thumb-boxed" : "";
+    return html`<button
+      class="gallery-thumb${boxed}"
+      data-source=${source}
+      title=${`Show ${GALLERY_SOURCE_LABELS[source]}`}
+      @click=${this._onGalleryClick}
+    >
+      <img
+        src=${url ?? nothing}
+        alt=""
+        style=${discStyle(source, this._galleryShape, sky ? sky.rotation : 0) || nothing}
+        @error=${source === "sun" ? this._onSunThumbError : undefined}
+      />
+      ${buildGalleryCaption(
+        GALLERY_SOURCE_LABELS[source],
+        sky ? sky.caption : date ? formatRelativeWhen(date, new Date()) : "loading…"
+      )}
+    </button>`;
+  }
+
+  /**
+   * The full-screen image's inline style: the configured height cap, plus the sky tile's own
+   * rotation so the panel shows what the thumbnail showed rather than snapping back to the
+   * geocentric frame the moment it is opened.
+   */
+  private _panelStyle(panelSource: ImagePanelMode): string | typeof nothing {
+    const parts = [this._heightStyle];
+    if (panelSource === "mymoon") {
+      parts.push(`transform: rotate(${this._skyView().rotation.toFixed(1)}deg)`);
+    }
+    return parts.filter(Boolean).join("; ") || nothing;
+  }
+
+  /**
+   * How the Moon will hang at 22:00 local, and what to say about it.
+   *
+   * Returns null-safe defaults when no location is known yet: an unrotated frame is the
+   * geocentric one, which is the honest thing to show when there is no observer to rotate for.
+   *
+   * "Below horizon" is not a failure and not a dark Moon — the frame still shows a normally
+   * lit gibbous or crescent. It means the Earth is in the way from here, which happens on
+   * roughly half of all nights at every latitude, so saying so is the difference between a
+   * tile that answers "should I go outside" and one that quietly implies yes.
+   */
+  private _skyView(): { rotation: number; caption: string } {
+    const location = this._locationData;
+    const now = new Date();
+    const reference = getLocalHourInstant(now, location?.timezone ?? "UTC", SKY_REFERENCE_HOUR);
+    const when = formatRelativeWhen(reference, now);
+    if (!location) return { rotation: 0, caption: when };
+
+    const { parallacticDeg, altitudeDeg } = getMoonSkyAngles(reference, location.lat, location.lon);
+    return {
+      rotation: parallacticDeg,
+      caption: altitudeDeg > 0 ? when : "below horizon",
+    };
   }
 
   // The moon disc is raw SVG DOM, not a Lit template — same imperative split as #solar-view

--- a/src/card/gallery/debug.ts
+++ b/src/card/gallery/debug.ts
@@ -9,11 +9,13 @@ import { formatDuration } from "../relative-time.js";
 // making it impossible to tell which one a spike came from. Split into two debug rows; sun
 // has no separate URL-discovery network call (its candidate URL is pure math), so it stays a
 // single row — ImageResolver passes the same accumulator as both url and img debug for sun.
-export type DebugRowId = "sun" | "earth-url" | "earth-img";
+export type DebugRowId = "mymoon" | "moon" | "sun" | "earth-url" | "earth-img";
 
-export const DEBUG_ROWS: DebugRowId[] = ["sun", "earth-url", "earth-img"];
+export const DEBUG_ROWS: DebugRowId[] = ["mymoon", "moon", "sun", "earth-url", "earth-img"];
 
 export const DEBUG_ROW_LABELS: Record<DebugRowId, string> = {
+  mymoon: "SVS/M sky",
+  moon: "SVS/M obj",
   sun: "SDO/S",
   "earth-url": "DSCOVR/E url",
   "earth-img": "DSCOVR/E img",
@@ -22,6 +24,8 @@ export const DEBUG_ROW_LABELS: Record<DebugRowId, string> = {
 // Which debug row(s) a given gallery source's resolve() call reports into — see the
 // DebugRowId comment above for why sun collapses both roles into one row.
 export const DEBUG_ROW_KEYS: Record<ImageSource, { url: DebugRowId; img: DebugRowId }> = {
+  mymoon: { url: "mymoon", img: "mymoon" },
+  moon: { url: "moon", img: "moon" },
   sun: { url: "sun", img: "sun" },
   earth: { url: "earth-url", img: "earth-img" },
 };
@@ -155,7 +159,7 @@ export function buildDebugOverlay(
         // and found nothing", when really the question never applies to this row at all.
         const hasCacheStep = rowId !== "earth-img";
         // Only sun's resolver ever retries (recover()'s one-slot-back fallback — see
-        // source-resolver-sdo-sun.ts) — earth's default recover() just rethrows, so 0 there
+        // source-resolver-sdo-sun.ts) — earth's and moon's default recover() just rethrows, so 0 there
         // would misleadingly suggest "checked, never needed one" rather than "not a thing
         // that can happen on this row".
         const canRetry = rowId === "sun";

--- a/src/card/gallery/gallery-controller.ts
+++ b/src/card/gallery/gallery-controller.ts
@@ -7,15 +7,26 @@ import type { SourcedImage } from "./url-cache.js";
 
 export type ImagePanelMode = "none" | ImageSource;
 
-// Presentation only — which sources appear is `gallery.sources`, orthogonal to this. Before
-// #140 the two were one union, which needed a member per combination and could not express
-// three sources without eight names.
-export type GalleryMode = "closed" | "open" | "slide";
-export const GALLERY_MODES: GalleryMode[] = ["closed", "open", "slide"];
+// How the strip presents itself. Which sources appear is no longer configurable — all four
+// tiles always show — so this is the whole of `gallery.mode` again, as it was before #140,
+// but without that version's conflation of presentation and source selection.
+export type GalleryMode = "off" | "open" | "slide";
+export const GALLERY_MODES: GalleryMode[] = ["off", "open", "slide"];
 export const DEFAULT_GALLERY_INTERVAL_MS = 60000;
 
-// Moon costs no network and cannot fail, so it is the one source safe to show out of the box.
-export const DEFAULT_GALLERY_SOURCES: GallerySource[] = ["moon"];
+// Where the strip sits. "overlay" floats it over the bottom of the solar view, which costs no
+// card height but covers the outer orbits; "below" makes it a sibling of the view, growing the
+// card by the strip's own height instead.
+export type GalleryPosition = "overlay" | "below";
+
+// How each thumbnail is framed. "square" — the default — shows the frame as its source
+// publishes it, black margin and all; "circle" crops to the body itself so the card shows
+// through around it.
+export type GalleryShape = "circle" | "square";
+
+// What the strip shows when `gallery.sources` says nothing: every fetched source, in the
+// order card-template.ts lists them. drawnmoon is opt-in by name.
+export const DEFAULT_GALLERY_SOURCES: GallerySource[] = IMAGE_SOURCES;
 
 // Render-ready shape for card.ts's template — raw data only (dates, urls, booleans), no
 // formatting, so formatRelativeAge/date-formatting stays in card.ts alongside its other
@@ -50,7 +61,6 @@ export class GalleryController {
   private _open: boolean;
   private _images: Partial<Record<ImageSource, SourcedImage>>;
   private _mode: GalleryMode;
-  private _sources: GallerySource[];
   private _autoIntervalMs: number;
   private _slideIndex: number;
   private _autoSwitchTimer: number | null;
@@ -58,27 +68,33 @@ export class GalleryController {
   private _debug: Record<DebugRowId, DebugAccumulator>;
   private _debugStartedAt: number;
   private _resolver: ImageResolver;
+  private _sources: GallerySource[];
 
-  constructor(onChange: () => void) {
+  // getTimezone is a function, not a value: the observer's zone is derived from HA state and
+  // a config override that can both change after construction, and the sky tile's reference
+  // instant has to follow. Same reason _locationData is a getter on the card.
+  constructor(onChange: () => void, getTimezone: () => string) {
     this._panelMode = "none";
     this._imageUrl = null;
     this._imageDate = null;
     this._imageLoaded = false;
     this._error = null;
     this._open = false;
-    this._mode = "closed";
+    this._mode = "off";
     this._sources = DEFAULT_GALLERY_SOURCES;
     this._autoIntervalMs = DEFAULT_GALLERY_INTERVAL_MS;
     this._slideIndex = 0;
     this._autoSwitchTimer = null;
     this._onChange = onChange;
     this._debug = {
+      mymoon: emptyDebugAccumulator(),
+      moon: emptyDebugAccumulator(),
       sun: emptyDebugAccumulator(),
       "earth-url": emptyDebugAccumulator(),
       "earth-img": emptyDebugAccumulator(),
     };
     this._debugStartedAt = Date.now();
-    this._resolver = new ImageResolver();
+    this._resolver = new ImageResolver(getTimezone);
     // Recovers each source's still-fresh cache into this instance's own known-URL
     // state — without this, a remount (this._images always starts empty) would otherwise
     // force a redundant preload of bytes the module cache already confirmed are current.
@@ -106,14 +122,13 @@ export class GalleryController {
   get mode(): GalleryMode {
     return this._mode;
   }
-  get sources(): GallerySource[] {
-    return this._sources;
-  }
   get images(): Partial<Record<ImageSource, SourcedImage>> {
     return this._images;
   }
   get debugStats(): Record<DebugRowId, SourceDebugStats> {
     return {
+      mymoon: toDebugStats(this._debug.mymoon),
+      moon: toDebugStats(this._debug.moon),
       sun: toDebugStats(this._debug.sun),
       "earth-url": toDebugStats(this._debug["earth-url"]),
       "earth-img": toDebugStats(this._debug["earth-img"]),
@@ -135,7 +150,7 @@ export class GalleryController {
       imageLoaded: this._imageLoaded,
       showStrip: this._open && this._panelMode === "none",
       thumbnails: this.displaySources.map((source) => {
-        const image = source === "moon" ? undefined : this._images[source];
+        const image = source === "drawnmoon" ? undefined : this._images[source];
         return { source, url: image?.url ?? null, date: image?.date ?? null };
       }),
       debugStats: this.debugStats,
@@ -143,23 +158,23 @@ export class GalleryController {
     };
   }
 
-  // The network-backed subset of the configured sources — "slide" still fetches all of them
-  // even though only one is displayed at a time, so rotating onto a source never shows a
-  // stale/missing thumbnail. Moon is filtered out because it is drawn locally: it has no URL
-  // to resolve, no cache to consult, and no failure mode to back off from.
+  // The network-backed subset of the configured list — "slide" still fetches all of them even
+  // though only one shows at a time, so rotating onto a source never reveals a stale or empty
+  // thumbnail. drawnmoon is filtered out: it is computed locally, so it has no URL to
+  // resolve, no cache to consult and no failure to back off from.
   private get _fetchSources(): ImageSource[] {
-    return this._sources.filter((s): s is ImageSource => s !== "moon");
+    return this._sources.filter((s): s is ImageSource => s !== "drawnmoon");
   }
 
-  // Applies config.gallery: mode + auto-switch interval, and whether the strip starts open
-  // (matches setConfig's previous behavior of resetting _galleryOpen from mode every call).
-  // Restarts the auto-switch timer if one is already running, same as the old
-  // `if (this._autoSwitchTimer != null) this._startAutoSwitchTimer()` in setConfig.
+  // Applies config.gallery: mode + auto-switch interval, and whether the strip starts open (matches setConfig's previous behavior of
+  // resetting _galleryOpen from mode every call). Restarts the auto-switch timer if one is
+  // already running, same as the old `if (this._autoSwitchTimer != null)
+  // this._startAutoSwitchTimer()` in setConfig.
   configure(mode: GalleryMode, sources: GallerySource[], autoIntervalMs: number): void {
     this._mode = mode;
     this._sources = sources;
     this._autoIntervalMs = autoIntervalMs;
-    this._open = mode !== "closed";
+    this._open = mode !== "off";
     // A shorter list would otherwise leave the rotation pointing past its end, so
     // displaySources would read undefined until the next tick wrapped it.
     if (this._slideIndex >= sources.length) this._slideIndex = 0;
@@ -271,11 +286,9 @@ export class GalleryController {
     }, this._autoIntervalMs) as unknown as number;
   }
 
-  // Advances the "slide" rotation one step through the configured list, wrapping at the end.
-  // An index into gallery.sources rather than a hardcoded earth/sun flip, so the rotation
-  // follows whatever the user listed — moon included — in the order they listed it. The
-  // reused <img> may show the previous bitmap for a frame while the new one decodes —
-  // cosmetic, not worth a pre-decode step.
+  // Advances the "slide" rotation one step through the strip, wrapping at the end. The reused
+  // <img> may show the previous bitmap for a frame while the new one decodes — cosmetic, not
+  // worth a pre-decode step.
   private _advanceSlide(): void {
     this._slideIndex = (this._slideIndex + 1) % this._sources.length;
     this._onChange();

--- a/src/card/gallery/image-resolver.ts
+++ b/src/card/gallery/image-resolver.ts
@@ -1,9 +1,11 @@
+import { getLocalHourInstant } from "../../astronomy/solar-position.js";
 import type { ImageSource } from "../card-template.js";
 import type { DebugAccumulator, DebugRowId } from "./debug.js";
 import { DEBUG_ROW_KEYS } from "./debug.js";
 import type { SourceResolver } from "./source-resolver.js";
 import { DscovrEarthResolver } from "./source-resolver-dscovr-earth.js";
 import { SdoSunResolver } from "./source-resolver-sdo-sun.js";
+import { SKY_REFERENCE_HOUR, SvsMoonResolver } from "./source-resolver-svs-moon.js";
 import type { SourcedImage } from "./url-cache.js";
 
 // The single gateway to a resolved sun/earth image — dispatches to the per-source resolver
@@ -13,11 +15,22 @@ import type { SourcedImage } from "./url-cache.js";
 // a SourceResolver subclass and an entry in `_resolvers` — GalleryController's call sites don't
 // change.
 export class ImageResolver {
-  private readonly _resolvers: Record<ImageSource, SourceResolver> = {
-    earth: new DscovrEarthResolver(),
-    sun: new SdoSunResolver(),
-  };
+  private readonly _resolvers: Record<ImageSource, SourceResolver>;
   private readonly _inFlight: Partial<Record<ImageSource, boolean>> = {};
+
+  // The sky tile's reference instant depends on the observer's timezone, which arrives from
+  // HA after construction — hence a getter rather than a value. Both moon resolvers share one
+  // class and differ only in which instant they ask for and which cache key they own.
+  constructor(getTimezone: () => string) {
+    this._resolvers = {
+      mymoon: new SvsMoonResolver("mymoon", () =>
+        getLocalHourInstant(new Date(), getTimezone(), SKY_REFERENCE_HOUR)
+      ),
+      moon: new SvsMoonResolver("moon", () => new Date()),
+      earth: new DscovrEarthResolver(),
+      sun: new SdoSunResolver(),
+    };
+  }
 
   hydrate(sources: readonly ImageSource[]): Partial<Record<ImageSource, SourcedImage>> {
     const images: Partial<Record<ImageSource, SourcedImage>> = {};

--- a/src/card/gallery/source-resolver-svs-moon.ts
+++ b/src/card/gallery/source-resolver-svs-moon.ts
@@ -1,0 +1,129 @@
+import type { ImageSource } from "../card-template.js";
+import { SourceResolver } from "./source-resolver.js";
+import type { SourcedImage, UrlCache } from "./url-cache.js";
+
+// NASA's Scientific Visualization Studio publishes "Moon Phase and Libration, <year>": 8,760
+// frames, one per hour, rendered from LOLA topography and the LROC WAC colour mosaic with
+// positions from JPL DE421. Geocentric — the view from the centre of the Earth, celestial
+// north up, apparent diameter to true scale.
+//
+// These are renders, not observations, and the whole year ships at once the previous
+// November or December. So unlike DSCOVR and SDO there is no publish latency to buffer
+// against and no "latest available" to discover: the frame for any hour of the mapped year
+// already exists, including hours still in the future.
+//
+// The URL is computed rather than looked up. SVS does expose a JSON API that would hand over
+// the URL directly, but it answers with `access-control-allow-origin: https://tempo.multiverse.music`
+// — one hardcoded third-party origin, unchanged whatever Origin is sent — so fetch() is
+// blocked from any Home Assistant origin. Plain <img src> is unaffected by CORS, which is why
+// the image itself still loads. Same shape as the SDO sun resolver for the same reason.
+export const SVS_BASE_URL = "https://svs.gsfc.nasa.gov/vis/a000000";
+export const MOON_THUMB_SIZE = "216x216_1x1_30p";
+export const MOON_FULL_SIZE = "730x730_1x1_30p";
+export const MOON_FRAME_MS = 3600000;
+
+// The hour the sky tile answers for: late enough to be dark across most inhabited latitudes
+// for most of the year, early enough that "tonight" still means tonight. Lives here rather
+// than in gallery-controller.ts so image-resolver.ts can read it without importing the
+// controller that constructs it — that pairing was a genuine import cycle.
+export const SKY_REFERENCE_HOUR = 22;
+
+// The one thing about this source that cannot be derived. SVS assigns each annual product a
+// new id with no pattern to it (+93, +139, +228, +172 across these five), and the id is in
+// the path. It has to ship as a constant and gain a row each December, when the following
+// year's product is released — historically between 9 Nov and 11 Dec.
+export const MOON_PRODUCT_IDS: Record<number, number> = {
+  2022: 4955,
+  2023: 5048,
+  2024: 5187,
+  2025: 5415,
+  2026: 5587,
+};
+
+function pad(value: number, width: number): string {
+  return String(value).padStart(width, "0");
+}
+
+/**
+ * The frame for one instant, at one of the published resolutions.
+ *
+ * Throws rather than degrading for an unmapped year, and that is deliberate. SVS answers an
+ * out-of-range date with the *last frame of the current product* under a 200, not a 404 — ask
+ * it for March 2027 today and it returns a Moon at 38% when the truth is 9%. A source that
+ * failed quietly here would show a confidently wrong Moon instead of no Moon.
+ */
+export function moonFrameUrl(at: Date, size: string): string {
+  const year = at.getUTCFullYear();
+  const product = MOON_PRODUCT_IDS[year];
+  if (product == null) {
+    throw new Error(`No NASA SVS moon product is published for ${year}`);
+  }
+  // Products are filed in hundreds: 5587 lives under a005500/a005587.
+  const group = Math.floor(product / 100) * 100;
+  const frame = Math.floor((at.getTime() - Date.UTC(year, 0, 1)) / MOON_FRAME_MS) + 1;
+  return `${SVS_BASE_URL}/a${pad(group, 6)}/a${pad(product, 6)}/frames/${size}/moon.${pad(frame, 4)}.jpg`;
+}
+
+/**
+ * The frame covering `at`, dated by the frame's own hour rather than the query instant — so
+ * two cards asking at different minutes of the same hour agree on both the URL and the date
+ * shown beneath it.
+ */
+export function getMoonFrameImage(at: Date, size: string = MOON_THUMB_SIZE): SourcedImage {
+  const hour = new Date(Math.floor(at.getTime() / MOON_FRAME_MS) * MOON_FRAME_MS);
+  return { url: moonFrameUrl(hour, size), date: hour };
+}
+
+/**
+ * The full-screen counterpart of a thumbnail URL.
+ *
+ * Both sizes are the same frame at two resolutions, so swapping the size segment is exact —
+ * no second lookup, no second cache entry, and the panel cannot drift onto a different hour
+ * than the tile the user clicked. Anything that is not a moon URL passes through untouched.
+ */
+export function fullSizeMoonUrl(url: string): string {
+  return url.replace(`/${MOON_THUMB_SIZE}/`, `/${MOON_FULL_SIZE}/`);
+}
+
+/**
+ * One class, instantiated once per Moon tile.
+ *
+ * The two tiles show the same body from the same renders but at different instants — the
+ * object tile follows the current hour, the sky tile pins to 22:00 local — so the reference
+ * time is a strategy rather than a hardcoded `Date.now()`, and each instance owns its own
+ * cache key. When both strategies happen to land on the same hour they resolve the same URL,
+ * and the shared decode gate means the bytes are fetched once.
+ */
+export class SvsMoonResolver extends SourceResolver {
+  readonly source: ImageSource;
+
+  constructor(
+    source: ImageSource,
+    private readonly _referenceTime: () => Date,
+    cache?: UrlCache
+  ) {
+    super(cache);
+    this.source = source;
+  }
+
+  // Freshness is URL identity, not elapsed time. A wall-clock TTL would have to be anchored
+  // to something (see the sun resolver's freshCachedSlot for how fiddly that gets), and here
+  // there is nothing to anchor: the reference time already determines exactly one frame, so
+  // "is the cached image the frame we want" is the whole question.
+  protected getCached(): SourcedImage | null {
+    const entry = this.cache.getEntry(this.source);
+    if (!entry) return null;
+    return entry.image.url === getMoonFrameImage(this._referenceTime()).url ? entry.image : null;
+  }
+
+  protected fetchCandidateUrl(): Promise<SourcedImage> {
+    const image = getMoonFrameImage(this._referenceTime());
+    this.cache.set(this.source, image);
+    return Promise.resolve(image);
+  }
+
+  // No recover() override on purpose. Sun overrides it because SDO's publish pipeline lags and
+  // the previous slot is a good guess. Here every frame of the year is already on disk, so a
+  // failure means the product id is wrong or the network is down — neither of which an earlier
+  // frame fixes. Fall through to the shared cooldown like any other source.
+}

--- a/src/card/relative-time.ts
+++ b/src/card/relative-time.ts
@@ -5,6 +5,24 @@ export function formatRelativeAge(date: Date, now: Date): string {
   return `${Math.floor(diffMin / 60)}h ago`;
 }
 
+/**
+ * The same phrasing as formatRelativeAge, but for an instant that may be in either direction.
+ *
+ * Earth and Sun tiles only ever show images already captured, so "ago" is the only tense they
+ * need. The sky Moon tile points at 22:00 local, which is ahead of the user for most of the
+ * day and behind them between 22:00 and midnight — one caption that flips tense on its own,
+ * rather than two captions and a rule for choosing between them.
+ */
+export function formatRelativeWhen(date: Date, now: Date): string {
+  // Floored, not rounded, so the sub-minute window either side of the instant reads "just
+  // now" the same way it does on its way past — rounding would tick over to "in 1m" while the
+  // moment is still half a minute away.
+  const diffMin = Math.floor((date.getTime() - now.getTime()) / 60000);
+  if (diffMin <= 0) return formatRelativeAge(date, now);
+  if (diffMin < 60) return `in ${diffMin}m`;
+  return `in ${Math.floor(diffMin / 60)}h`;
+}
+
 // Same floor-to-minutes/floor-to-hours bucketing as formatRelativeAge, just phrased for a
 // duration-since-mount instead of an age-of-a-timestamp, so "running for" reads naturally.
 export function formatDuration(ms: number): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,6 +118,12 @@ export interface CardConfig {
   ecliptic_view?: string;
   show_version?: boolean;
   debug?: boolean;
-  gallery?: { mode?: string; sources?: string[]; slide_interval_secs?: number };
+  gallery?: {
+    mode?: string;
+    position?: string;
+    shape?: string;
+    slide_interval_secs?: number;
+    sources?: string[];
+  };
   location?: { latitude?: number; longitude?: number; name?: string; timezone?: string };
 }

--- a/test/__snapshots__/snapshot.test.ts.snap
+++ b/test/__snapshots__/snapshot.test.ts.snap
@@ -112,11 +112,15 @@ exports[`cardStyles > matches snapshot 1`] = `
   .image-view.visible {
     display: block;
   }
+  /* The full-screen sky view rotates its frame into the observer's orientation, and a rotated
+     square sweeps its corners outside its own box — at thumbnail size they are black on black,
+     but here they ride up over the status bar. Clipping to the inscribed circle fixes it: the
+     disc never reaches the edge, and a circle is rotation-invariant, so nothing can escape at
+     any angle. Thumbnails get the tighter, per-source crop from discStyle() instead. */
+  .sky-rotated {
+    clip-path: circle(50%);
+  }
   .gallery {
-    position: absolute;
-    left: 0;
-    right: 0;
-    bottom: 0;
     display: flex;
     align-items: flex-end;
     justify-content: flex-end;
@@ -124,8 +128,24 @@ exports[`cardStyles > matches snapshot 1`] = `
     padding: 2px;
     box-sizing: border-box;
   }
+  /* Floats over the bottom of the solar view: costs no card height, covers the outer orbits. */
+  .gallery-overlay {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+  }
+  /* A plain flex item of .solar-view-wrapper instead, so the card grows by the strip's own
+     height and nothing is hidden behind it. Only flex-shrink needs stating — everything else
+     is already the default now that .gallery itself no longer positions. */
+  .gallery-below {
+    flex-shrink: 0;
+  }
   .gallery-thumb {
-    flex: 0 0 20%;
+    /* Shares the row rather than claiming a fixed 20%: four tiles ship, and debug:true adds a
+       fifth, which at a fixed basis overflows once gaps and padding are counted. */
+    flex: 1 1 0;
+    max-width: 20%;
     position: relative;
     aspect-ratio: 1;
     padding: 0;
@@ -133,8 +153,9 @@ exports[`cardStyles > matches snapshot 1`] = `
        the moon tile's 1px border falls outside its 20% flex-basis and it renders 2px larger
        than the Earth/Sun tiles beside it. */
     box-sizing: border-box;
-    border: 1px solid var(--divider-color, color-mix(in srgb, currentColor 15%, transparent));
-    border-radius: 4px;
+    /* Explicit, not omitted: .gallery-thumb is a <button> on the fetched tiles, and dropping
+       the rule entirely hands it back the UA stylesheet's 2px outset ButtonBorder. */
+    border: 0;
     background: transparent;
     overflow: hidden;
     cursor: pointer;
@@ -148,18 +169,28 @@ exports[`cardStyles > matches snapshot 1`] = `
     object-fit: cover;
     display: block;
   }
-  /* Moon is drawn locally, not fetched — a <div> holding an <svg>, not an <img>, and with
-     no full-screen view to open it gets no pointer affordance. */
+  /* Square shape, rotating tile: the image has to be clipped to a circle or the rotation turns
+     its frame into an octagon, so the black square its neighbours get from their own frame has
+     to come from the tile instead. Sources render their body on pure black, and in square mode
+     the image is unscaled — so the clip lands at the tile edge, outside the body, and the body
+     ends up exactly the size it is on the tiles either side of it. */
+  .gallery-thumb-boxed {
+    background: #000;
+  }
+  /* The drawn disc is the one tile that is still a square plate, so it is the one tile that
+     still wants a frame. The fetched tiles are clipped to the body itself (see discStyle) and
+     a rounded-rectangle outline around a floating disc reads as a leftover box — but the
+     border cannot simply follow the clip, because .gallery-thumb also carries the caption
+     across its full width, and overflow:hidden would crop the ends off a circular one. */
   .gallery-thumb-moon {
     cursor: default;
+    border: 1px solid var(--divider-color, color-mix(in srgb, currentColor 15%, transparent));
+    border-radius: 4px;
   }
-  /* The black backdrop belongs on the disc, not the tile. The tile border is a translucent
-     15% currentColor, so it composites against whatever sits behind it: transparent on the
-     fetched tiles, where it picks up the card and reads as a visible edge. Painting the tile
-     itself black made that border 15% white over black — invisible — so the moon's dark area
-     ran the full 104px while its neighbours' stopped at 102px inside their borders, and the
-     tile looked taller than tiles that measure exactly the same. Here the black fills the
-     content box instead, the same region the img occupies. */
+  /* The black backdrop belongs on the disc, not the tile: painting .gallery-thumb-moon itself
+     black would put its 15%-currentColor border over black, where it disappears, and the
+     drawn moon would then run the full 104px while its neighbours stopped inside their own
+     edge. Filling the content box instead keeps it to the region the img occupies. */
   .moon-disc,
   .moon-disc svg {
     width: 100%;
@@ -171,14 +202,16 @@ exports[`cardStyles > matches snapshot 1`] = `
   }
   .gallery-info {
     position: absolute;
-    bottom: 1px;
-    left: 2px;
-    right: 2px;
+    /* Spans the whole tile so the two lines can take its top and bottom edges. Stacked and
+       centred rather than a single row split left/right: once the thumbnails are clipped to
+       the body, a full-width row runs off the disc at both ends, and centring on the tile
+       centres on the body too — the sources all sit their subject dead centre in frame. */
+    inset: 2px;
     display: flex;
+    flex-direction: column;
     justify-content: space-between;
-    /* Bottom-align rather than stretch: a stretched span puts its line box at the top, so
-       any disagreement about the box's height moves the text instead of staying put. */
-    align-items: flex-end;
+    align-items: center;
+    text-align: center;
     /* font-size and line-height are pinned on the container, not just the spans, because
        the tiles are built from different elements — a <div> for the moon, a <button> for the
        fetched sources — and a <button> takes its font from the UA stylesheet (13.333px)
@@ -196,7 +229,15 @@ exports[`cardStyles > matches snapshot 1`] = `
   .gallery-age {
     font: inherit;
     color: #fff;
-    text-shadow: 0 0 2px #000;
+    /* Three stacked shadows, not one. The caption used to sit entirely on the image's black
+       margin; now the thumbnails are clipped to the body itself, so its ends overhang the
+       card — white on a light theme's white. A single 2px glow was not enough contrast to
+       survive that, and the caption also has to stay readable where it crosses a sunlit limb,
+       so a solid backdrop is out: it would put a dark bar under a floating disc. */
+    text-shadow:
+      0 0 2px #000,
+      0 0 3px #000,
+      0 1px 2px #000;
     white-space: nowrap;
   }
   .nav {

--- a/test/astronomy/moon-position.test.ts
+++ b/test/astronomy/moon-position.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { getMoonEquatorial, greenwichSiderealDeg } from "../../src/astronomy/moon-position.js";
+
+describe("getMoonEquatorial", () => {
+  // Ground truth from NASA SVS Dial-a-Moon (https://svs.gsfc.nasa.gov/api/dialamoon/<time>),
+  // which reports J2000-referred coordinates. This module returns coordinates *of date*,
+  // because that is what a local hour angle needs — so the two differ by ~26 years of
+  // precession, about 0.4° in right ascension by 2026. The tolerance below is that offset,
+  // not model error: after de-precessing, this series agrees with NASA to 0.034° in RA.
+  const NASA: [string, number, number][] = [
+    // utc, j2000_ra (degrees, = j2000_ra hours × 15), j2000_dec
+    ["2026-08-21T12:00:00Z", 251.187, -27.4818],
+    ["2026-01-05T03:00:00Z", 130.761, 21.0071],
+    ["2026-12-30T18:00:00Z", 185.9985, -6.7218],
+  ];
+
+  it.each(NASA)(
+    "puts the Moon within precession's reach of NASA's J2000 position at %s",
+    (utc, ra, dec) => {
+      const moon = getMoonEquatorial(new Date(utc));
+      expect(Math.abs(moon.raDeg - ra)).toBeLessThan(0.5);
+      expect(Math.abs(moon.decDeg - dec)).toBeLessThan(0.2);
+    }
+  );
+
+  // Regression pins: recomputing these by hand is expensive, and a silent coefficient typo
+  // would otherwise still pass the 0.5° check above.
+  it("returns coordinates of date", () => {
+    const moon = getMoonEquatorial(new Date("2026-08-21T12:00:00Z"));
+    expect(moon.raDeg).toBeCloseTo(251.5719, 3);
+    expect(moon.decDeg).toBeCloseTo(-27.5167, 3);
+  });
+
+  it("keeps right ascension in [0, 360)", () => {
+    for (let h = 0; h < 720; h++) {
+      const { raDeg } = getMoonEquatorial(new Date(Date.UTC(2026, 0, 1) + h * 3600000));
+      expect(raDeg).toBeGreaterThanOrEqual(0);
+      expect(raDeg).toBeLessThan(360);
+    }
+  });
+
+  it("never leaves the ±6° band the lunar orbit is inclined into", () => {
+    let max = 0;
+    for (let h = 0; h < 24 * 40; h++) {
+      const { decDeg } = getMoonEquatorial(new Date(Date.UTC(2026, 0, 1) + h * 3600000));
+      max = Math.max(max, Math.abs(decDeg));
+    }
+    // 23.44° obliquity + 5.15° orbital inclination — the Moon cannot exceed their sum.
+    expect(max).toBeLessThan(23.44 + 5.15);
+  });
+});
+
+describe("greenwichSiderealDeg", () => {
+  it("matches the standard value at J2000.0", () => {
+    // 2000-01-01T12:00Z: GMST = 280.46061837° by definition of the series' constant term.
+    expect(greenwichSiderealDeg(new Date("2000-01-01T12:00:00Z"))).toBeCloseTo(280.4606, 3);
+  });
+
+  it("advances one sidereal day (360.9856°) per solar day", () => {
+    const a = greenwichSiderealDeg(new Date("2026-08-21T00:00:00Z"));
+    const b = greenwichSiderealDeg(new Date("2026-08-22T00:00:00Z"));
+    expect(((b - a + 360) % 360) - 0.9856).toBeCloseTo(0, 3);
+  });
+
+  it("keeps the angle in [0, 360)", () => {
+    for (let h = 0; h < 100; h++) {
+      const g = greenwichSiderealDeg(new Date(Date.UTC(2026, 0, 1) + h * 3600000));
+      expect(g).toBeGreaterThanOrEqual(0);
+      expect(g).toBeLessThan(360);
+    }
+  });
+});

--- a/test/astronomy/parallactic.test.ts
+++ b/test/astronomy/parallactic.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { getMoonSkyAngles } from "../../src/astronomy/parallactic.js";
+
+const DENTON = { lat: 33.2148, lon: -97.1331 };
+const SYDNEY = { lat: -33.87, lon: 151.21 };
+
+describe("getMoonSkyAngles", () => {
+  // One moon pass over Denton, 20–21 Aug 2026. The parallactic angle sweeps from negative at
+  // moonrise, through ~0 at transit, to positive at moonset — the rotation that today's
+  // two-state hemisphere flip approximates with 0° or 180°.
+  const PASS: [string, string, number, number][] = [
+    // label, utc, q, altitude
+    ["moonrise", "2026-08-20T20:00:00Z", -52.17, 0.19],
+    ["transit", "2026-08-21T00:50:00Z", -0.665, 29.98],
+    ["moonset", "2026-08-21T05:45:00Z", 52.087, -0.13],
+  ];
+
+  it.each(PASS)("computes q and altitude at %s", (_label, utc, q, alt) => {
+    const angles = getMoonSkyAngles(new Date(utc), DENTON.lat, DENTON.lon);
+    expect(angles.parallacticDeg).toBeCloseTo(q, 1);
+    expect(angles.altitudeDeg).toBeCloseTo(alt, 1);
+  });
+
+  it("sweeps through zero at transit and reverses sign either side", () => {
+    const [rise, transit, set] = PASS.map(
+      ([, utc]) => getMoonSkyAngles(new Date(utc), DENTON.lat, DENTON.lon).parallacticDeg
+    );
+    expect(rise).toBeLessThan(0);
+    expect(Math.abs(transit)).toBeLessThan(1);
+    expect(set).toBeGreaterThan(0);
+    expect(set - rise).toBeGreaterThan(100);
+  });
+
+  // The whole reason the hemisphere flip can be deleted: a southern observer's q lands far
+  // from a northern one's at the same instant, with no latitude branch anywhere.
+  it("inverts for a southern observer without a hemisphere branch", () => {
+    const utc = new Date("2026-08-21T06:00:00Z");
+    const north = getMoonSkyAngles(utc, DENTON.lat, DENTON.lon);
+    const south = getMoonSkyAngles(utc, SYDNEY.lat, SYDNEY.lon);
+    expect(south.parallacticDeg).toBeCloseTo(-111.1, 0);
+    expect(south.altitudeDeg).toBeCloseTo(57.2, 0);
+    // Opposed by more than a right angle — nothing a 0°/180° flip could stand in for.
+    const gap = Math.abs(((south.parallacticDeg - north.parallacticDeg + 540) % 360) - 180);
+    expect(gap).toBeGreaterThan(90);
+  });
+
+  it("reports the Moon below the horizon when it is", () => {
+    // Denton local noon — the Moon is on the far side of the planet.
+    const { altitudeDeg } = getMoonSkyAngles(
+      new Date("2026-08-21T17:00:00Z"),
+      DENTON.lat,
+      DENTON.lon
+    );
+    expect(altitudeDeg).toBeLessThan(0);
+  });
+
+  it("keeps q in (-180, 180] and altitude in [-90, 90]", () => {
+    for (let h = 0; h < 24 * 40; h++) {
+      const { parallacticDeg, altitudeDeg } = getMoonSkyAngles(
+        new Date(Date.UTC(2026, 0, 1) + h * 3600000),
+        DENTON.lat,
+        DENTON.lon
+      );
+      expect(parallacticDeg).toBeGreaterThan(-180.0001);
+      expect(parallacticDeg).toBeLessThanOrEqual(180);
+      expect(Math.abs(altitudeDeg)).toBeLessThanOrEqual(90);
+    }
+  });
+});

--- a/test/astronomy/solar-position.test.ts
+++ b/test/astronomy/solar-position.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   computeNextTransitionTime,
   computeSolarElevationDeg,
+  getLocalHourInstant,
   getLocalTimeInZone,
   getSkyMode,
 } from "../../src/astronomy/solar-position.js";
@@ -181,5 +182,74 @@ describe("computeNextTransitionTime", () => {
     const result = computeNextTransitionTime(0, 0, date);
     expect(result).not.toBeNull();
     expect(result.toMode).toBe("Day");
+  });
+});
+
+describe("getLocalHourInstant", () => {
+  const CHICAGO = "America/Chicago";
+
+  it("finds 22:00 on the local calendar day containing the given instant", () => {
+    // 2026-08-21 15:00 UTC is 10:00 CDT the same day; 22:00 CDT is 03:00 UTC on the 22nd.
+    const result = getLocalHourInstant(new Date("2026-08-21T15:00:00Z"), CHICAGO, 22);
+    expect(result.toISOString()).toBe("2026-08-22T03:00:00.000Z");
+  });
+
+  it("stays on the local day even when UTC has already rolled over", () => {
+    // 2026-08-22 02:00 UTC is still 21:00 CDT on the 21st, so 22:00 is an hour away.
+    const result = getLocalHourInstant(new Date("2026-08-22T02:00:00Z"), CHICAGO, 22);
+    expect(result.toISOString()).toBe("2026-08-22T03:00:00.000Z");
+  });
+
+  it("rolls to the next local day once local midnight passes", () => {
+    // 2026-08-22 05:30 UTC is 00:30 CDT on the 22nd — the reference jumps a day forward.
+    const result = getLocalHourInstant(new Date("2026-08-22T05:30:00Z"), CHICAGO, 22);
+    expect(result.toISOString()).toBe("2026-08-23T03:00:00.000Z");
+  });
+
+  // Two passes over the zone offset exist for exactly these days: the offset at the instant
+  // we are asking *from* is not always the offset at the instant we are asking *for*.
+  it("uses the daylight offset in force at the target hour, not at the query time", () => {
+    // 2026-03-08 is the US spring-forward. At 08:00 UTC the zone is still CST (UTC-6),
+    // but by 22:00 local it is CDT (UTC-5), so the answer is 03:00 UTC not 04:00.
+    const result = getLocalHourInstant(new Date("2026-03-08T08:00:00Z"), CHICAGO, 22);
+    expect(result.toISOString()).toBe("2026-03-09T03:00:00.000Z");
+  });
+
+  it("uses the standard offset after the autumn transition", () => {
+    // 2026-11-01 is the US fall-back: 22:00 CST (UTC-6) is 04:00 UTC on the 2nd.
+    const result = getLocalHourInstant(new Date("2026-11-01T18:00:00Z"), CHICAGO, 22);
+    expect(result.toISOString()).toBe("2026-11-02T04:00:00.000Z");
+  });
+
+  it("falls back to UTC for an unknown timezone", () => {
+    const result = getLocalHourInstant(new Date("2026-08-21T15:00:00Z"), "Not/AZone", 22);
+    expect(result.toISOString()).toBe("2026-08-21T22:00:00.000Z");
+  });
+
+  it("normalises hour value 24 to 0 (engine-quirk branch)", () => {
+    // Same engine quirk getLocalTimeInZone guards against: some engines report midnight as
+    // '24'. Left unnormalised it would roll the offset a day out.
+    // Only the first offset pass is mocked; the second reads the real UTC formatter, so the
+    // assertion still exercises the two-pass path rather than the quirk twice over.
+    vi.spyOn(Intl.DateTimeFormat.prototype, "formatToParts").mockReturnValueOnce([
+      { type: "year", value: "2026" },
+      { type: "month", value: "08" },
+      { type: "day", value: "21" },
+      { type: "hour", value: "24" },
+      { type: "minute", value: "00" },
+      { type: "second", value: "00" },
+    ]);
+    const result = getLocalHourInstant(new Date("2026-08-21T00:00:00Z"), "UTC", 22);
+    expect(result.toISOString()).toBe("2026-08-21T22:00:00.000Z");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("handles the fixed-offset zones a location override produces", () => {
+    // Etc/GMT+6 is UTC-6 (POSIX sign inversion) — what offsetZoneFromLongitude yields.
+    const result = getLocalHourInstant(new Date("2026-08-21T15:00:00Z"), "Etc/GMT+6", 22);
+    expect(result.toISOString()).toBe("2026-08-22T04:00:00.000Z");
   });
 });

--- a/test/card/card-config.test.ts
+++ b/test/card/card-config.test.ts
@@ -16,8 +16,10 @@ describe("parseCardConfig", () => {
       locationOverride: null,
       locationNameOverride: null,
       heightStyle: "",
-      galleryMode: "closed",
-      gallerySources: ["moon"],
+      galleryMode: "off",
+      galleryPosition: "overlay",
+      galleryShape: "square",
+      gallerySources: ["mymoon", "moon", "earth", "sun"],
       galleryIntervalMs: 60000,
     });
   });
@@ -157,53 +159,99 @@ describe("parseCardConfig", () => {
       expect(parseCardConfig({ gallery: { mode: "open" } }).galleryMode).toBe("open");
       expect(parseCardConfig({ gallery: { mode: "slide" } }).galleryMode).toBe("slide");
     });
-    it("falls back to 'closed' for an unrecognised mode", () => {
-      expect(parseCardConfig({ gallery: { mode: "bogus" } }).galleryMode).toBe("closed");
+    it("falls back to 'off' for an unrecognised mode", () => {
+      expect(parseCardConfig({ gallery: { mode: "bogus" } }).galleryMode).toBe("off");
+    });
+    it("accepts 'off'", () => {
+      expect(parseCardConfig({ gallery: { mode: "off" } }).galleryMode).toBe("off");
+    });
+
+    describe("position", () => {
+      it("puts the strip below the solar view when asked", () => {
+        expect(parseCardConfig({ gallery: { position: "below" } }).galleryPosition).toBe("below");
+      });
+      it("overlays by default and for anything unrecognised", () => {
+        expect(parseCardConfig({}).galleryPosition).toBe("overlay");
+        expect(parseCardConfig({ gallery: { position: "bogus" } }).galleryPosition).toBe("overlay");
+      });
+    });
+
+    describe("shape", () => {
+      it("crops to the body when asked for circle", () => {
+        expect(parseCardConfig({ gallery: { shape: "circle" } }).galleryShape).toBe("circle");
+      });
+      it("shows the published frame by default and for anything unrecognised", () => {
+        expect(parseCardConfig({}).galleryShape).toBe("square");
+        expect(parseCardConfig({ gallery: { shape: "round" } }).galleryShape).toBe("square");
+      });
     });
 
     describe("sources", () => {
-      it("keeps recognised sources in the order given", () => {
+      it("keeps recognised sources in the order given — order is the layout", () => {
         expect(
-          parseCardConfig({ gallery: { sources: ["sun", "moon", "earth"] } }).gallerySources
-        ).toEqual(["sun", "moon", "earth"]);
+          parseCardConfig({ gallery: { sources: ["sun", "drawnmoon", "mymoon"] } }).gallerySources
+        ).toEqual(["sun", "drawnmoon", "mymoon"]);
       });
+
       it("drops unknown entries and de-duplicates, keeping first position", () => {
         expect(
-          parseCardConfig({ gallery: { sources: ["moon", "mars", "earth", "moon"] } })
-            .gallerySources
-        ).toEqual(["moon", "earth"]);
+          parseCardConfig({
+            gallery: { sources: ["moon", "hubble-mars", "sun", "moon"] },
+          }).gallerySources
+        ).toEqual(["moon", "sun"]);
       });
-      it("falls back to ['moon'] when nothing valid remains", () => {
-        expect(parseCardConfig({ gallery: { sources: ["mars"] } }).gallerySources).toEqual([
+
+      it("falls back to the fetched sources when nothing valid remains", () => {
+        const fetched = ["mymoon", "moon", "earth", "sun"];
+        expect(parseCardConfig({ gallery: { sources: ["hubble-mars"] } }).gallerySources).toEqual(
+          fetched
+        );
+        expect(parseCardConfig({ gallery: { sources: [] } }).gallerySources).toEqual(fetched);
+        expect(
+          parseCardConfig({ gallery: { sources: "moon" as unknown as string[] } }).gallerySources
+        ).toEqual(fetched);
+      });
+
+      // drawnmoon is opt-in by name: a diagram does not belong in a strip of photographs
+      // unless it was asked for.
+      it("leaves drawnmoon out of the default set", () => {
+        expect(parseCardConfig({}).gallerySources).not.toContain("drawnmoon");
+        expect(parseCardConfig({ gallery: { sources: ["drawnmoon"] } }).gallerySources).toEqual([
+          "drawnmoon",
+        ]);
+      });
+
+      // Source names gained their instrument in this version. A #140 dashboard should keep
+      // showing the same bodies rather than silently reverting to the default set.
+      it("maps the pre-instrument names onto their sources", () => {
+        expect(
+          parseCardConfig({ gallery: { sources: ["moon", "earth", "sun"] } }).gallerySources
+        ).toEqual(["moon", "earth", "sun"]);
+      });
+
+      it("de-duplicates across the old and new spelling of one source", () => {
+        expect(parseCardConfig({ gallery: { sources: ["moon", "moon"] } }).gallerySources).toEqual([
           "moon",
         ]);
-        expect(parseCardConfig({ gallery: { sources: [] } }).gallerySources).toEqual(["moon"]);
-        expect(
-          parseCardConfig({ gallery: { sources: "earth" as unknown as string[] } }).gallerySources
-        ).toEqual(["moon"]);
       });
     });
 
-    // Pre-#140 configs used a single `mode` string that conflated presentation with source
-    // selection. Without this mapping they would fail the mode check and silently fall back
-    // to the default, quietly changing what an existing dashboard shows.
+    // Two older generations of `mode` values. The pre-#140 names picked sources as well as
+    // presentation; #140's "closed" is this version's "off". Without this mapping they would
+    // fail the mode check and silently fall back to the default.
     describe("legacy mode strings", () => {
       it.each([
-        ["none", "closed", ["moon"]],
-        ["earth", "open", ["earth"]],
-        ["sun", "open", ["sun"]],
-        ["both", "open", ["earth", "sun"]],
-        ["slide", "slide", ["earth", "sun"]],
-      ])("maps %s to %s with %j", (legacy, mode, sources) => {
-        const parsed = parseCardConfig({ gallery: { mode: legacy } });
-        expect(parsed.galleryMode).toBe(mode);
-        expect(parsed.gallerySources).toEqual(sources);
+        ["none", "off"],
+        ["closed", "off"],
+        ["earth", "open"],
+        ["sun", "open"],
+        ["both", "open"],
+      ])("maps %s to %s", (legacy, mode) => {
+        expect(parseCardConfig({ gallery: { mode: legacy } }).galleryMode).toBe(mode);
       });
 
-      it("an explicit sources list wins over a legacy mode's implied sources", () => {
-        const parsed = parseCardConfig({ gallery: { mode: "both", sources: ["moon"] } });
-        expect(parsed.galleryMode).toBe("open");
-        expect(parsed.gallerySources).toEqual(["moon"]);
+      it("leaves slide alone — it means the same thing it always did", () => {
+        expect(parseCardConfig({ gallery: { mode: "slide" } }).galleryMode).toBe("slide");
       });
     });
     it("converts slide_interval_secs to milliseconds", () => {

--- a/test/card/card-template.test.ts
+++ b/test/card/card-template.test.ts
@@ -5,6 +5,7 @@ import {
   buildMoonTitle,
   buildStatusBar,
   buildStatusBarView,
+  discStyle,
   formatDate,
 } from "../../src/card/card-template.js";
 import type { SourceDebugStats } from "../../src/card/gallery/debug.js";
@@ -154,6 +155,62 @@ describe("buildStatusBar", () => {
   });
 });
 
+describe("discStyle", () => {
+  const SOURCES = ["moon", "mymoon", "earth", "sun"] as const;
+
+  // The invariant the two numbers exist to satisfy. clip-path resolves in the element's own
+  // coordinates and transform applies to the result, so clip radius x scale must land exactly
+  // on 50% — any more and the circle escapes the tile, which is the overflow that put the
+  // rotated sky frame over the status bar in the first place.
+  it.each(SOURCES)("clips %s so the scaled circle exactly fills the tile", (source) => {
+    const style = discStyle(source, "circle");
+    const radius = Number(/circle\((\d+(?:\.\d+)?)%\)/.exec(style)?.[1]);
+    const scale = Number(/scale\((\d+(?:\.\d+)?)\)/.exec(style)?.[1]);
+    // Not exact: both numbers are rounded for legible CSS output. 0.2% of a 104px tile is a
+    // fifth of a pixel — tight enough to catch a decoupled pair, loose enough for rounding.
+    expect(Math.abs(radius * scale - 50)).toBeLessThan(0.2);
+  });
+
+  // Each source leaves a different margin around its body, so a single shared constant would
+  // either crop a limb or leave a black ring.
+  it("scales each source by its own measured disc fraction", () => {
+    const scaleOf = (source: (typeof SOURCES)[number]) =>
+      Number(/scale\((\d+(?:\.\d+)?)\)/.exec(discStyle(source, "circle"))?.[1]);
+    // Earth is framed much more loosely by DSCOVR than the Moon is by SVS.
+    expect(scaleOf("earth")).toBeGreaterThan(scaleOf("moon"));
+    expect(scaleOf("sun")).toBeGreaterThan(scaleOf("moon"));
+    // Never enough to crop: every source's body fits inside its own frame.
+    for (const source of SOURCES) expect(scaleOf(source)).toBeLessThan(1.3);
+  });
+
+  it("folds the sky rotation in ahead of the scale, and omits it otherwise", () => {
+    expect(discStyle("mymoon", "circle", 17.1)).toContain("transform: rotate(17.1deg) scale(");
+    expect(discStyle("mymoon", "circle", 0)).not.toContain("rotate");
+  });
+
+  describe("square", () => {
+    it("leaves the published frame untouched", () => {
+      for (const source of SOURCES) expect(discStyle(source, "square")).toBe("");
+    });
+
+    // The one exception, and it is not cosmetic: an unclipped rotated square sweeps its
+    // corners out of the tile and over the status bar.
+    it("still clips the sky tile, because it rotates", () => {
+      expect(discStyle("mymoon", "square", 17.1)).toBe(
+        "clip-path: circle(50%); transform: rotate(17.1deg)"
+      );
+    });
+
+    it("clips less than circle mode does, so more of the frame survives", () => {
+      const radius = (style: string) =>
+        Number(/circle\((\d+(?:\.\d+)?)%\)/.exec(style)?.[1] ?? "0");
+      expect(radius(discStyle("mymoon", "square", 17.1))).toBeGreaterThan(
+        radius(discStyle("mymoon", "circle", 17.1))
+      );
+    });
+  });
+});
+
 describe("buildImageStatusBar", () => {
   const now = new Date("2026-08-12T12:00:00Z");
 
@@ -177,6 +234,26 @@ describe("buildImageStatusBar", () => {
     );
     expect(root.querySelector(".status-bar span").textContent).toBe(
       "EARTH · DSCOVR · captured 26-08-11 06:00 · 30h ago"
+    );
+  });
+
+  // The Moon tiles are renders, not photographs, and the sky one is normally for an hour
+  // that has not happened yet — so it takes both a different verb and a forward tense.
+  it("says 'rendered' for the geocentric moon", () => {
+    const root = renderToDOM(
+      buildImageStatusBar("moon", "26-08-12 11:00", new Date("2026-08-12T11:00:00Z"), now, true)
+    );
+    expect(root.querySelector(".status-bar span").textContent).toBe(
+      "MOON · NASA SVS · rendered 26-08-12 11:00 · 1h ago"
+    );
+  });
+
+  it("points the sky moon forwards, at the hour it was rendered for", () => {
+    const root = renderToDOM(
+      buildImageStatusBar("mymoon", "26-08-13 03:00", new Date("2026-08-13T03:00:00Z"), now, true)
+    );
+    expect(root.querySelector(".status-bar span").textContent).toBe(
+      "MOON · NASA SVS · rendered for 26-08-13 03:00 · in 15h"
     );
   });
 

--- a/test/card/card.gallery.test.ts
+++ b/test/card/card.gallery.test.ts
@@ -4,6 +4,38 @@ import { getSunImageUrl } from "../../src/card/gallery/source-resolver-sdo-sun.j
 import { UrlCache } from "../../src/card/gallery/url-cache.js";
 import { clickButton, createAndMount, setupCardTest, stubImagePreload } from "./helpers.js";
 
+// Fails the first decode whose URL matches, and only that one. The strip resolves four
+// sources concurrently now, so a positional stub can no longer name one of them.
+function hangDecodeFor(urlFragment) {
+  vi.stubGlobal(
+    "Image",
+    class {
+      src = "";
+      decode() {
+        // Never settles — simulates a hung image load, but only for the source under test.
+        return this.src.includes(urlFragment) ? new Promise(() => {}) : Promise.resolve();
+      }
+    }
+  );
+}
+
+function failFirstDecodeFor(urlFragment) {
+  let failed = false;
+  vi.stubGlobal(
+    "Image",
+    class {
+      src = "";
+      decode() {
+        if (!failed && this.src.includes(urlFragment)) {
+          failed = true;
+          return Promise.reject(new Error("decode failed"));
+        }
+        return Promise.resolve();
+      }
+    }
+  );
+}
+
 setupCardTest();
 
 // The image gallery: strip, panel, source resolution, retries, and its own auto-switch timer.
@@ -47,74 +79,242 @@ describe("SolarViewCard gallery", () => {
       card.remove();
     });
 
-    it("opening the default gallery shows a moon tile and fetches nothing", async () => {
-      const fetchMock = vi.fn();
-      vi.stubGlobal("fetch", fetchMock);
+    it("opening the default gallery shows the whole strip", async () => {
       const card = document.createElement("ha-planetary-solar-system-card-test");
       document.body.appendChild(card);
       clickButton(card, "gallery");
       await flush();
 
-      const tiles = card.shadowRoot.querySelectorAll(".gallery > *");
-      expect(tiles.length).toBe(1);
-      expect(tiles[0].getAttribute("data-source")).toBe("moon");
-      expect(tiles[0].querySelector("svg.moon-phase-disc")).toBeTruthy();
-      expect(fetchMock).not.toHaveBeenCalled();
+      const tiles = [...card.shadowRoot.querySelectorAll(".gallery > *")];
+      expect(tiles.map((t) => t.getAttribute("data-source"))).toEqual([
+        "mymoon",
+        "moon",
+        "earth",
+        "sun",
+      ]);
       card.remove();
     });
 
-    it("gives the moon tile a tooltip, like the NASA tiles have", () => {
+    // The drawn disc is a diagram, not a photograph — opt-in by name, and debug: true has
+    // nothing to do with it now that it is a source like any other.
+    it("shows the drawn moon disc only when listed in sources", async () => {
+      const card = createAndMount({ gallery: { mode: "open" }, debug: true });
+      expect(card.shadowRoot.querySelector("svg.moon-phase-disc")).toBeNull();
+      card.remove();
+
+      const listed = createAndMount({ gallery: { mode: "open", sources: ["drawnmoon"] } });
+      const drawn = listed.shadowRoot.querySelector('[data-source="drawnmoon"]');
+      expect(drawn).toBeTruthy();
+      expect(drawn.querySelector("svg.moon-phase-disc")).toBeTruthy();
+      listed.remove();
+    });
+
+    // Position is the user's, not ours: sources[0] renders leftmost whatever it is.
+    it("renders tiles in the order sources lists them", () => {
+      const card = createAndMount({
+        gallery: { mode: "open", sources: ["sun", "drawnmoon", "mymoon"] },
+      });
+      const order = [...card.shadowRoot.querySelectorAll(".gallery > *")].map((t) =>
+        t.getAttribute("data-source")
+      );
+      expect(order).toEqual(["sun", "drawnmoon", "mymoon"]);
+      card.remove();
+    });
+
+    it("gives the drawn tile a tooltip", () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date("2024-01-25T18:00:00Z")); // Full Moon
-      const card = createAndMount({ gallery: { mode: "open", sources: ["moon"] } });
-      expect(card.shadowRoot.querySelector('[data-source="moon"]').getAttribute("title")).toBe(
+      const card = createAndMount({ gallery: { mode: "open", sources: ["drawnmoon"] } });
+      expect(card.shadowRoot.querySelector('[data-source="drawnmoon"]').getAttribute("title")).toBe(
         "Tonight's Moon — Full Moon, 100% illuminated"
       );
       card.remove();
       vi.useRealTimers();
     });
 
-    it("the moon tile is not clickable — there is no full-screen moon", () => {
-      const card = createAndMount({ gallery: { mode: "open", sources: ["moon"] } });
-      const tile = card.shadowRoot.querySelector('[data-source="moon"]');
-      expect(tile.tagName).toBe("DIV");
+    // Every NASA tile opens full-screen, including both moons — they are fetched images now,
+    // so the pointer affordance promises something a click can actually deliver.
+    it("makes every strip tile a button", () => {
+      const card = createAndMount({ gallery: { mode: "open" } });
+      const tiles = [...card.shadowRoot.querySelectorAll(".gallery > *")];
+      expect(tiles.map((t) => t.tagName)).toEqual(["BUTTON", "BUTTON", "BUTTON", "BUTTON"]);
+      // Order matters: the drawn debug plate leads the strip when it is present.
       card.remove();
     });
 
-    it("captions the moon tile with MOON and the phase for the displayed date", () => {
+    // The sky tile is the only one that can say the body it shows is not in view. That is not
+    // a failure and not a dark Moon — the frame still shows a normally lit one — it means the
+    // Earth is in the way from here, which is true on roughly half of all nights at every
+    // latitude. Denton on 8 Sep 2026: the Moon is 35 degrees below the horizon at 22:00 local.
+    // Note the caption describes the *reference hour*, not the moment the card is rendered.
+    it("says so when the Moon is below the horizon at the reference hour", () => {
       vi.useFakeTimers();
-      vi.setSystemTime(new Date("2024-01-25T18:00:00Z")); // Full Moon
-      const card = createAndMount({ gallery: { mode: "open", sources: ["moon"] } });
-      const info = card.shadowRoot.querySelector('[data-source="moon"] .gallery-info');
-      expect(info.querySelector(".gallery-label").textContent).toBe("MOON");
-      expect(info.querySelector(".gallery-age").textContent).toBe("Full Moon");
+      vi.setSystemTime(new Date("2026-09-08T20:00:00Z")); // 15:00 CDT the same local day
+      const card = document.createElement("ha-planetary-solar-system-card-test");
+      card.setConfig({
+        gallery: { mode: "open" },
+        location: { latitude: 33.2148, longitude: -97.1331, timezone: "America/Chicago" },
+      });
+      document.body.appendChild(card);
+      card._render();
+      expect(card.shadowRoot.querySelector('[data-source="mymoon"] .gallery-age').textContent).toBe(
+        "below horizon"
+      );
       card.remove();
       vi.useRealTimers();
     });
 
+    // Same location, a reference hour the Moon is actually up for: the caption goes back to
+    // pointing at 22:00 instead.
+    it("counts towards the reference hour when the Moon will be up", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-08-22T01:00:00Z")); // 20:00 CDT, Moon up at 22:00
+      const card = document.createElement("ha-planetary-solar-system-card-test");
+      card.setConfig({
+        gallery: { mode: "open" },
+        location: { latitude: 33.2148, longitude: -97.1331, timezone: "America/Chicago" },
+      });
+      document.body.appendChild(card);
+      card._render();
+      expect(card.shadowRoot.querySelector('[data-source="mymoon"] .gallery-age').textContent).toBe(
+        "in 2h"
+      );
+      card.remove();
+      vi.useRealTimers();
+    });
+
+    // Every fetched tile is cropped to the body itself, so the frame's black surround drops
+    // out and the card shows through. Only the sky tile also rotates — that rotation is what
+    // makes it the observer's view rather than NASA's, so the two moons must not match.
+    it("crops every fetched tile to the disc, and rotates only the sky one", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-08-22T01:00:00Z"));
+      const card = document.createElement("ha-planetary-solar-system-card-test");
+      card.setConfig({
+        gallery: { mode: "open", shape: "circle" },
+        location: { latitude: 33.2148, longitude: -97.1331, timezone: "America/Chicago" },
+      });
+      document.body.appendChild(card);
+      card._render();
+      const styleOf = (source) =>
+        card.shadowRoot.querySelector(`[data-source="${source}"] img`).getAttribute("style");
+      for (const source of ["mymoon", "moon", "earth", "sun"]) {
+        expect(styleOf(source)).toMatch(/^clip-path: circle\(\d+(\.\d+)?%\); transform: /);
+      }
+      expect(styleOf("mymoon")).toMatch(/rotate\(-?\d+(\.\d+)?deg\) scale\(/);
+      expect(styleOf("moon")).toMatch(/transform: scale\(/);
+      expect(styleOf("moon")).not.toContain("rotate");
+      card.remove();
+      vi.useRealTimers();
+    });
+
+    // Thumbnails are 216 px; the full-screen view is the same frame at 730. Swapping the size
+    // segment keeps the panel on the exact frame the tile showed.
+    it("opens the moon full-screen at the larger resolution", async () => {
+      const card = createAndMount({ gallery: { mode: "open" } });
+      await flush();
+      card.shadowRoot.querySelector('[data-source="moon"]').click();
+      await flush();
+      const src = card.shadowRoot.querySelector("#image-view").getAttribute("src");
+      expect(src).toContain("730x730_1x1_30p");
+      expect(src).not.toContain("216x216");
+      card.remove();
+    });
+
+    // Opening the sky tile must not snap back to the geocentric frame.
+    it("carries the sky rotation into the full-screen view", async () => {
+      const card = createAndMount({
+        gallery: { mode: "open" },
+        location: { latitude: 33.2148, longitude: -97.1331, timezone: "America/Chicago" },
+      });
+      await flush();
+      card.shadowRoot.querySelector('[data-source="mymoon"]').click();
+      await flush();
+      expect(card.shadowRoot.querySelector("#image-view").getAttribute("style")).toMatch(
+        /transform: rotate\(-?\d+(\.\d+)?deg\)/
+      );
+      card.remove();
+    });
+
+    // gallery.shape flips the whole strip between the cropped body and the published frame.
+    it("shows the published frame when gallery.shape is square", () => {
+      const card = createAndMount({ gallery: { mode: "open", shape: "square" } });
+      const styleOf = (source) =>
+        card.shadowRoot.querySelector(`[data-source="${source}"] img`).getAttribute("style");
+      for (const source of ["moon", "earth", "sun"]) {
+        expect(styleOf(source)).toBeNull();
+      }
+      card.remove();
+    });
+
+    // The sky tile's own frame cannot survive rotation, so in square mode the tile supplies the
+    // black square instead and the image is clipped to a circle inside it. Net effect: it is
+    // framed exactly like its neighbours, with a rotated body inside.
+    it("boxes the sky tile in square mode so it matches its neighbours", () => {
+      const card = createAndMount({
+        gallery: { mode: "open", shape: "square" },
+        location: { latitude: 33.2148, longitude: -97.1331, timezone: "America/Chicago" },
+      });
+      const classOf = (source) =>
+        card.shadowRoot.querySelector(`[data-source="${source}"]`).className;
+      expect(classOf("mymoon")).toContain("gallery-thumb-boxed");
+      expect(classOf("moon")).not.toContain("gallery-thumb-boxed");
+      card.remove();
+    });
+
+    // Circle mode needs no backdrop: every tile is cropped to its body, so there is no square
+    // for the sky tile to match.
+    it("does not box the sky tile in circle mode", () => {
+      const card = createAndMount({
+        gallery: { mode: "open", shape: "circle" },
+        location: { latitude: 33.2148, longitude: -97.1331, timezone: "America/Chicago" },
+      });
+      expect(card.shadowRoot.querySelector('[data-source="mymoon"]').className).not.toContain(
+        "gallery-thumb-boxed"
+      );
+      card.remove();
+    });
+
+    it("keeps the sky tile's image clipped even in square mode", () => {
+      const card = createAndMount({
+        gallery: { mode: "open", shape: "square" },
+        location: { latitude: 33.2148, longitude: -97.1331, timezone: "America/Chicago" },
+      });
+      const style = card.shadowRoot
+        .querySelector('[data-source="mymoon"] img')
+        .getAttribute("style");
+      expect(style).toContain("clip-path: circle(50%)");
+      expect(style).toMatch(/rotate\(-?\d+(\.\d+)?deg\)/);
+      expect(style).not.toContain("scale");
+      card.remove();
+    });
+
+    it("labels the two moon tiles apart", () => {
+      const card = createAndMount({ gallery: { mode: "open" } });
+      const labelOf = (source) =>
+        card.shadowRoot.querySelector(`[data-source="${source}"] .gallery-label`).textContent;
+      expect(labelOf("moon")).toBe("MOON");
+      expect(labelOf("mymoon")).toBe("MY SKY");
+      card.remove();
+    });
+
     // The caption is what makes the tiles read as one strip. Comparing the shapes rather
     // than eyeballing each one means a future divergence fails here instead of shipping.
+    // Order is load-bearing now: the caption is a centred column, so the label span is the
+    // line above the body and the age span the line below it.
     it("gives every tile the same caption structure", () => {
       const card = createAndMount({
-        gallery: { mode: "open", sources: ["moon", "earth", "sun"] },
+        gallery: {
+          mode: "open",
+          sources: ["drawnmoon", "mymoon", "moon", "earth", "sun"],
+        },
       });
       const shapes = [...card.shadowRoot.querySelectorAll(".gallery-info")].map((info) =>
         [...info.children].map((el) => `${el.tagName}.${el.className}`)
       );
-      expect(shapes).toHaveLength(3);
+      expect(shapes).toHaveLength(5);
       expect(new Set(shapes.map((s) => s.join(","))).size).toBe(1);
       expect(shapes[0]).toEqual(["SPAN.gallery-label", "SPAN.gallery-age"]);
-      card.remove();
-    });
-
-    it("renders tiles in the configured sources order", () => {
-      const card = createAndMount({
-        gallery: { mode: "open", sources: ["sun", "moon", "earth"] },
-      });
-      const order = [...card.shadowRoot.querySelectorAll(".gallery > *")].map((t) =>
-        t.getAttribute("data-source")
-      );
-      expect(order).toEqual(["sun", "moon", "earth"]);
       card.remove();
     });
 
@@ -125,28 +325,28 @@ describe("SolarViewCard gallery", () => {
       card.remove();
     });
 
-    it("shows 2 thumbnails (EARTH, SUN) as soon as the card connects", async () => {
+    it("shows all four thumbnails as soon as the card connects", async () => {
       stubEarthFetch();
       const card = mountWithGallery();
       await flush();
-      const thumbs = card.shadowRoot.querySelectorAll(".gallery-thumb");
-      expect(thumbs.length).toBe(2);
-      expect(Array.from(thumbs).map((t) => t.dataset.source)).toEqual(["earth", "sun"]);
-      const labels = Array.from(thumbs).map((t) => t.querySelector(".gallery-label").textContent);
-      expect(labels).toEqual(["DSCOVR/E", "SDO/S"]);
+      const thumbs = [...card.shadowRoot.querySelectorAll(".gallery-thumb")];
+      expect(thumbs.map((t) => t.dataset.source)).toEqual(["mymoon", "moon", "earth", "sun"]);
+      const labels = thumbs.map((t) => t.querySelector(".gallery-label").textContent);
+      expect(labels).toEqual(["MY SKY", "MOON", "DSCOVR/E", "SDO/S"]);
 
       // Each candidate is preloaded off-DOM before it's ever assigned to the thumbnail, so
       // by the time the fetch/preload chain settles the age is already known — no separate
-      // on-<img> "load" event needed.
-      const ages = Array.from(thumbs).map((t) => t.querySelector(".gallery-age").textContent);
-      for (const age of ages) {
-        expect(age).toMatch(/^(\d+[mh] ago|just now)$/);
+      // on-<img> "load" event needed. The sky tile is the one that can point forwards, at
+      // 22:00 local, or say the Moon is not up at all.
+      for (const thumb of thumbs) {
+        const age = thumb.querySelector(".gallery-age").textContent;
+        expect(age).toMatch(/^(in \d+[mh]|\d+[mh] ago|just now|below horizon)$/);
       }
       card.remove();
     });
 
     it("a sun thumbnail preload failure retries the previous 15-min slot once", async () => {
-      stubImagePreload(false, true);
+      failFirstDecodeFor("sdo.gsfc.nasa.gov");
       const card = mountWithGallery();
       await flush();
 
@@ -232,7 +432,7 @@ describe("SolarViewCard gallery", () => {
     });
 
     it("opens on the retried slot when the primary sun candidate fails to preload", async () => {
-      stubImagePreload(false, true);
+      failFirstDecodeFor("sdo.gsfc.nasa.gov");
       const card = mountWithGallery();
       // The background fetch retries once and lands before the click — clicking then just
       // displays what it already resolved.
@@ -549,20 +749,11 @@ describe("SolarViewCard gallery", () => {
     it("falls back to the solar view with a visible error when the earth image load hangs past the timeout", async () => {
       vi.useFakeTimers();
       stubEarthFetch();
-      vi.stubGlobal(
-        "Image",
-        class {
-          src = "";
-          decode() {
-            return new Promise(() => {}); // never settles — simulates a hung image load
-          }
-        }
-      );
-      // gallery.mode: "earth" keeps this isolated to earth's own timeout — "both" would
-      // also hang sun's preload (same stubbed Image), which retries up to SUN_MAX_RETRIES
-      // times and so needs several more 15s waits before the shared Promise.allSettled in
-      // _refreshImageSources settles, unrelated to what this test is checking.
-      const card = mountWithGallery({ gallery: { mode: "earth" } });
+      // Hangs earth's preload only. The strip fetches every source now, so hanging all of
+      // them would also stall sun through SUN_MAX_RETRIES worth of 15s waits before the
+      // shared Promise.allSettled settles — unrelated to what this test is checking.
+      hangDecodeFor("epic.gsfc.nasa.gov");
+      const card = mountWithGallery();
       await vi.advanceTimersByTimeAsync(0);
       card.shadowRoot.querySelector('.gallery-thumb[data-source="earth"]').click();
       await vi.advanceTimersByTimeAsync(15000); // FETCH_TIMEOUT_MS in source-resolver.ts
@@ -645,25 +836,23 @@ describe("SolarViewCard gallery", () => {
       card.remove();
     });
 
-    it("gallery.mode: earth shows only the earth thumbnail and fetches only earth", async () => {
-      const fetchMock = stubEarthFetch();
-      const card = mountWithGallery({ gallery: { mode: "earth" } });
-      await flush();
-      const thumbs = card.shadowRoot.querySelectorAll(".gallery-thumb");
-      expect(Array.from(thumbs).map((t) => t.dataset.source)).toEqual(["earth"]);
-      expect(fetchMock).toHaveBeenCalled();
-      card.remove();
-    });
-
-    it("gallery.mode: sun shows only the sun thumbnail and never calls fetch", async () => {
-      const fetchMock = stubEarthFetch();
-      const card = mountWithGallery({ gallery: { mode: "sun" } });
-      await flush();
-      const thumbs = card.shadowRoot.querySelectorAll(".gallery-thumb");
-      expect(Array.from(thumbs).map((t) => t.dataset.source)).toEqual(["sun"]);
-      expect(fetchMock).not.toHaveBeenCalled();
-      card.remove();
-    });
+    // The legacy source-picking modes still open the strip, they just no longer prune it —
+    // an unmigrated dashboard gains the tiles it never asked for rather than breaking.
+    it.each(["earth", "sun", "both"])(
+      "legacy gallery.mode: %s opens the whole strip",
+      async (mode) => {
+        const card = mountWithGallery({ gallery: { mode } });
+        await flush();
+        const thumbs = card.shadowRoot.querySelectorAll(".gallery-thumb");
+        expect([...thumbs].map((t) => t.dataset.source)).toEqual([
+          "mymoon",
+          "moon",
+          "earth",
+          "sun",
+        ]);
+        card.remove();
+      }
+    );
 
     it("gallery strip refreshes the sun thumbnail every 15 minutes, not 1 hour", async () => {
       vi.useFakeTimers();
@@ -688,12 +877,12 @@ describe("SolarViewCard gallery", () => {
       expect(fetchMock).toHaveBeenCalled(); // both sources fetched in the background
       let thumbs = card.shadowRoot.querySelectorAll(".gallery-thumb");
       expect(thumbs.length).toBe(1);
-      expect(thumbs[0].dataset.source).toBe("earth");
+      expect(thumbs[0].dataset.source).toBe("mymoon");
 
       await vi.advanceTimersByTimeAsync(120 * 1000);
       thumbs = card.shadowRoot.querySelectorAll(".gallery-thumb");
       expect(thumbs.length).toBe(1);
-      expect(thumbs[0].dataset.source).toBe("sun");
+      expect(thumbs[0].dataset.source).toBe("moon");
 
       card.remove();
       vi.useRealTimers();
@@ -706,19 +895,19 @@ describe("SolarViewCard gallery", () => {
 
       card.setConfig({ gallery: { mode: "slide", slide_interval_secs: 180 } });
       await vi.advanceTimersByTimeAsync(120 * 1000); // past the old interval, before the new one
-      expect(card.shadowRoot.querySelector(".gallery-thumb").dataset.source).toBe("earth");
+      expect(card.shadowRoot.querySelector(".gallery-thumb").dataset.source).toBe("mymoon");
 
       await vi.advanceTimersByTimeAsync(60000); // now past the new 3-min interval
-      expect(card.shadowRoot.querySelector(".gallery-thumb").dataset.source).toBe("sun");
+      expect(card.shadowRoot.querySelector(".gallery-thumb").dataset.source).toBe("moon");
 
-      await vi.advanceTimersByTimeAsync(180 * 1000); // flips back
+      await vi.advanceTimersByTimeAsync(180 * 1000); // flips again
       expect(card.shadowRoot.querySelector(".gallery-thumb").dataset.source).toBe("earth");
 
       card.remove();
       vi.useRealTimers();
     });
 
-    // Legacy "none" maps to {closed, [moon]}: the strip stays shut, so the background
+    // Legacy "none" maps to "off": the strip stays shut, so the background
     // refresh has nothing to fetch — the whole point of leaving it collapsed by default.
     it("a collapsed gallery never fetches, however long it ticks", async () => {
       vi.useFakeTimers();

--- a/test/card/card.status-bar.test.ts
+++ b/test/card/card.status-bar.test.ts
@@ -158,14 +158,16 @@ describe("SolarViewCard status bar", () => {
       card.remove();
     });
 
-    it("shows sun/earth rows with cumulative stats when debug is true", async () => {
+    it("shows a row per source with cumulative stats when debug is true", async () => {
       const card = createAndMount({ debug: true, gallery: { mode: "both" } });
       await vi.waitFor(() => expect(card._gallery.debugStats.sun.elapsed).not.toBeNull());
       card._render();
       const overlay = card.shadowRoot.querySelector(".debug-overlay");
       const rowText = [...overlay.querySelectorAll("tr")].map((tr) => tr.textContent);
-      expect(rowText[1]).toContain("SDO/S");
-      expect(rowText[2]).toContain("DSCOVR/E");
+      expect(rowText[1]).toContain("SVS/M sky");
+      expect(rowText[2]).toContain("SVS/M obj");
+      expect(rowText[3]).toContain("SDO/S");
+      expect(rowText[4]).toContain("DSCOVR/E");
       expect(overlay.textContent).toContain("source");
       expect(overlay.textContent).toContain("refresh");
       expect(overlay.textContent).toContain("fetch");

--- a/test/card/gallery/backoff-integration.test.ts
+++ b/test/card/gallery/backoff-integration.test.ts
@@ -64,9 +64,10 @@ describe("gallery backoff integration", () => {
     await vi.advanceTimersByTimeAsync(6 * 3600000);
 
     expect(imageAttempts).toBeGreaterThan(attemptsAfterMount); // it did keep trying...
-    expect(imageAttempts).toBeLessThan(50); // ...but nowhere near the ~1440 a naive
-    // per-tick retry (primary + SUN_MAX_RETRIES fallbacks, every one of the 360 ticks)
-    // would have produced
+    expect(imageAttempts).toBeLessThan(80); // ...but nowhere near the ~2500 a naive per-tick
+    // retry would have produced: four sources probing on every one of the 360 ticks, sun
+    // costing its primary guess plus SUN_MAX_RETRIES fallbacks each time. Each source backs
+    // off on its own cooldown, so the ceiling scales with source count, not tick count.
     expect(urlCache.inCooldown("sun")).toBe(true); // still backed off at the end of the outage
 
     card.remove();

--- a/test/card/gallery/debug.test.ts
+++ b/test/card/gallery/debug.test.ts
@@ -23,6 +23,8 @@ function renderToDOM(result) {
 
 describe("buildDebugOverlay", () => {
   const stats = {
+    moon: zeroDebugStats,
+    mymoon: zeroDebugStats,
     "earth-url": zeroDebugStats,
     "earth-img": zeroDebugStats,
     sun: {
@@ -82,6 +84,10 @@ describe("buildDebugOverlay", () => {
     const rows = root.querySelectorAll("tbody tr, table tr");
     const cells = [...rows].slice(1).map((row) => [...row.children].map((td) => td.textContent));
     expect(cells).toEqual([
+      // Neither moon row can retry either: every frame of the year is pre-published, so an
+      // earlier one is never a better guess (see source-resolver-svs-moon.ts).
+      ["SVS/M sky", "0", "0", "0", "0", "0", "—", "—", "—"],
+      ["SVS/M obj", "0", "0", "0", "0", "0", "—", "—", "—"],
       ["SDO/S", "4", "2", "5", "3", "1", "2", "123ms", "5m"],
       // Neither earth row can retry (only sun's resolver ever does) — retry shows "—".
       ["DSCOVR/E url", "0", "0", "0", "0", "0", "—", "—", "—"],
@@ -96,17 +102,21 @@ describe("buildDebugOverlay", () => {
 
   it("shows seconds in the last column under a minute, not a floored 'just now'", () => {
     const recent = {
+      moon: zeroDebugStats,
+      mymoon: zeroDebugStats,
       "earth-url": zeroDebugStats,
       "earth-img": zeroDebugStats,
       sun: { ...zeroDebugStats, lastAttemptAt: Date.now() - 45_000 },
     };
     const root = renderToDOM(buildDebugOverlay(recent, Date.now()));
-    const sunRow = [...root.querySelectorAll("table tr")[1].children].map((td) => td.textContent);
+    const sunRow = [...root.querySelectorAll("table tr")[3].children].map((td) => td.textContent);
     expect(sunRow[sunRow.length - 1]).toBe("45s");
   });
 
   it("sums the total row's refreshes with max() instead of add(), for lockstep both/slide modes", () => {
     const lockstep = {
+      moon: zeroDebugStats,
+      mymoon: zeroDebugStats,
       sun: { ...zeroDebugStats, refreshes: 5, elapsed: 100 },
       "earth-url": { ...zeroDebugStats, refreshes: 5, elapsed: 200 },
       "earth-img": zeroDebugStats,

--- a/test/card/gallery/gallery-controller.test.ts
+++ b/test/card/gallery/gallery-controller.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { GalleryController } from "../../../src/card/gallery/gallery-controller.js";
+import {
+  DEFAULT_GALLERY_SOURCES,
+  GalleryController,
+} from "../../../src/card/gallery/gallery-controller.js";
 import { urlCache } from "../../../src/card/gallery/url-cache.js";
 
 // Every fetch path preloads a candidate off-DOM via `new Image()` before ever assigning it,
@@ -15,6 +18,25 @@ function stubImagePreload(...results: boolean[]) {
         const succeeds = results.length ? results[Math.min(calls, results.length - 1)] : true;
         calls++;
         return succeeds ? Promise.resolve() : Promise.reject(new Error("decode failed"));
+      }
+    }
+  );
+}
+
+// Fails the first decode whose URL matches, and only that one — the four sources resolve
+// concurrently, so "the first decode overall" is no longer a way to name one of them.
+function failFirstDecodeFor(urlFragment: string) {
+  let failed = false;
+  vi.stubGlobal(
+    "Image",
+    class {
+      src = "";
+      decode() {
+        if (!failed && this.src.includes(urlFragment)) {
+          failed = true;
+          return Promise.reject(new Error("decode failed"));
+        }
+        return Promise.resolve();
       }
     }
   );
@@ -42,11 +64,13 @@ afterEach(() => {
 
 describe("GalleryController defaults", () => {
   it("starts closed with no panel and no known images", () => {
-    const gallery = new GalleryController(() => {});
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
     expect(gallery.isOpen).toBe(false);
     expect(gallery.panelMode).toBe("none");
-    expect(gallery.mode).toBe("closed");
-    expect(gallery.sources).toEqual(["moon"]);
+    expect(gallery.mode).toBe("off");
     expect(gallery.images).toEqual({});
   });
 });
@@ -56,17 +80,23 @@ describe("GalleryController remount", () => {
   // start with no known URL, so the URL-identity gate always missed on its first tick and
   // forced a redundant preload/decode of bytes each source's own cache already held.
   it("hydrates known images from each source's cache instead of starting empty", async () => {
-    const first = new GalleryController(() => {});
-    first.configure("open", ["earth", "sun"], 60000);
+    const first = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    first.configure("open", DEFAULT_GALLERY_SOURCES, 60000);
     first.start();
     await vi.waitFor(() => expect(first.images.earth).toBeDefined());
     await vi.waitFor(() => expect(first.images.sun).toBeDefined());
 
-    const remounted = new GalleryController(() => {});
+    const remounted = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
     expect(remounted.images.earth?.url).toBe(first.images.earth?.url);
     expect(remounted.images.sun?.url).toBe(first.images.sun?.url);
 
-    remounted.configure("open", ["earth", "sun"], 60000);
+    remounted.configure("open", DEFAULT_GALLERY_SOURCES, 60000);
     remounted.start();
     await Promise.resolve();
     await Promise.resolve();
@@ -80,57 +110,82 @@ describe("GalleryController remount", () => {
 });
 
 describe("GalleryController.configure", () => {
-  it("opens for open/slide, stays collapsed for closed", () => {
-    const gallery = new GalleryController(() => {});
-    gallery.configure("open", ["earth", "sun"], 60000);
+  it("opens for open/slide, stays collapsed for off", () => {
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    gallery.configure("open", DEFAULT_GALLERY_SOURCES, 60000);
     expect(gallery.isOpen).toBe(true);
-    gallery.configure("closed", ["moon"], 60000);
+    gallery.configure("off", DEFAULT_GALLERY_SOURCES, 60000);
     expect(gallery.isOpen).toBe(false);
-    gallery.configure("slide", ["earth", "sun"], 60000);
+    gallery.configure("slide", DEFAULT_GALLERY_SOURCES, 60000);
     expect(gallery.isOpen).toBe(true);
   });
 
-  it("displaySources is the configured list, in the configured order", () => {
-    const gallery = new GalleryController(() => {});
-    gallery.configure("open", ["earth"], 60000);
-    expect(gallery.displaySources).toEqual(["earth"]);
-    gallery.configure("open", ["sun", "moon", "earth"], 60000);
-    expect(gallery.displaySources).toEqual(["sun", "moon", "earth"]);
+  // The strip is fixed now: sky Moon, object Moon, Earth, Sun, in that order. `gallery.sources`
+  // is gone, so there is no configuration that can change this.
+  it("displaySources is the whole strip, in render order", () => {
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    gallery.configure("open", DEFAULT_GALLERY_SOURCES, 60000);
+    expect(gallery.displaySources).toEqual(["mymoon", "moon", "earth", "sun"]);
   });
 });
 
-describe("GalleryController moon source", () => {
-  it("shows moon as a thumbnail without ever fetching it", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve([]) });
-    vi.stubGlobal("fetch", fetchMock);
-    const gallery = new GalleryController(() => {});
-    gallery.configure("open", ["moon"], 60000);
+describe("GalleryController moon sources", () => {
+  it("fetches both moon tiles alongside earth and sun", async () => {
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    gallery.configure("open", DEFAULT_GALLERY_SOURCES, 60000);
     gallery.start();
-    expect(gallery.viewModel().thumbnails.map((t) => t.source)).toEqual(["moon"]);
-    expect(fetchMock).not.toHaveBeenCalled();
-    expect(gallery.images).toEqual({});
+    await vi.waitFor(() => expect(gallery.images.moon).toBeDefined());
+    await vi.waitFor(() => expect(gallery.images.mymoon).toBeDefined());
+    expect(gallery.images.moon?.url).toContain("svs.gsfc.nasa.gov");
   });
 
-  it("fetches only the network sources when moon sits alongside them", async () => {
-    const gallery = new GalleryController(() => {});
-    gallery.configure("open", ["moon", "earth"], 60000);
+  // Same NASA product, different instants — the object tile follows the current hour, the sky
+  // tile pins to 22:00 local — so each holds its own cache entry rather than sharing one.
+  it("gives each moon tile its own image entry", async () => {
+    const gallery = new GalleryController(
+      () => {},
+      () => "America/Chicago"
+    );
+    gallery.configure("open", DEFAULT_GALLERY_SOURCES, 60000);
     gallery.start();
-    await vi.waitFor(() => expect(gallery.images.earth).toBeDefined());
-    expect(gallery.images.sun).toBeUndefined();
-    expect(gallery.images.moon as unknown).toBeUndefined();
+    await vi.waitFor(() => expect(gallery.images.moon).toBeDefined());
+    await vi.waitFor(() => expect(gallery.images.mymoon).toBeDefined());
+    expect(gallery.images.mymoon?.date).not.toEqual(gallery.images.moon?.date);
   });
 
-  it("carries no url or date on the moon thumbnail", () => {
-    const gallery = new GalleryController(() => {});
-    gallery.configure("open", ["moon"], 60000);
-    expect(gallery.viewModel().thumbnails).toEqual([{ source: "moon", url: null, date: null }]);
+  it("carries url and date onto both moon thumbnails once resolved", async () => {
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    gallery.configure("open", DEFAULT_GALLERY_SOURCES, 60000);
+    gallery.start();
+    await vi.waitFor(() => expect(gallery.images.moon).toBeDefined());
+    const tiles = gallery.viewModel().thumbnails;
+    for (const source of ["moon", "mymoon"]) {
+      const tile = tiles.find((t) => t.source === source);
+      expect(tile?.url).toBeTruthy();
+      expect(tile?.date).toBeInstanceOf(Date);
+    }
   });
 });
 
 describe("GalleryController.start / tick", () => {
   it("fetches every source the mode needs when started open", async () => {
-    const gallery = new GalleryController(() => {});
-    gallery.configure("open", ["earth", "sun"], 60000);
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    gallery.configure("open", DEFAULT_GALLERY_SOURCES, 60000);
     gallery.start();
     await vi.waitFor(() => expect(gallery.images.earth).toBeDefined());
     expect(gallery.images.sun).toBeDefined();
@@ -139,15 +194,21 @@ describe("GalleryController.start / tick", () => {
   it("does not fetch when started closed", () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve([]) });
     vi.stubGlobal("fetch", fetchMock);
-    const gallery = new GalleryController(() => {});
-    gallery.configure("closed", ["moon"], 60000);
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    gallery.configure("off", DEFAULT_GALLERY_SOURCES, 60000);
     gallery.start();
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("tick refreshes only while open", async () => {
-    const gallery = new GalleryController(() => {});
-    gallery.configure("open", ["earth"], 60000);
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    gallery.configure("open", DEFAULT_GALLERY_SOURCES, 60000);
     gallery.tick();
     await vi.waitFor(() => expect(gallery.images.earth).toBeDefined());
   });
@@ -155,8 +216,11 @@ describe("GalleryController.start / tick", () => {
   it("tick is a no-op while closed", () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve([]) });
     vi.stubGlobal("fetch", fetchMock);
-    const gallery = new GalleryController(() => {});
-    gallery.configure("closed", ["moon"], 60000);
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    gallery.configure("off", DEFAULT_GALLERY_SOURCES, 60000);
     gallery.tick();
     expect(fetchMock).not.toHaveBeenCalled();
   });
@@ -164,8 +228,11 @@ describe("GalleryController.start / tick", () => {
 
 describe("GalleryController.toggle", () => {
   it("opening clears any error and triggers a refresh", async () => {
-    const gallery = new GalleryController(() => {});
-    gallery.configure("open", ["earth"], 60000);
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    gallery.configure("open", DEFAULT_GALLERY_SOURCES, 60000);
     gallery.toggle(); // configure() opens by default; close first
     expect(gallery.isOpen).toBe(false);
     gallery.toggle(); // reopen
@@ -174,8 +241,11 @@ describe("GalleryController.toggle", () => {
   });
 
   it("closing closes any open panel", () => {
-    const gallery = new GalleryController(() => {});
-    gallery.configure("open", ["earth"], 60000);
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    gallery.configure("open", DEFAULT_GALLERY_SOURCES, 60000);
     gallery.toggle(); // closes
     expect(gallery.isOpen).toBe(false);
     expect(gallery.panelMode).toBe("none");
@@ -184,8 +254,11 @@ describe("GalleryController.toggle", () => {
 
 describe("GalleryController.openPanel / closePanel", () => {
   it("shows instantly when the source is already known", async () => {
-    const gallery = new GalleryController(() => {});
-    gallery.configure("open", ["earth"], 60000);
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    gallery.configure("open", DEFAULT_GALLERY_SOURCES, 60000);
     gallery.start();
     await vi.waitFor(() => expect(gallery.images.earth).toBeDefined());
 
@@ -196,8 +269,11 @@ describe("GalleryController.openPanel / closePanel", () => {
   });
 
   it("fetches when the source isn't known yet", async () => {
-    const gallery = new GalleryController(() => {});
-    gallery.configure("open", ["earth"], 60000); // open, but start() not called — nothing fetched yet
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    gallery.configure("open", DEFAULT_GALLERY_SOURCES, 60000); // open, but start() not called — nothing fetched yet
     gallery.openPanel("earth");
     expect(gallery.panelMode).toBe("earth");
     expect(gallery.imageLoaded).toBe(false);
@@ -205,8 +281,11 @@ describe("GalleryController.openPanel / closePanel", () => {
   });
 
   it("closePanel resets panel state", () => {
-    const gallery = new GalleryController(() => {});
-    gallery.configure("open", ["earth"], 60000);
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    gallery.configure("open", DEFAULT_GALLERY_SOURCES, 60000);
     gallery.openPanel("earth");
     gallery.closePanel();
     expect(gallery.panelMode).toBe("none");
@@ -217,14 +296,20 @@ describe("GalleryController.openPanel / closePanel", () => {
 
 describe("GalleryController image event handlers", () => {
   it("onImageLoad marks the current image loaded", () => {
-    const gallery = new GalleryController(() => {});
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
     gallery.onImageLoad();
     expect(gallery.imageLoaded).toBe(true);
   });
 
   it("onImageLoadError surfaces the error banner and closes the panel", () => {
-    const gallery = new GalleryController(() => {});
-    gallery.configure("open", ["earth"], 60000);
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    gallery.configure("open", DEFAULT_GALLERY_SOURCES, 60000);
     gallery.openPanel("earth");
     gallery.onImageLoadError();
     expect(gallery.panelMode).toBe("none");
@@ -232,14 +317,20 @@ describe("GalleryController image event handlers", () => {
   });
 
   it("onImageLoadError is a no-op when no panel is open", () => {
-    const gallery = new GalleryController(() => {});
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
     gallery.onImageLoadError();
     expect(gallery.error).toBeNull();
   });
 
   it("onSunThumbError drops the sun thumbnail", async () => {
-    const gallery = new GalleryController(() => {});
-    gallery.configure("open", ["sun"], 60000);
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    gallery.configure("open", DEFAULT_GALLERY_SOURCES, 60000);
     gallery.start();
     await vi.waitFor(() => expect(gallery.images.sun).toBeDefined());
     gallery.onSunThumbError();
@@ -250,8 +341,11 @@ describe("GalleryController image event handlers", () => {
 describe("GalleryController failed fetch", () => {
   it("surfaces the error banner when the open panel's source fails to resolve", async () => {
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
-    const gallery = new GalleryController(() => {});
-    gallery.configure("open", ["earth"], 60000);
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    gallery.configure("open", DEFAULT_GALLERY_SOURCES, 60000);
     gallery.openPanel("earth");
     await vi.waitFor(() => expect(gallery.panelMode).toBe("none"));
     expect(gallery.error).toContain("unavailable");
@@ -261,52 +355,57 @@ describe("GalleryController failed fetch", () => {
 describe("GalleryController slide auto-switch", () => {
   it("flips the displayed source on each interval while mode is slide", async () => {
     vi.useFakeTimers();
-    const gallery = new GalleryController(() => {});
-    gallery.configure("slide", ["earth", "sun"], 1000);
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    gallery.configure("slide", DEFAULT_GALLERY_SOURCES, 1000);
     gallery.start();
-    expect(gallery.displaySources).toEqual(["earth"]);
+    expect(gallery.displaySources).toEqual(["mymoon"]);
     await vi.advanceTimersByTimeAsync(1000);
-    expect(gallery.displaySources).toEqual(["sun"]);
+    expect(gallery.displaySources).toEqual(["moon"]);
   });
 
-  it("rotates through every configured source, moon included, and wraps", async () => {
+  it("rotates through the whole strip and wraps", async () => {
     vi.useFakeTimers();
-    const gallery = new GalleryController(() => {});
-    gallery.configure("slide", ["moon", "earth", "sun"], 1000);
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    gallery.configure("slide", DEFAULT_GALLERY_SOURCES, 1000);
     gallery.start();
-    expect(gallery.displaySources).toEqual(["moon"]);
-    await vi.advanceTimersByTimeAsync(1000);
-    expect(gallery.displaySources).toEqual(["earth"]);
-    await vi.advanceTimersByTimeAsync(1000);
-    expect(gallery.displaySources).toEqual(["sun"]);
-    await vi.advanceTimersByTimeAsync(1000);
-    expect(gallery.displaySources).toEqual(["moon"]);
+    const seen = [gallery.displaySources[0]];
+    for (let i = 0; i < 4; i++) {
+      await vi.advanceTimersByTimeAsync(1000);
+      seen.push(gallery.displaySources[0]);
+    }
+    expect(seen).toEqual(["mymoon", "moon", "earth", "sun", "mymoon"]);
   });
 
-  it("a single configured source has nothing to rotate to", async () => {
-    vi.useFakeTimers();
-    const gallery = new GalleryController(() => {});
-    gallery.configure("slide", ["moon"], 1000);
-    gallery.start();
-    await vi.advanceTimersByTimeAsync(3000);
-    expect(gallery.displaySources).toEqual(["moon"]);
-  });
-
+  // Reconfiguring to a shorter list while the rotation sits past its new end would leave
+  // displaySources reading undefined until the next tick happened to wrap it.
   it("reconfiguring a shorter list cannot leave the slide index out of bounds", async () => {
     vi.useFakeTimers();
-    const gallery = new GalleryController(() => {});
-    gallery.configure("slide", ["moon", "earth", "sun"], 1000);
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    gallery.configure("slide", DEFAULT_GALLERY_SOURCES, 1000);
     gallery.start();
     await vi.advanceTimersByTimeAsync(2000);
-    expect(gallery.displaySources).toEqual(["sun"]);
+    expect(gallery.displaySources).toEqual(["earth"]);
+
     gallery.configure("slide", ["moon"], 1000);
     expect(gallery.displaySources).toEqual(["moon"]);
   });
 
   it("stop() clears the auto-switch interval", async () => {
     vi.useFakeTimers();
-    const gallery = new GalleryController(() => {});
-    gallery.configure("slide", ["earth", "sun"], 1000);
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    gallery.configure("slide", DEFAULT_GALLERY_SOURCES, 1000);
     gallery.start();
     gallery.stop();
     const before = gallery.displaySources;
@@ -316,10 +415,13 @@ describe("GalleryController slide auto-switch", () => {
 
   it("reconfiguring away from slide stops future auto-switches", async () => {
     vi.useFakeTimers();
-    const gallery = new GalleryController(() => {});
-    gallery.configure("slide", ["earth", "sun"], 1000);
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    gallery.configure("slide", DEFAULT_GALLERY_SOURCES, 1000);
     gallery.start();
-    gallery.configure("open", ["earth"], 1000);
+    gallery.configure("open", DEFAULT_GALLERY_SOURCES, 1000);
     const before = gallery.displaySources;
     await vi.advanceTimersByTimeAsync(5000);
     expect(gallery.displaySources).toEqual(before);
@@ -327,8 +429,11 @@ describe("GalleryController slide auto-switch", () => {
 
   it("switching onto a source never re-resolves its URL from cache/network", async () => {
     vi.useFakeTimers();
-    const gallery = new GalleryController(() => {});
-    gallery.configure("slide", ["earth", "sun"], 1000);
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    gallery.configure("slide", DEFAULT_GALLERY_SOURCES, 1000);
     gallery.start();
     await vi.advanceTimersByTimeAsync(0);
     expect(gallery.images.sun).toBeDefined();
@@ -336,24 +441,31 @@ describe("GalleryController slide auto-switch", () => {
 
     // The slide timer flips displaySources purely as a local state change — it never touches
     // the resolver, so cacheHits stays exactly where refresh() left it.
+    const before = gallery.displaySources;
     await vi.advanceTimersByTimeAsync(1000);
-    expect(gallery.displaySources).toEqual(["sun"]);
+    expect(gallery.displaySources).not.toEqual(before);
     expect(gallery.debugStats.sun.cacheHits).toBe(cacheHitsAfterFetch);
   });
 });
 
 describe("GalleryController.viewModel", () => {
   it("reflects the error state", () => {
-    const gallery = new GalleryController(() => {});
-    gallery.configure("open", ["earth"], 60000);
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    gallery.configure("open", DEFAULT_GALLERY_SOURCES, 60000);
     gallery.openPanel("earth");
     (gallery as unknown as { _error: string | null })._error = "Earth image unavailable";
     expect(gallery.viewModel().error).toBe("Earth image unavailable");
   });
 
   it("reflects no panel open, strip closed", () => {
-    const gallery = new GalleryController(() => {});
-    gallery.configure("open", ["earth"], 60000);
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    gallery.configure("open", DEFAULT_GALLERY_SOURCES, 60000);
     gallery.toggle(); // configure() opens by default; close it
     const vm = gallery.viewModel();
     expect(vm.error).toBeNull();
@@ -361,17 +473,23 @@ describe("GalleryController.viewModel", () => {
   });
 
   it("reflects an open strip with no panel", () => {
-    const gallery = new GalleryController(() => {});
-    gallery.configure("open", ["earth", "sun"], 60000);
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    gallery.configure("open", DEFAULT_GALLERY_SOURCES, 60000);
     const vm = gallery.viewModel();
     expect(vm.showStrip).toBe(true);
     expect(vm.panelSource).toBe("none");
-    expect(vm.thumbnails.map((t) => t.source)).toEqual(["earth", "sun"]);
+    expect(vm.thumbnails.map((t) => t.source)).toEqual(["mymoon", "moon", "earth", "sun"]);
   });
 
   it("reflects an open panel with image data, and hides the strip", async () => {
-    const gallery = new GalleryController(() => {});
-    gallery.configure("open", ["earth", "sun"], 60000);
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    gallery.configure("open", DEFAULT_GALLERY_SOURCES, 60000);
     gallery.openPanel("earth");
     await vi.waitFor(() => expect(gallery.imageLoaded).toBe(true));
     const vm = gallery.viewModel();
@@ -382,19 +500,29 @@ describe("GalleryController.viewModel", () => {
     expect(vm.showStrip).toBe(false);
   });
 
-  it("thumbnails carry url/date from images for sources not yet fetched", () => {
-    const gallery = new GalleryController(() => {});
-    gallery.configure("open", ["sun"], 60000);
-    const vm = gallery.viewModel();
-    expect(vm.thumbnails).toEqual([{ source: "sun", url: null, date: null }]);
+  it("thumbnails carry null url/date for sources not yet fetched", () => {
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    gallery.configure("open", DEFAULT_GALLERY_SOURCES, 60000);
+    expect(gallery.viewModel().thumbnails).toEqual([
+      { source: "mymoon", url: null, date: null },
+      { source: "moon", url: null, date: null },
+      { source: "earth", url: null, date: null },
+      { source: "sun", url: null, date: null },
+    ]);
   });
 
   it("hides the strip while collapsed but still reports its thumbnails", () => {
-    const gallery = new GalleryController(() => {});
-    gallery.configure("closed", ["moon"], 60000);
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    gallery.configure("off", DEFAULT_GALLERY_SOURCES, 60000);
     const vm = gallery.viewModel();
     expect(vm.showStrip).toBe(false);
-    expect(vm.thumbnails.map((t) => t.source)).toEqual(["moon"]);
+    expect(vm.thumbnails.map((t) => t.source)).toEqual(["mymoon", "moon", "earth", "sun"]);
   });
 });
 
@@ -410,9 +538,14 @@ describe("GalleryController.debugStats", () => {
     lastAttemptAt: null,
   };
 
-  it("starts at zero for both sources", () => {
-    const gallery = new GalleryController(() => {});
+  it("starts at zero for every source", () => {
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
     expect(gallery.debugStats).toEqual({
+      moon: zeroStats,
+      mymoon: zeroStats,
       sun: zeroStats,
       "earth-url": zeroStats,
       "earth-img": zeroStats,
@@ -420,8 +553,11 @@ describe("GalleryController.debugStats", () => {
   });
 
   it("gates the image preload on URL identity, skipping it once the URL is unchanged", async () => {
-    const gallery = new GalleryController(() => {});
-    gallery.configure("open", ["earth", "sun"], 60000);
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    gallery.configure("open", DEFAULT_GALLERY_SOURCES, 60000);
     gallery.start();
     await vi.waitFor(() => expect(gallery.images.earth).toBeDefined());
 
@@ -466,8 +602,11 @@ describe("GalleryController.debugStats", () => {
         })
       )
     );
-    const gallery = new GalleryController(() => {});
-    gallery.configure("open", ["earth"], 60000);
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    gallery.configure("open", DEFAULT_GALLERY_SOURCES, 60000);
     gallery.start();
     await vi.waitFor(() => expect(gallery.debugStats["earth-url"].refreshes).toBe(1));
 
@@ -486,8 +625,11 @@ describe("GalleryController.debugStats", () => {
 
   it("counts a failed image preload as a fetch distinct from the EPIC API call", async () => {
     stubImagePreload(false);
-    const gallery = new GalleryController(() => {});
-    gallery.configure("open", ["earth"], 60000);
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    gallery.configure("open", DEFAULT_GALLERY_SOURCES, 60000);
     gallery.start();
     await vi.waitFor(() => expect(gallery.debugStats["earth-img"].failures).toBe(1));
 
@@ -502,9 +644,12 @@ describe("GalleryController.debugStats", () => {
   });
 
   it("counts a retry when sun's primary slot guess fails and falls back", async () => {
-    stubImagePreload(false, true);
-    const gallery = new GalleryController(() => {});
-    gallery.configure("open", ["sun"], 60000);
+    failFirstDecodeFor("sdo.gsfc.nasa.gov");
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    gallery.configure("open", DEFAULT_GALLERY_SOURCES, 60000);
     gallery.start();
     await vi.waitFor(() => expect(gallery.debugStats.sun.retries).toBe(1));
 
@@ -512,11 +657,18 @@ describe("GalleryController.debugStats", () => {
     expect(gallery.debugStats.sun.failures).toBe(1);
   });
 
-  it("does not count sources outside the configured mode", async () => {
-    const gallery = new GalleryController(() => {});
-    gallery.configure("open", ["earth"], 60000);
+  // Every source is fetched now, including while "slide" shows one at a time — rotating onto
+  // a tile must never be the moment its image starts loading.
+  it("counts a refresh for every source, even the ones slide mode is not showing", async () => {
+    const gallery = new GalleryController(
+      () => {},
+      () => "UTC"
+    );
+    gallery.configure("slide", DEFAULT_GALLERY_SOURCES, 60000);
     gallery.start();
     await vi.waitFor(() => expect(gallery.debugStats["earth-url"].refreshes).toBe(1));
-    expect(gallery.debugStats.sun.refreshes).toBe(0);
+    expect(gallery.debugStats.sun.refreshes).toBe(1);
+    expect(gallery.debugStats.moon.refreshes).toBe(1);
+    expect(gallery.debugStats.mymoon.refreshes).toBe(1);
   });
 });

--- a/test/card/gallery/source-resolver-svs-moon.test.ts
+++ b/test/card/gallery/source-resolver-svs-moon.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { emptyDebugAccumulator } from "../../../src/card/gallery/debug.js";
+import {
+  fullSizeMoonUrl,
+  getMoonFrameImage,
+  MOON_FRAME_MS,
+  MOON_FULL_SIZE,
+  MOON_PRODUCT_IDS,
+  MOON_THUMB_SIZE,
+  moonFrameUrl,
+  SVS_BASE_URL,
+  SvsMoonResolver,
+} from "../../../src/card/gallery/source-resolver-svs-moon.js";
+import { UrlCache } from "../../../src/card/gallery/url-cache.js";
+
+function stubImageDecode(succeeds = true) {
+  vi.stubGlobal(
+    "Image",
+    class {
+      src = "";
+      decode() {
+        return succeeds ? Promise.resolve() : Promise.reject(new Error("decode failed"));
+      }
+    }
+  );
+}
+
+describe("source-resolver-svs-moon", () => {
+  let cache: UrlCache;
+
+  beforeEach(() => {
+    cache = new UrlCache();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  describe("moonFrameUrl", () => {
+    // Ground truth: every one of these URLs was fetched from NASA and returned 200 with a
+    // real frame. The frame number is the 1-based hour of the year, which is how SVS names
+    // the 8,760 pre-rendered frames of its annual "Moon Phase and Libration" product.
+    const FRAMES: [string, string][] = [
+      ["2026-08-21T12:00:00Z", "moon.5581.jpg"],
+      ["2026-01-05T03:00:00Z", "moon.0100.jpg"],
+      ["2026-12-30T18:00:00Z", "moon.8731.jpg"],
+    ];
+
+    it.each(FRAMES)("names the frame for %s", (utc, filename) => {
+      expect(moonFrameUrl(new Date(utc), MOON_THUMB_SIZE)).toContain(filename);
+    });
+
+    it("uses the first hour of the year for its first instant", () => {
+      expect(moonFrameUrl(new Date("2026-01-01T00:00:00Z"), MOON_THUMB_SIZE)).toContain(
+        "moon.0001.jpg"
+      );
+    });
+
+    it("builds the full SVS path, grouping the product id by hundreds", () => {
+      // Product 5587 (2026) lives under a005500/a005587 — the group is the id floored to 100.
+      expect(moonFrameUrl(new Date("2026-08-21T12:00:00Z"), MOON_THUMB_SIZE)).toBe(
+        `${SVS_BASE_URL}/a005500/a005587/frames/${MOON_THUMB_SIZE}/moon.5581.jpg`
+      );
+    });
+
+    it("serves the same frame at full-screen resolution", () => {
+      expect(moonFrameUrl(new Date("2026-08-21T12:00:00Z"), MOON_FULL_SIZE)).toBe(
+        `${SVS_BASE_URL}/a005500/a005587/frames/${MOON_FULL_SIZE}/moon.5581.jpg`
+      );
+    });
+
+    // Every frame for a mapped year is pre-published, so a miss can only mean the year has no
+    // product constant yet. Failing loudly is the point: SVS answers an out-of-range date with
+    // the last frame of the current product rather than a 404, so a silent fallback would show
+    // a confidently wrong Moon.
+    it("throws for a year with no published product", () => {
+      expect(() => moonFrameUrl(new Date("2019-06-01T00:00:00Z"), MOON_THUMB_SIZE)).toThrow(/2019/);
+    });
+
+    it("maps every product id it knows to a distinct year", () => {
+      const years = Object.keys(MOON_PRODUCT_IDS);
+      const ids = Object.values(MOON_PRODUCT_IDS);
+      expect(new Set(ids).size).toBe(ids.length);
+      expect(years.length).toBeGreaterThanOrEqual(5);
+    });
+  });
+
+  describe("fullSizeMoonUrl", () => {
+    it("swaps the thumbnail resolution for the full-screen one", () => {
+      const thumb = moonFrameUrl(new Date("2026-08-21T12:00:00Z"), MOON_THUMB_SIZE);
+      expect(fullSizeMoonUrl(thumb)).toBe(
+        moonFrameUrl(new Date("2026-08-21T12:00:00Z"), MOON_FULL_SIZE)
+      );
+    });
+
+    // The panel must open the frame the tile was showing, never a freshly computed one — a
+    // click that lands either side of the hour boundary would otherwise change the picture.
+    it("keeps the frame number the thumbnail resolved", () => {
+      const thumb = moonFrameUrl(new Date("2026-03-04T07:00:00Z"), MOON_THUMB_SIZE);
+      expect(fullSizeMoonUrl(thumb)).toContain("moon.1496.jpg");
+    });
+
+    it("leaves a non-moon URL alone", () => {
+      const earth = "https://epic.gsfc.nasa.gov/archive/natural/2026/08/19/jpg/epic_1b_x.jpg";
+      expect(fullSizeMoonUrl(earth)).toBe(earth);
+    });
+  });
+
+  describe("getMoonFrameImage", () => {
+    it("dates the image by the frame's own hour, not the query instant", () => {
+      const { date } = getMoonFrameImage(new Date("2026-08-21T12:42:30Z"));
+      expect(date.toISOString()).toBe("2026-08-21T12:00:00.000Z");
+    });
+  });
+
+  describe("SvsMoonResolver", () => {
+    const NOW = Date.UTC(2026, 7, 21, 12, 42, 30);
+
+    it("resolves the current hour's frame", async () => {
+      vi.spyOn(Date, "now").mockReturnValue(NOW);
+      stubImageDecode();
+      const resolver = new SvsMoonResolver("moon", () => new Date(Date.now()), cache);
+      const image = await resolver.resolve(emptyDebugAccumulator(), emptyDebugAccumulator());
+      expect(image.url).toContain("moon.5581.jpg");
+    });
+
+    // The sky tile asks for a different instant than the object tile, so the two hold their
+    // own cache entries under their own keys rather than fighting over one.
+    it("keeps its own cache entry per source key", async () => {
+      vi.spyOn(Date, "now").mockReturnValue(NOW);
+      stubImageDecode();
+      const object = new SvsMoonResolver("moon", () => new Date(Date.now()), cache);
+      const sky = new SvsMoonResolver("mymoon", () => new Date("2026-08-22T03:00:00Z"), cache);
+      await object.resolve(emptyDebugAccumulator(), emptyDebugAccumulator());
+      await sky.resolve(emptyDebugAccumulator(), emptyDebugAccumulator());
+      expect(cache.getStale("moon")?.url).toContain("moon.5581.jpg");
+      expect(cache.getStale("mymoon")?.url).toContain("moon.5596.jpg");
+    });
+
+    // Freshness is URL identity, so every card holding a frame drops it at the same instant —
+    // the moment the reference time crosses into the next hour — without a TTL to anchor.
+    it("serves from cache until the frame's own hour is over", async () => {
+      vi.spyOn(Date, "now").mockReturnValue(NOW);
+      stubImageDecode();
+      const resolver = new SvsMoonResolver("moon", () => new Date(Date.now()), cache);
+      const debug = emptyDebugAccumulator();
+      await resolver.resolve(debug, emptyDebugAccumulator());
+      const fetchesAfterFirst = debug.fetches;
+
+      vi.spyOn(Date, "now").mockReturnValue(NOW + 10 * 60000); // same hour
+      await resolver.resolve(debug, emptyDebugAccumulator());
+      expect(debug.fetches).toBe(fetchesAfterFirst);
+      expect(debug.cacheHits).toBeGreaterThan(0);
+    });
+
+    it("moves to the next frame once the hour rolls over", async () => {
+      vi.spyOn(Date, "now").mockReturnValue(NOW);
+      stubImageDecode();
+      const resolver = new SvsMoonResolver("moon", () => new Date(Date.now()), cache);
+      await resolver.resolve(emptyDebugAccumulator(), emptyDebugAccumulator());
+
+      vi.spyOn(Date, "now").mockReturnValue(NOW + MOON_FRAME_MS);
+      const next = await resolver.resolve(emptyDebugAccumulator(), emptyDebugAccumulator());
+      expect(next.url).toContain("moon.5582.jpg");
+    });
+
+    // No recover() override: every frame is pre-published, so a failure is not publish lag and
+    // stepping backwards cannot help. It falls into the shared cooldown like any other source.
+    it("propagates a failed decode rather than hunting earlier frames", async () => {
+      vi.spyOn(Date, "now").mockReturnValue(NOW);
+      stubImageDecode(false);
+      const resolver = new SvsMoonResolver("moon", () => new Date(Date.now()), cache);
+      await expect(
+        resolver.resolve(emptyDebugAccumulator(), emptyDebugAccumulator())
+      ).rejects.toThrow();
+    });
+
+    it("hydrates from a still-fresh cache after a remount", async () => {
+      vi.spyOn(Date, "now").mockReturnValue(NOW);
+      stubImageDecode();
+      const first = new SvsMoonResolver("moon", () => new Date(Date.now()), cache);
+      await first.resolve(emptyDebugAccumulator(), emptyDebugAccumulator());
+
+      const remounted = new SvsMoonResolver("moon", () => new Date(Date.now()), cache);
+      expect(remounted.hydrate()?.url).toContain("moon.5581.jpg");
+    });
+  });
+});

--- a/test/card/relative-time.test.ts
+++ b/test/card/relative-time.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatRelativeAge } from "../../src/card/relative-time.js";
+import { formatRelativeAge, formatRelativeWhen } from "../../src/card/relative-time.js";
 
 describe("formatRelativeAge", () => {
   const now = new Date("2026-08-12T12:00:00Z");
@@ -26,5 +26,34 @@ describe("formatRelativeAge", () => {
 
   it("treats a future date as 'just now'", () => {
     expect(formatRelativeAge(new Date("2026-08-12T12:05:00Z"), now)).toBe("just now");
+  });
+});
+
+describe("formatRelativeWhen", () => {
+  const NOW = new Date("2026-08-21T20:00:00Z");
+
+  it("counts down to an instant still ahead", () => {
+    expect(formatRelativeWhen(new Date("2026-08-21T22:00:00Z"), NOW)).toBe("in 2h");
+  });
+
+  it("counts down in minutes inside the last hour", () => {
+    expect(formatRelativeWhen(new Date("2026-08-21T20:30:00Z"), NOW)).toBe("in 30m");
+  });
+
+  it("says just now within a minute either side", () => {
+    expect(formatRelativeWhen(new Date("2026-08-21T20:00:30Z"), NOW)).toBe("just now");
+    expect(formatRelativeWhen(new Date("2026-08-21T19:59:30Z"), NOW)).toBe("just now");
+  });
+
+  it("falls back to the past wording once the instant has gone by", () => {
+    expect(formatRelativeWhen(new Date("2026-08-21T19:00:00Z"), NOW)).toBe("1h ago");
+    expect(formatRelativeWhen(new Date("2026-08-21T19:30:00Z"), NOW)).toBe("30m ago");
+  });
+
+  it("agrees with formatRelativeAge for every past instant", () => {
+    for (const minutes of [1, 5, 59, 60, 61, 300]) {
+      const past = new Date(NOW.getTime() - minutes * 60000);
+      expect(formatRelativeWhen(past, NOW)).toBe(formatRelativeAge(past, NOW));
+    }
   });
 });


### PR DESCRIPTION
Replaces the locally drawn moon disc with NASA's rendered imagery, and adds a second moon tile turned to the observer's own sky.

## Two moon tiles

| Tile | Shows |
| --- | --- |
| `moon` → **MOON** | NASA SVS frame as published: geocentric, celestial north up, identical for everyone |
| `mymoon` → **MY SKY** | the same frame rotated by the parallactic angle for your latitude, longitude and clock, for 22:00 local |

One tile cannot answer both questions. The rotation is the largest error in the old tile: the two-state hemisphere flip it replaces is a 0-or-180 guess at a continuous quantity.

Orientation error against the real sky, every hour of 2026 with the moon above 5°:

| Site | before | after |
| --- | --- | --- |
| Denton, TX | median 48°, max 72° | median 0.05°, max 0.62° |
| Sydney | median 49°, max 71° | median 0.05°, max 0.54° |
| Quito | median 91°, max 180° | median 0.07°, max 5.36° |
| Reykjavík | median 21°, max 30° | median 0.02°, max 0.05° |

`MY SKY` says `below horizon` on the nights the moon is not up at 22:00 — about half of them, at every latitude.

## Astronomy

`moon-phase.ts` cannot supply RA/Dec: its three-term series is tuned for illumination, and leaves up to 6.07° of orientation error against the 19-term series' 0.62°. New coordinates are **of date**, not J2000, since a local hour angle is measured against the true equinox of the moment. Validated against NASA's Dial-a-Moon over dates spanning a year — **0.034° in RA** once precession is accounted for.

## Two constraints worth knowing

1. **SVS's JSON API is CORS-locked** to one hardcoded third-party origin, so `fetch` is blocked from any HA origin. `<img>` is not, so the image still loads — the URL is computed, like the SDO sun tile, rather than looked up.
2. **The annual product id is not derivable** (4955 · 5048 · 5187 · 5415 · 5587). It ships as a constant and needs a row each December. Both moon tiles go blank on 1 January of an unmapped year — which is why the drawn disc survives as `drawnmoon`, opt-in: it is the only moon that needs no network.

## Config

```yaml
gallery:
  mode: open          # off | open | slide
  position: below     # overlay | below
  shape: square       # square | circle
  sources: [mymoon, moon, earth, sun]   # + drawnmoon, opt-in
```

Source names describe what a tile shows, not which instrument produced it — hence `moon`/`mymoon` rather than instrument prefixes. The README records that rule so it is settled for future sources. `moon`, `earth` and `sun` keep the names they already shipped; only `moon` shifts meaning, from the drawn disc to the NASA render. Legacy `mode` values still resolve.

## Scope

Larger than one concern: imagery, astronomy, config surface, and layout. They are entangled through the source-id types, so splitting would have meant an intermediate state that does not typecheck.

## Verification

- 910 tests, 100% coverage (statements, branches, functions, lines), `check:ci` clean
- Ground truth in tests comes from NASA's own API, not from the model under test
- Rendered against live NASA endpoints in headless Chromium and sampled real pixels — across both shapes, both placements, and both themes. The light theme caught two bugs the dark theme hid entirely: captions losing their backdrop, and a UA `<button>` border reappearing.

Bandwidth: both moon tiles together are ~245 KB/day, against ~4.7 MB for the sun tile.

Related: #148 (SDO publish buffer, unrelated to this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)