### PR TITLE
fix: stop sun stall from re-probing every render tick

### DIFF
--- a/src/card/gallery/source-resolver-sdo-sun.ts
+++ b/src/card/gallery/source-resolver-sdo-sun.ts
@@ -91,8 +91,10 @@ export class SdoSunResolver extends SourceResolver {
       if (!found) {
         // Nothing newer than the frame we already hold, so the gap below is known-empty and
         // there is nothing to search. Re-commit it so the TTL entry stops advertising the
-        // guess that just 404'd.
+        // guess that just 404'd, and stamp the check so freshCachedSlot() holds off re-probing
+        // for a full TTL instead of retrying on every tick (#152).
         this.cache.set(this.source, confirmed);
+        this.cache.recordChecked(this.source);
         return confirmed;
       }
     } else {
@@ -122,8 +124,11 @@ export class SdoSunResolver extends SourceResolver {
 
     // Committed once, for the slot that won — an attempt that 404s never touches the shared
     // cache, so a concurrent reader (another refresh() tick racing this search) can never
-    // observe a still-unconfirmed guess.
+    // observe a still-unconfirmed guess. Also the cold-start search's only exit, so it needs
+    // its own stamp here too (#152) — without it, a cold start that lands on an old/stalled
+    // frame settles with no throttle behind it, and the very next tick re-probes from scratch.
     this.cache.set(this.source, found);
+    this.cache.recordChecked(this.source);
     return found;
   }
 }
@@ -141,8 +146,16 @@ function isTimeout(err: unknown): boolean {
 function freshCachedSlot(cache: UrlCache): SourcedImage | null {
   const entry = cache.getEntry("sun");
   if (!entry) return null;
-  const validUntil = entry.image.date.getTime() + SUN_CACHE_TTL_MS + SUN_PUBLISH_BUFFER_MS;
-  return Date.now() < validUntil ? entry.image : null;
+  const slotValidUntil = entry.image.date.getTime() + SUN_CACHE_TTL_MS + SUN_PUBLISH_BUFFER_MS;
+  // A stalled feed keeps confirming the same (older) frame forever, so slotValidUntil alone
+  // never advances and every tick re-probes NASA (#152: two requests/min for hours, no
+  // backoff, since "still nothing newer" is a successful check, not a failure). recover()
+  // stamps lastCheckedAt only for that specific outcome — deliberately not entry.fetchedAt,
+  // which the optimistic getSunImageUrl() guess also writes, at a different moment per card
+  // instance, and which is exactly what #122 already ruled out as an expiry anchor.
+  const lastCheckedAt = cache.getLastCheckedAt("sun") ?? 0;
+  const recheckValidUntil = lastCheckedAt + SUN_CACHE_TTL_MS;
+  return Date.now() < Math.max(slotValidUntil, recheckValidUntil) ? entry.image : null;
 }
 
 export function getSunImageUrl(cache: UrlCache = urlCache): SourcedImage {

--- a/src/card/gallery/url-cache.ts
+++ b/src/card/gallery/url-cache.ts
@@ -29,6 +29,11 @@ export class UrlCache {
   private entries = new Map<string, CacheEntry>();
   private decoded = new Map<string, string>();
   private backoff = new Backoff();
+  // Distinct from `entries.fetchedAt`, which an optimistic guess (getSunImageUrl) also
+  // writes, at a different moment per card instance — using that as a "when did we last
+  // actually check" clock would reintroduce #122's cross-card desync. Only sun's recover()
+  // stamps this, and only for its "still nothing newer" outcome (#152).
+  private lastChecked = new Map<string, number>();
 
   get(key: string, maxAgeMs: number): SourcedImage | null {
     const entry = this.entries.get(key);
@@ -63,6 +68,14 @@ export class UrlCache {
     return this.backoff.inCooldown(key);
   }
 
+  recordChecked(key: string): void {
+    this.lastChecked.set(key, Date.now());
+  }
+
+  getLastCheckedAt(key: string): number | undefined {
+    return this.lastChecked.get(key);
+  }
+
   recordFailure(key: string, retryAfterMs?: number): void {
     this.backoff.recordFailure(key, retryAfterMs);
   }
@@ -75,6 +88,7 @@ export class UrlCache {
     this.entries.clear();
     this.decoded.clear();
     this.backoff.clear();
+    this.lastChecked.clear();
   }
 }
 

--- a/test/card/gallery/source-resolver-sdo-sun.test.ts
+++ b/test/card/gallery/source-resolver-sdo-sun.test.ts
@@ -428,6 +428,30 @@ describe("source-resolver-sdo-sun", () => {
       expect(stalled.calls - afterColdStart).toBe(16);
     });
 
+    it("holds the confirmed frame for a full TTL after a re-check, so getSunImageUrl() skips the network for the next minute of ticks (#152)", async () => {
+      stubArchivePublishedUpTo("2026-08-21T12:30:00.000Z");
+      const resolver = new SdoSunResolver(cache);
+      const debug = emptyDebugAccumulator();
+
+      let now = Date.parse("2026-08-21T20:37:00.000Z");
+      vi.spyOn(Date, "now").mockReturnValue(now);
+      await resolver.resolve(debug, debug); // cold start: confirms 12:30, stamps the check
+      now += 15 * 60000;
+      vi.spyOn(Date, "now").mockReturnValue(now);
+      await resolver.resolve(debug, debug); // re-check: still nothing newer, re-stamps
+
+      const stalled = stubArchivePublishedUpTo("2026-08-21T12:30:00.000Z");
+      // 1-minute ticks, well inside the freshly stamped 15-min window and long past the
+      // slot's own 45-min buffer window — getSunImageUrl() must serve the cache, not probe.
+      for (let tick = 0; tick < 5; tick++) {
+        now += 60000;
+        vi.spyOn(Date, "now").mockReturnValue(now);
+        const image = getSunImageUrl(cache);
+        expect(image.date.toISOString()).toBe("2026-08-21T12:30:00.000Z");
+      }
+      expect(stalled.calls).toBe(0);
+    });
+
     it("catches up to the newest frame in one refresh once the feed recovers", async () => {
       // Creeping forward one slot per tick would take eight hours to recover from an
       // eight-hour stall; bisecting between the confirmed frame and the fresh guess lands on
@@ -450,16 +474,19 @@ describe("source-resolver-sdo-sun", () => {
     });
 
     it("skips the search entirely when the guess is only one slot past the confirmed frame", async () => {
-      vi.spyOn(Date, "now").mockReturnValue(NOW);
+      // The guess at this moment lands exactly on the newest published frame, so the very
+      // first resolve() succeeds directly and never touches recover() — the check that
+      // stamps lastCheckedAt (#152) — leaving the throttle clear for the second call below.
+      vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-08-15T22:15:00.000Z"));
       const archive = stubArchivePublishedUpTo("2026-08-15T21:45:00.000Z");
       const resolver = new SdoSunResolver(cache);
       const debug = emptyDebugAccumulator();
       await resolver.resolve(debug, debug); // confirms 21:45
 
-      // Just past the 22:30 cache hold, the fresh guess is 22:00 — exactly 21:45 plus one
-      // slot. It 404s, and there is no gap left between it and the confirmed frame, so
-      // nothing more is worth asking.
-      vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-08-15T22:32:00.000Z"));
+      // Well past both the 22:30 cache hold and any #152 throttle, the fresh guess is 22:00
+      // — exactly 21:45 plus one slot. It 404s, and there is no gap left between it and the
+      // confirmed frame, so nothing more is worth asking.
+      vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-08-15T22:44:00.000Z"));
       const before = archive.calls;
       const image = await resolver.resolve(debug, debug);
 


### PR DESCRIPTION
## Summary
- A stalled SDO feed's confirmed frame never advances, so `freshCachedSlot()` never went stale-then-fresh again — every render tick re-hit NASA for the newest slot regardless of `refresh_mins` (2 requests/tick, indefinitely, no backoff, since "still nothing newer" is a successful check, not a failure).
- `recover()` now stamps a `lastCheckedAt` time on both its exit paths (cold-start search and the "nothing newer than confirmed" shortcut), and `freshCachedSlot()` honors it as a 15-min throttle layered on top of the existing slot-date one.

## Test plan
- [x] Added regression test: after a re-check settles on "still stalled," `getSunImageUrl()` serves cache for the next 15 min of 1-min ticks with zero network calls.
- [x] `npm run test:coverage` — 938/938 pass, 100% coverage
- [x] `npm run check:ci` — typecheck/lint/format clean