### PR TITLE
fix: normalize gallery tile sizing and captions across shapes

### DIFF
--- a/src/card/card-styles.ts
+++ b/src/card/card-styles.ts
@@ -154,6 +154,10 @@ export const cardStyles = css`
      the same color as .gallery-thumb's backdrop — so a circle-clipped photo on a square black
      tile is pixel-identical to a square-clipped one. The tile itself has to round too for
      gallery.shape: circle to read as anything. */
+  /* .gallery-thumb's black background stays doing double duty: the loading filler before the
+     <img> has a decoded frame, and — once loaded — the thin ring TARGET_FRACTION deliberately
+     leaves outside the disc (see discStyle()) rather than scaling all the way to the tile's
+     own edge. */
   .gallery-thumb-circle {
     border-radius: 50%;
   }
@@ -186,7 +190,9 @@ export const cardStyles = css`
        centred rather than a single row split left/right: once the thumbnails are clipped to
        the body, a full-width row runs off the disc at both ends, and centring on the tile
        centres on the body too — the sources all sit their subject dead centre in frame. */
-    inset: 2px;
+    /* Top pulled down 1px past the other three sides — flush with the tile edge read too
+       cramped against the disc's own limb. */
+    inset: 3px 2px 2px;
     display: flex;
     flex-direction: column;
     justify-content: space-between;
@@ -199,8 +205,12 @@ export const cardStyles = css`
        decided by the element type and the engine's default line-height, which is how the
        moon's caption ended up sitting higher than its neighbours'.
        Scales with the tile (see container-type above) instead of a fixed 8px, so the longest
-       phase name still fits on a narrow card and stays legible on a wide one. */
-    font-size: clamp(6px, 9cqw, 9px);
+       phase name still fits on a narrow card and stays legible on a wide one — same idea as
+       the SVG body labels, which scale with the card because the whole SVG does. The old 9px
+       ceiling stopped the caption growing past a small card's size while the planet labels
+       beside it kept scaling; 40px is a backstop against a pathological giant tile, not a
+       real-world limit — a tile would need to be ~440px wide before 9cqw even reaches it. */
+    font-size: clamp(6px, 9cqw, 40px);
     line-height: 1;
     font-family: sans-serif;
     pointer-events: none;

--- a/src/card/card-template.ts
+++ b/src/card/card-template.ts
@@ -74,10 +74,10 @@ export const IMAGE_SOURCE_LABELS: Record<ImageSource, string> = {
 
 // Labels for the gallery thumbnail strip — the top line of every tile's caption.
 export const GALLERY_SOURCE_LABELS: Record<GallerySource, string> = {
-  mymoon: "MY SKY",
+  mymoon: "MYMOON",
   moon: "MOON",
-  earth: "DSCOVR/E",
-  sun: "SDO/S",
+  earth: "EARTH",
+  sun: "SUN",
   drawnmoon: "DRAWN",
 };
 
@@ -114,20 +114,23 @@ export function buildMoonTitle(date: Date, isLiveMode: boolean): string {
  * the sampled ceiling by much.
  */
 const DISC_FRACTION: Record<ImageSource, number> = {
-  mymoon: 0.963,
-  moon: 0.963,
-  earth: 0.822,
-  sun: 0.943,
+  mymoon: 0.95,
+  moon: 0.95,
+  earth: 0.82,
+  sun: 0.945,
 };
 
 /**
- * Every body renders at this same fraction of its tile, whichever source it is. Without a
- * shared target each source's own frame margin bleeds through at a different size — Earth's
- * loose DSCOVR crop noticeably smaller than the Moon's tight SVS one — which reads as
- * inconsistency rather than as the bodies' real relative sizes. A fixed target and a uniform
- * black ring instead put every tile on equal footing.
+ * Every body renders at this same fraction of its tile, whichever source it is — and whichever
+ * shape: square and circle share this table, so the object is the same on-screen size in both,
+ * only the crop around it (inset square vs round) changes. Without a shared target each
+ * source's own frame margin bleeds through at a different size — Earth's loose DSCOVR crop
+ * noticeably smaller than the Moon's tight SVS one — which reads as inconsistency rather than
+ * as the bodies' real relative sizes. A fixed target and a uniform margin instead put every
+ * tile on equal footing, and staying under 1.0 everywhere leaves a safety margin against
+ * DISC_FRACTION being a sampled ceiling rather than a proven one (see its own comment).
  *
- * Sun gets its own, smaller target rather than sharing the rest's 0.92: Moon and Earth are
+ * Sun gets its own, smaller target rather than sharing the rest's 0.90: Moon and Earth are
  * pinned to their largest measurement (see DISC_FRACTION), so most days show them well under
  * that — genuinely smaller, not just cropped differently, since their distance really varies.
  * The Sun's distance barely does (~3% over a year, against the Moon's ~14%), so it renders at
@@ -135,10 +138,10 @@ const DISC_FRACTION: Record<ImageSource, number> = {
  * it a lower one of its own instead of counting on real-world variance to shrink it for free.
  */
 const TARGET_FRACTION: Record<ImageSource, number> = {
-  mymoon: 0.92,
-  moon: 0.92,
-  earth: 0.92,
-  sun: 0.83,
+  mymoon: 0.89,
+  moon: 0.89,
+  earth: 0.87,
+  sun: 0.8,
 };
 
 /**
@@ -221,8 +224,8 @@ const IMAGE_STATUS_VERB: Record<ImageSource, string> = {
 const IMAGE_STATUS_INSTRUMENT: Record<ImageSource, string> = {
   mymoon: "NASA SVS",
   moon: "NASA SVS",
-  earth: "DSCOVR",
-  sun: "SDO HMI",
+  earth: "NASA DSCOVR",
+  sun: "NASA SDO HMI",
 };
 
 export function buildImageStatusBar(

--- a/test/__snapshots__/snapshot.test.ts.snap
+++ b/test/__snapshots__/snapshot.test.ts.snap
@@ -176,6 +176,10 @@ exports[`cardStyles > matches snapshot 1`] = `
      the same color as .gallery-thumb's backdrop — so a circle-clipped photo on a square black
      tile is pixel-identical to a square-clipped one. The tile itself has to round too for
      gallery.shape: circle to read as anything. */
+  /* .gallery-thumb's black background stays doing double duty: the loading filler before the
+     <img> has a decoded frame, and — once loaded — the thin ring TARGET_FRACTION deliberately
+     leaves outside the disc (see discStyle()) rather than scaling all the way to the tile's
+     own edge. */
   .gallery-thumb-circle {
     border-radius: 50%;
   }
@@ -208,7 +212,9 @@ exports[`cardStyles > matches snapshot 1`] = `
        centred rather than a single row split left/right: once the thumbnails are clipped to
        the body, a full-width row runs off the disc at both ends, and centring on the tile
        centres on the body too — the sources all sit their subject dead centre in frame. */
-    inset: 2px;
+    /* Top pulled down 1px past the other three sides — flush with the tile edge read too
+       cramped against the disc's own limb. */
+    inset: 3px 2px 2px;
     display: flex;
     flex-direction: column;
     justify-content: space-between;
@@ -221,8 +227,12 @@ exports[`cardStyles > matches snapshot 1`] = `
        decided by the element type and the engine's default line-height, which is how the
        moon's caption ended up sitting higher than its neighbours'.
        Scales with the tile (see container-type above) instead of a fixed 8px, so the longest
-       phase name still fits on a narrow card and stays legible on a wide one. */
-    font-size: clamp(6px, 9cqw, 9px);
+       phase name still fits on a narrow card and stays legible on a wide one — same idea as
+       the SVG body labels, which scale with the card because the whole SVG does. The old 9px
+       ceiling stopped the caption growing past a small card's size while the planet labels
+       beside it kept scaling; 40px is a backstop against a pathological giant tile, not a
+       real-world limit — a tile would need to be ~440px wide before 9cqw even reaches it. */
+    font-size: clamp(6px, 9cqw, 40px);
     line-height: 1;
     font-family: sans-serif;
     pointer-events: none;

--- a/test/card/card-template.test.ts
+++ b/test/card/card-template.test.ts
@@ -160,16 +160,15 @@ describe("discStyle", () => {
 
   // The invariant the two numbers exist to satisfy. clip-path resolves in the element's own
   // coordinates and transform applies to the result, so clip radius x scale must land exactly
-  // on the source's target — any more and the circle escapes the tile, which is the overflow
-  // that put the rotated sky frame over the status bar in the first place. Sun's target is
-  // lower than the rest (see TARGET_FRACTION) — it's the one source whose real apparent size
-  // barely varies, so without its own lower target it would render at full size on nearly
-  // every frame while Moon and Earth, pinned to their rarely-hit maximum, mostly don't.
+  // on the source's target — any more and the circle escapes the tile. Sun's target is lower
+  // than the rest (see TARGET_FRACTION) — it's the one source whose real apparent size barely
+  // varies, so without its own lower target it would render at full size on nearly every frame
+  // while Moon and Earth, pinned to their rarely-hit maximum, mostly don't.
   const EXPECTED_TARGET: Record<(typeof SOURCES)[number], number> = {
-    moon: 46,
-    mymoon: 46,
-    earth: 46,
-    sun: 41.5,
+    moon: 44.5,
+    mymoon: 44.5,
+    earth: 43.5,
+    sun: 40,
   };
   it.each(SOURCES)("clips %s so the scaled circle lands on its own target size", (source) => {
     const style = discStyle(source, "circle");
@@ -198,7 +197,7 @@ describe("discStyle", () => {
 
   describe("square", () => {
     // Same target size as circle mode, but a square clip instead of a round one — so the
-    // shape setting still changes the puck's outline, not just whether it exists.
+    // shape setting changes the puck's outline, not its size.
     it("crops to an inset square and scales to the shared target", () => {
       for (const source of SOURCES) {
         const style = discStyle(source, "square");
@@ -214,12 +213,13 @@ describe("discStyle", () => {
       );
     });
 
-    it("clips less than circle mode does, so more of the frame survives", () => {
-      const radius = (style: string) =>
-        Number(/circle\((\d+(?:\.\d+)?)%\)/.exec(style)?.[1] ?? "0");
-      expect(radius(discStyle("mymoon", "square", 17.1))).toBeGreaterThan(
-        radius(discStyle("mymoon", "circle", 17.1))
-      );
+    // The point of this session's change: same object size in both shapes, only the crop
+    // around it differs.
+    it("scales identically to circle mode for the same source", () => {
+      const scale = (style: string) => Number(/scale\((\d+(?:\.\d+)?)\)/.exec(style)?.[1] ?? "0");
+      for (const source of SOURCES) {
+        expect(scale(discStyle(source, "square"))).toBeCloseTo(scale(discStyle(source, "circle")));
+      }
     });
   });
 });
@@ -227,18 +227,18 @@ describe("discStyle", () => {
 describe("buildImageStatusBar", () => {
   const now = new Date("2026-08-12T12:00:00Z");
 
-  it("labels the earth source with EARTH · DSCOVR, target body first, probe name after", () => {
+  it("labels the earth source with EARTH · NASA DSCOVR, target body first, probe name after", () => {
     const root = renderToDOM(
       buildImageStatusBar("earth", "26-08-10 18:49", new Date("2026-08-10T18:49:00Z"), now, true)
     );
-    expect(root.querySelector(".status-bar span").textContent).toContain("EARTH · DSCOVR");
+    expect(root.querySelector(".status-bar span").textContent).toContain("EARTH · NASA DSCOVR");
   });
 
-  it("labels the sun source with SUN · SDO HMI, target body first, probe name after", () => {
+  it("labels the sun source with SUN · NASA SDO HMI, target body first, probe name after", () => {
     const root = renderToDOM(
       buildImageStatusBar("sun", "26-08-12 11:55", new Date("2026-08-12T11:55:00Z"), now, true)
     );
-    expect(root.querySelector(".status-bar span").textContent).toContain("SUN · SDO HMI");
+    expect(root.querySelector(".status-bar span").textContent).toContain("SUN · NASA SDO HMI");
   });
 
   it("includes the absolute date text and relative age, verb 'captured' for earth", () => {
@@ -246,7 +246,7 @@ describe("buildImageStatusBar", () => {
       buildImageStatusBar("earth", "26-08-11 06:00", new Date("2026-08-11T06:00:00Z"), now, true)
     );
     expect(root.querySelector(".status-bar span").textContent).toBe(
-      "EARTH · DSCOVR · captured 26-08-11 06:00 · 30h ago"
+      "EARTH · NASA DSCOVR · captured 26-08-11 06:00 · 30h ago"
     );
   });
 
@@ -275,7 +275,7 @@ describe("buildImageStatusBar", () => {
       buildImageStatusBar("sun", "26-08-12 11:55", new Date("2026-08-12T11:55:00Z"), now, true)
     );
     expect(root.querySelector(".status-bar span").textContent).toBe(
-      "SUN · SDO HMI · captured 26-08-12 11:55 · 5m ago"
+      "SUN · NASA SDO HMI · captured 26-08-12 11:55 · 5m ago"
     );
   });
 
@@ -283,7 +283,9 @@ describe("buildImageStatusBar", () => {
     const root = renderToDOM(
       buildImageStatusBar("sun", "26-08-12 11:55", new Date("2026-08-12T11:55:00Z"), now, false)
     );
-    expect(root.querySelector(".status-bar span").textContent).toBe("SUN · SDO HMI · loading…");
+    expect(root.querySelector(".status-bar span").textContent).toBe(
+      "SUN · NASA SDO HMI · loading…"
+    );
   });
 });
 
@@ -338,7 +340,9 @@ describe("buildStatusBarView", () => {
         currentDate
       )
     );
-    expect(root.querySelector(".status-bar span").textContent).toBe("SUN · SDO HMI · loading…");
+    expect(root.querySelector(".status-bar span").textContent).toBe(
+      "SUN · NASA SDO HMI · loading…"
+    );
   });
 });
 

--- a/test/card/card.gallery.test.ts
+++ b/test/card/card.gallery.test.ts
@@ -294,7 +294,7 @@ describe("SolarViewCard gallery", () => {
       const labelOf = (source) =>
         card.shadowRoot.querySelector(`[data-source="${source}"] .gallery-label`).textContent;
       expect(labelOf("moon")).toBe("MOON");
-      expect(labelOf("mymoon")).toBe("MY SKY");
+      expect(labelOf("mymoon")).toBe("MYMOON");
       card.remove();
     });
 
@@ -332,7 +332,7 @@ describe("SolarViewCard gallery", () => {
       const thumbs = [...card.shadowRoot.querySelectorAll(".gallery-thumb")];
       expect(thumbs.map((t) => t.dataset.source)).toEqual(["mymoon", "moon", "earth", "sun"]);
       const labels = thumbs.map((t) => t.querySelector(".gallery-label").textContent);
-      expect(labels).toEqual(["MY SKY", "MOON", "DSCOVR/E", "SDO/S"]);
+      expect(labels).toEqual(["MYMOON", "MOON", "EARTH", "SUN"]);
 
       // Each candidate is preloaded off-DOM before it's ever assigned to the thumbnail, so
       // by the time the fetch/preload chain settles the age is already known — no separate
@@ -406,7 +406,9 @@ describe("SolarViewCard gallery", () => {
       card.shadowRoot.querySelector('.gallery-thumb[data-source="sun"]').click();
       await flush();
       expect(card._gallery.panelMode).toBe("sun");
-      expect(card.shadowRoot.querySelector(".status-bar").textContent).toContain("SUN · SDO HMI");
+      expect(card.shadowRoot.querySelector(".status-bar").textContent).toContain(
+        "SUN · NASA SDO HMI"
+      );
       const img = card.shadowRoot.querySelector("#image-view");
       expect(img.classList.contains("visible")).toBe(true);
       expect(card.shadowRoot.querySelector(".gallery")).toBeNull();
@@ -697,7 +699,9 @@ describe("SolarViewCard gallery", () => {
       expect(img.src).toBe(
         `${EPIC_BASE_URL}/archive/natural/2026/08/10/jpg/epic_1b_20260810234950.jpg`
       );
-      expect(card.shadowRoot.querySelector(".status-bar").textContent).toContain("EARTH · DSCOVR");
+      expect(card.shadowRoot.querySelector(".status-bar").textContent).toContain(
+        "EARTH · NASA DSCOVR"
+      );
       card.remove();
     });
 


### PR DESCRIPTION
## Summary
- Circle mode scaled each disc to fill the tile edge-to-edge using its own DISC_FRACTION, independent of square mode's shared target — different apparent size per shape, and a black ring visible whenever the sampled DISC_FRACTION undershot the real frame. Circle and square now share one `TARGET_FRACTION` table, so an object renders the same on-screen size regardless of shape; only the crop outline (round vs inset square) differs.
- Gallery caption `font-size` was capped at a fixed 9px, so it stopped scaling once the card grew past a small size — unlike the SVG planet labels, which scale with the whole SVG. Cap raised to 40px (still a backstop, not a real-world limit).
- Top caption line nudged down 1px; the drawn-moon frame's border/background left as-is (still the intended look for that tile).
- Gallery labels simplified: `SUN` / `EARTH` / `MOON` / `MYMOON` instead of the DSCOVR/E, SDO/S, SVS/M abbreviations. Full-screen status bar now prefixes "NASA" on all three instrument names (SVS, DSCOVR, SDO HMI), not just the Moon's.

## Test plan
- [x] `npm run test:coverage` — 938 passed, 100% coverage
- [x] `npm run check:ci` — typecheck, biome, prettier clean
- [x] Verified circle/square rendering with real NASA imagery in a local harness (headless Chromium) before committing

🤖 Generated with [Claude Code](https://claude.com/claude-code)