### PR TITLE
refactor: extract ViewingLocation from card.ts

### DIFF
--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -1,8 +1,6 @@
 import type { TemplateResult } from "lit";
 import { html, LitElement, nothing } from "lit";
-import { getMoonSkyAngles } from "../astronomy/parallactic.js";
-import { computeSolarElevationDeg, getSkyMode } from "../astronomy/solar-position.js";
-import type { CardConfig, Colors, HASSConfig, Hemisphere, LocationData } from "../types.js";
+import type { CardConfig, Colors, HASSConfig } from "../types.js";
 import { parseCardConfig } from "./card-config.js";
 import { cardStyles } from "./card-styles.js";
 import { buildGalleryCaption, buildStatusBarView, discStyle } from "./card-template.js";
@@ -21,6 +19,8 @@ import { SOURCES } from "./gallery/sources.js";
 import { formatDate, formatRelativeWhen } from "./relative-time.js";
 import { SolarView } from "./solar-view.js";
 import { resolveTheme, THEME_OVERRIDE_VARS } from "./theme.js";
+import type { SkyFrame } from "./viewing-location.js";
+import { ViewingLocation } from "./viewing-location.js";
 import { ZoomController } from "./zoom-controller.js";
 
 export type { GalleryMode };
@@ -37,44 +37,12 @@ const SUSPENDS_AUTO_ZOOM = new Set([
   "month-forward",
 ]);
 
-// The sky tile's backdrop, by getSkyMode()'s own band names. Solid colors, not the visibility
-// cone's translucent tints (CONE_DAY etc., see renderer/observer.ts) — the cone is designed to
-// sit as a faint wash over the SVG view, but a tile-sized backdrop needs to read as "day" or
-// "night" at a glance rather than disappear against the card background. Day and night are the
-// two ends of the range (light vs. black); the three twilight steps carry the same warm-cool-
-// violet hue progression as the cone's own bands, just fully opaque instead of near-invisible.
-const MOON_SKY_BACKGROUND: Record<string, string> = {
-  Day: "#d0d0d0",
-  "Civil Twilight": "#8a6142",
-  "Nautical Twilight": "#3a4a6b",
-  "Astronomical Twilight": "#2a1f42",
-  Night: "#000000",
-};
-
-// HASS and config.location update independently (hass setter vs. setConfig), so each source
-// is kept as one grouped field rather than losing either one to an eager merge — _locationData
-// and _locationName below resolve them on read, override winning per-field.
-interface HassLocation {
-  lat: number | null;
-  lon: number | null;
-  timezone: string | null;
-  name: string | null;
-}
-interface LocationOverride {
-  lat: number;
-  lon: number;
-  timezone: string;
-}
-
 export class SolarViewCard extends LitElement {
   static styles = cardStyles;
 
   private _dateNav: DateNavigation;
   private _zoom: ZoomController;
-  private _hemisphere: Hemisphere;
-  private _hassLocation: HassLocation;
-  private _locationOverride: LocationOverride | null;
-  private _locationNameOverride: string | null;
+  private _location: ViewingLocation;
   private _autoUpdateTimer: number | null;
   private _debugTimer: number | null;
   private _galleryPosition: GalleryPosition;
@@ -96,10 +64,7 @@ export class SolarViewCard extends LitElement {
       () => this._render(),
       () => this._solarView.applyViewState()
     );
-    this._hemisphere = "north";
-    this._hassLocation = { lat: null, lon: null, timezone: null, name: null };
-    this._locationOverride = null;
-    this._locationNameOverride = null;
+    this._location = new ViewingLocation();
     this._autoUpdateTimer = null;
     this._debugTimer = null;
     this._galleryPosition = "overlay";
@@ -114,43 +79,8 @@ export class SolarViewCard extends LitElement {
     this._gallery = new GalleryController(() => this._render());
   }
 
-  // ---------------------------------------------------------------------------
-  // Proxy getters
-  // ---------------------------------------------------------------------------
-  get _locationData(): LocationData | null {
-    const override = this._locationOverride;
-    const lat = override?.lat ?? this._hassLocation.lat;
-    const lon = override?.lon ?? this._hassLocation.lon;
-    return lat != null && lon != null
-      ? {
-          lat,
-          lon,
-          timezone: override?.timezone ?? this._hassLocation.timezone ?? "UTC",
-          zoneOverride: override != null,
-        }
-      : null;
-  }
-  get _effectiveLocationName(): string | null {
-    return this._locationNameOverride ?? this._hassLocation.name;
-  }
-
   set hass(hass: HASSConfig) {
-    const next: HassLocation = {
-      lat: hass.config?.latitude ?? null,
-      lon: hass.config?.longitude ?? null,
-      timezone: hass.config?.time_zone || null,
-      name: hass.config?.location_name || null,
-    };
-    const prev = this._hassLocation;
-    if (
-      next.lat !== prev.lat ||
-      next.lon !== prev.lon ||
-      next.timezone !== prev.timezone ||
-      next.name !== prev.name
-    ) {
-      this._hassLocation = next;
-      this._render();
-    }
+    if (this._location.update(hass)) this._render();
   }
 
   setConfig(config: CardConfig): void {
@@ -167,8 +97,7 @@ export class SolarViewCard extends LitElement {
     this._colors = parsed.colors;
     this._theme = parsed.theme;
     this._eclipticView = parsed.eclipticView;
-    this._locationOverride = parsed.locationOverride;
-    this._locationNameOverride = parsed.locationNameOverride;
+    this._location.configure(parsed.locationOverride, parsed.locationNameOverride);
     this._heightStyle = parsed.heightStyle;
     this._galleryPosition = parsed.galleryPosition;
     this._galleryShape = parsed.galleryShape;
@@ -212,16 +141,19 @@ export class SolarViewCard extends LitElement {
   }
 
   render() {
-    const lat = this._locationData?.lat;
-    if (lat != null) {
-      this._hemisphere = lat < 0 ? "south" : "north";
-    }
+    // One instant for the whole frame, so a sky tile, its tint and the full-screen panel can't
+    // land on three slightly different moments. Computed at most once per render, and only if
+    // something actually asks: the moon ephemeris and solar elevation behind it aren't worth
+    // running on every tick of a card whose gallery has no sky tile enabled.
+    const now = new Date();
+    let skyFrame: SkyFrame | null = null;
+    const sky = () => (skyFrame ??= this._location.skyFrame(now));
 
     const gallery = this._gallery.viewModel(this._galleryPosition);
     const statusBar = buildStatusBarView(
       gallery,
-      this._locationData,
-      this._effectiveLocationName,
+      this._location.data,
+      this._location.name,
       this._dateNav.currentDate
     );
     const zoomLevel = this._zoom.displayZoomLevel;
@@ -246,7 +178,7 @@ export class SolarViewCard extends LitElement {
             <img
               id="image-view"
               class="image-view"
-              style=${this._panelImageStyle(gallery.panelSource)}
+              style=${this._panelImageStyle(gallery.panelSource, sky)}
               src=${gallery.imageUrl ? fullSizeMoonUrl(gallery.imageUrl) : nothing}
               alt=""
               @click=${this._onImageClick}
@@ -258,7 +190,7 @@ export class SolarViewCard extends LitElement {
             gallery.showStrip
               ? html`<div class="gallery gallery-${this._galleryPosition}">
                   ${gallery.thumbnails.map(({ source, url, date }) =>
-                    this._renderGalleryTile(source, url, date)
+                    this._renderGalleryTile(source, url, date, sky, now)
                   )}
                 </div>`
               : nothing
@@ -304,8 +236,8 @@ export class SolarViewCard extends LitElement {
       this._solarView.mount(
         container,
         this._dateNav.currentDate,
-        this._hemisphere,
-        this._locationData,
+        this._location.hemisphere,
+        this._location.data,
         this._colors,
         this._eclipticView
       );
@@ -342,9 +274,14 @@ export class SolarViewCard extends LitElement {
   private _renderGalleryTile(
     source: GallerySource,
     url: string | null,
-    date: Date | null
+    date: Date | null,
+    skyFrame: () => SkyFrame,
+    now: Date
   ): TemplateResult {
-    const sky = SOURCES[source].skyFrame ? this._skyView() : null;
+    // The catalog says whether this tile wants the observer's frame; ViewingLocation says what
+    // that frame is. Every other source shows the geocentric render as published, and never
+    // makes the caller compute a frame it has no use for.
+    const sky = SOURCES[source].skyFrame ? skyFrame() : null;
     const discStyleValue = discStyle(source, this._galleryShape, sky ? sky.rotation : 0);
     return html`<button
       class="gallery-thumb ${this._galleryShape === "circle" ? "gallery-thumb-circle" : ""}"
@@ -372,7 +309,7 @@ export class SolarViewCard extends LitElement {
       }
       ${buildGalleryCaption(
         SOURCES[source].tile,
-        date ? formatRelativeWhen(date, new Date()) : "loading…"
+        date ? formatRelativeWhen(date, now) : "loading…"
       )}
     </button>`;
   }
@@ -397,34 +334,12 @@ export class SolarViewCard extends LitElement {
    * what the thumbnail showed rather than snapping back to the geocentric frame the moment it
    * is opened. Every other source needs no style of its own here.
    */
-  private _panelImageStyle(panelSource: ImagePanelMode): string | typeof nothing {
+  private _panelImageStyle(
+    panelSource: ImagePanelMode,
+    skyFrame: () => SkyFrame
+  ): string | typeof nothing {
     if (panelSource === "none" || !SOURCES[panelSource].skyFrame) return nothing;
-    return `transform: rotate(${this._skyView().rotation.toFixed(1)}deg)`;
-  }
-
-  /**
-   * How the Moon hangs in the observer's sky right now.
-   *
-   * Returns null-safe defaults when no location is known yet: an unrotated frame on the
-   * default black backdrop is the geocentric one, which is the honest thing to show when
-   * there is no observer to rotate or light for.
-   *
-   * "Below horizon" isn't a failure — it means the Earth is in the way from here, which is
-   * true on roughly half of any given hour's worth of nights, at every latitude, because the
-   * Moon keeps its own hours rather than the Sun's — but it does mean there's nothing to show:
-   * the caller leaves the image out rather than rendering a Moon that isn't in the sky. The
-   * backdrop answers a separate question, what the sky itself looks like right now, so it's
-   * still lit correctly either way.
-   */
-  private _skyView(): { rotation: number; belowHorizon: boolean; background: string } {
-    const location = this._locationData;
-    if (!location) return { rotation: 0, belowHorizon: false, background: "#000" };
-
-    const now = new Date();
-    const { parallacticDeg, altitudeDeg } = getMoonSkyAngles(now, location.lat, location.lon);
-    const sunElevDeg = computeSolarElevationDeg(location.lat, location.lon, now);
-    const background = MOON_SKY_BACKGROUND[getSkyMode(sunElevDeg)];
-    return { rotation: parallacticDeg, belowHorizon: altitudeDeg <= 0, background };
+    return `transform: rotate(${skyFrame().rotation.toFixed(1)}deg)`;
   }
 
   /**

--- a/src/card/viewing-location.ts
+++ b/src/card/viewing-location.ts
@@ -1,0 +1,154 @@
+import { getMoonSkyAngles } from "../astronomy/parallactic.js";
+import { computeSolarElevationDeg, getSkyMode } from "../astronomy/solar-position.js";
+import type { HASSConfig, Hemisphere, LocationData } from "../types.js";
+
+// The sky tile's backdrop, by getSkyMode()'s own band names. Solid colors, not the visibility
+// cone's translucent tints (CONE_DAY etc., see renderer/observer.ts) — the cone is designed to
+// sit as a faint wash over the SVG view, but a tile-sized backdrop needs to read as "day" or
+// "night" at a glance rather than disappear against the card background. Day and night are the
+// two ends of the range (light vs. black); the three twilight steps carry the same warm-cool-
+// violet hue progression as the cone's own bands, just fully opaque instead of near-invisible.
+const MOON_SKY_BACKGROUND: Record<string, string> = {
+  Day: "#d0d0d0",
+  "Civil Twilight": "#8a6142",
+  "Nautical Twilight": "#3a4a6b",
+  "Astronomical Twilight": "#2a1f42",
+  Night: "#000000",
+};
+
+// HASS and config.location update independently (hass setter vs. setConfig), so each source
+// is kept as one grouped field rather than losing either one to an eager merge — `data` and
+// `name` below resolve them on read, override winning per-field.
+interface HassLocation {
+  lat: number | null;
+  lon: number | null;
+  timezone: string | null;
+  name: string | null;
+}
+
+interface LocationOverride {
+  lat: number;
+  lon: number;
+  timezone: string;
+}
+
+/** How the Moon hangs in the observer's sky at one instant. */
+export interface SkyFrame {
+  /** Parallactic angle — how far to turn the geocentric render into this observer's view. */
+  rotation: number;
+  /** True when the Earth is in the way from here, so there is no Moon to show. */
+  belowHorizon: boolean;
+  /** What the sky itself looks like right now, whether or not the Moon is up. */
+  background: string;
+}
+
+/**
+ * Where the user is watching from, and what their sky looks like.
+ *
+ * Merges HA's own location with a `config.location` override, and answers the three questions
+ * the card asks about the observer: where they are (`data`/`name`), which way their seasons run
+ * (`hemisphere`), and how the Moon sits in their sky right now (`skyFrame`). Previously these
+ * lived as six fields and two methods on the card element, which meant the merge rules and the
+ * sky astronomy could only be exercised by mounting a custom element in jsdom.
+ *
+ * Named for the observer's position rather than "Observer", which renderer/observer.ts already
+ * owns for the needle and the visibility cone drawn on the solar view.
+ */
+export class ViewingLocation {
+  private _hass: HassLocation;
+  private _override: LocationOverride | null;
+  private _nameOverride: string | null;
+
+  constructor() {
+    this._hass = { lat: null, lon: null, timezone: null, name: null };
+    this._override = null;
+    this._nameOverride = null;
+  }
+
+  /**
+   * Takes HA's own location. Returns whether anything actually moved, so the caller re-renders
+   * on a real change rather than on every hass assignment — HA reassigns that property on every
+   * state update in the whole system, which is far more often than the card's location changes.
+   */
+  update(hass: HASSConfig): boolean {
+    const next: HassLocation = {
+      lat: hass.config?.latitude ?? null,
+      lon: hass.config?.longitude ?? null,
+      timezone: hass.config?.time_zone || null,
+      name: hass.config?.location_name || null,
+    };
+    const prev = this._hass;
+    if (
+      next.lat === prev.lat &&
+      next.lon === prev.lon &&
+      next.timezone === prev.timezone &&
+      next.name === prev.name
+    ) {
+      return false;
+    }
+    this._hass = next;
+    return true;
+  }
+
+  /** Applies `config.location` — already validated and zone-resolved by parseCardConfig. */
+  configure(override: LocationOverride | null, nameOverride: string | null): void {
+    this._override = override;
+    this._nameOverride = nameOverride;
+  }
+
+  get data(): LocationData | null {
+    const override = this._override;
+    const lat = override?.lat ?? this._hass.lat;
+    const lon = override?.lon ?? this._hass.lon;
+    return lat != null && lon != null
+      ? {
+          lat,
+          lon,
+          timezone: override?.timezone ?? this._hass.timezone ?? "UTC",
+          zoneOverride: override != null,
+        }
+      : null;
+  }
+
+  get name(): string | null {
+    return this._nameOverride ?? this._hass.name;
+  }
+
+  // Derived rather than remembered: with no location known there is no hemisphere to report,
+  // and north is the same default the card starts at. (The card used to cache the last
+  // hemisphere it saw, so losing the location mid-session kept the old seasons on screen.)
+  get hemisphere(): Hemisphere {
+    const lat = this.data?.lat;
+    return lat != null && lat < 0 ? "south" : "north";
+  }
+
+  /**
+   * How the Moon hangs in this observer's sky at `now`.
+   *
+   * Returns null-safe defaults when no location is known yet: an unrotated frame on the
+   * default black backdrop is the geocentric one, which is the honest thing to show when
+   * there is no observer to rotate or light for.
+   *
+   * "Below horizon" isn't a failure — it means the Earth is in the way from here, which is
+   * true on roughly half of any given hour's worth of nights, at every latitude, because the
+   * Moon keeps its own hours rather than the Sun's — but it does mean there's nothing to show:
+   * the caller leaves the image out rather than rendering a Moon that isn't in the sky. The
+   * backdrop answers a separate question, what the sky itself looks like right now, so it's
+   * still lit correctly either way.
+   *
+   * `now` is passed in rather than read here, so one render paints the tile, its tint and the
+   * full-screen panel from a single instant instead of three slightly different ones.
+   */
+  skyFrame(now: Date): SkyFrame {
+    const location = this.data;
+    if (!location) return { rotation: 0, belowHorizon: false, background: "#000" };
+
+    const { parallacticDeg, altitudeDeg } = getMoonSkyAngles(now, location.lat, location.lon);
+    const sunElevDeg = computeSolarElevationDeg(location.lat, location.lon, now);
+    return {
+      rotation: parallacticDeg,
+      belowHorizon: altitudeDeg <= 0,
+      background: MOON_SKY_BACKGROUND[getSkyMode(sunElevDeg)],
+    };
+  }
+}

--- a/test/card/card.status-bar.test.ts
+++ b/test/card/card.status-bar.test.ts
@@ -13,7 +13,14 @@ describe("SolarViewCard status bar", () => {
       date = new Date("2026-03-05T12:00:00Z")
     ) {
       const card = document.createElement("ha-planetary-solar-system-card-test");
-      card._hassLocation = { lat, lon, timezone: "Europe/London", name: "London" };
+      card.hass = {
+        config: {
+          latitude: lat,
+          longitude: lon,
+          time_zone: "Europe/London",
+          location_name: "London",
+        },
+      };
       card._dateNav.currentDate = date;
       document.body.appendChild(card);
       return card;

--- a/test/card/card.test.ts
+++ b/test/card/card.test.ts
@@ -202,12 +202,13 @@ describe("SolarViewCard", () => {
           location_name: "London",
         },
       };
-      expect(card._hassLocation).toEqual({
+      expect(card._location.data).toEqual({
         lat: 51.5,
         lon: -0.1,
         timezone: "Europe/London",
-        name: "London",
+        zoneOverride: false,
       });
+      expect(card._location.name).toBe("London");
       const bar = card.shadowRoot.querySelector(".status-bar");
       expect(bar).not.toBeNull();
       card.remove();
@@ -241,9 +242,10 @@ describe("SolarViewCard", () => {
           location_name: "London",
         },
       };
-      expect(card._hassLocation.lat).toBe(51.5);
+      expect(card._location.data?.lat).toBe(51.5);
       card.hass = { config: {} };
-      expect(card._hassLocation).toEqual({ lat: null, lon: null, timezone: null, name: null });
+      expect(card._location.data).toBeNull();
+      expect(card._location.name).toBeNull();
       card.remove();
     });
   });
@@ -261,10 +263,10 @@ describe("SolarViewCard", () => {
       };
       card.setConfig({ location: { latitude: -34.9, longitude: -56.2, name: "Montevideo" } });
       card._render();
-      expect(card._locationData?.lat).toBe(-34.9);
-      expect(card._locationData?.lon).toBe(-56.2);
-      expect(card._hemisphere).toBe("south");
-      expect(card._effectiveLocationName).toBe("Montevideo");
+      expect(card._location.data?.lat).toBe(-34.9);
+      expect(card._location.data?.lon).toBe(-56.2);
+      expect(card._location.hemisphere).toBe("south");
+      expect(card._location.name).toBe("Montevideo");
       card.remove();
     });
 
@@ -273,9 +275,9 @@ describe("SolarViewCard", () => {
       card.hass = { config: { latitude: 51.5, longitude: -0.1 } };
       card.setConfig({ location: { latitude: -34.9 } });
       card._render();
-      expect(card._locationData?.lat).toBe(51.5);
-      expect(card._locationData?.lon).toBe(-0.1);
-      expect(card._hemisphere).toBe("north");
+      expect(card._location.data?.lat).toBe(51.5);
+      expect(card._location.data?.lon).toBe(-0.1);
+      expect(card._location.hemisphere).toBe("north");
       card.remove();
     });
 
@@ -284,8 +286,8 @@ describe("SolarViewCard", () => {
       card.hass = { config: { latitude: 51.5, longitude: -0.1 } };
       card.setConfig({ location: { latitude: 200, longitude: -56.2 } });
       card._render();
-      expect(card._locationData?.lat).toBe(51.5);
-      expect(card._locationData?.lon).toBe(-0.1);
+      expect(card._location.data?.lat).toBe(51.5);
+      expect(card._location.data?.lon).toBe(-0.1);
       card.remove();
     });
 
@@ -294,8 +296,8 @@ describe("SolarViewCard", () => {
       card.hass = { config: { latitude: 51.5, longitude: -0.1 } };
       card.setConfig({ location: { latitude: -34.9, longitude: -200 } });
       card._render();
-      expect(card._locationData?.lat).toBe(51.5);
-      expect(card._locationData?.lon).toBe(-0.1);
+      expect(card._location.data?.lat).toBe(51.5);
+      expect(card._location.data?.lon).toBe(-0.1);
       card.remove();
     });
 
@@ -304,8 +306,8 @@ describe("SolarViewCard", () => {
       card.hass = { config: { latitude: 41.9, longitude: -87.6, time_zone: "America/Chicago" } };
       card.setConfig({ location: { latitude: 51.5, longitude: -0.1278, name: "London" } });
       card._render();
-      expect(card._locationData?.timezone).toBe("Etc/GMT+0");
-      expect(card._locationData?.zoneOverride).toBe(true);
+      expect(card._location.data?.timezone).toBe("Etc/GMT+0");
+      expect(card._location.data?.zoneOverride).toBe(true);
       card.remove();
     });
 
@@ -314,8 +316,8 @@ describe("SolarViewCard", () => {
       card.hass = { config: { latitude: 41.9, longitude: -87.6, time_zone: "America/Chicago" } };
       card.setConfig({});
       card._render();
-      expect(card._locationData?.timezone).toBe("America/Chicago");
-      expect(card._locationData?.zoneOverride).toBe(false);
+      expect(card._location.data?.timezone).toBe("America/Chicago");
+      expect(card._location.data?.zoneOverride).toBe(false);
       card.remove();
     });
 
@@ -323,9 +325,9 @@ describe("SolarViewCard", () => {
       const card = createAndMount();
       card.hass = { config: { latitude: 51.5, longitude: -0.1, location_name: "London" } };
       card.setConfig({});
-      expect(card._locationData?.lat).toBe(51.5);
-      expect(card._locationData?.lon).toBe(-0.1);
-      expect(card._effectiveLocationName).toBe("London");
+      expect(card._location.data?.lat).toBe(51.5);
+      expect(card._location.data?.lon).toBe(-0.1);
+      expect(card._location.name).toBe("London");
       card.remove();
     });
   });
@@ -363,9 +365,8 @@ describe("SolarViewCard", () => {
   describe("southern hemisphere", () => {
     it("sets hemisphere to south when lat is negative", () => {
       const card = createAndMount();
-      card._hassLocation = { lat: -33.9, lon: 151.2, timezone: null, name: null }; // Sydney
-      card._render();
-      expect(card._hemisphere).toBe("south");
+      card.hass = { config: { latitude: -33.9, longitude: 151.2 } }; // Sydney
+      expect(card._location.hemisphere).toBe("south");
       card.remove();
     });
   });

--- a/test/card/viewing-location.test.ts
+++ b/test/card/viewing-location.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import { ViewingLocation } from "../../src/card/viewing-location.js";
+
+const LONDON = {
+  config: { latitude: 51.5, longitude: -0.1, time_zone: "Europe/London", location_name: "London" },
+};
+
+describe("ViewingLocation", () => {
+  describe("update", () => {
+    it("reports a change the first time HA supplies a location", () => {
+      const location = new ViewingLocation();
+      expect(location.update(LONDON)).toBe(true);
+      expect(location.data).toEqual({
+        lat: 51.5,
+        lon: -0.1,
+        timezone: "Europe/London",
+        zoneOverride: false,
+      });
+    });
+
+    it("reports no change when the same location arrives again", () => {
+      const location = new ViewingLocation();
+      location.update(LONDON);
+      expect(location.update(LONDON)).toBe(false);
+    });
+
+    it("reports a change when any one field moves", () => {
+      const location = new ViewingLocation();
+      location.update(LONDON);
+      expect(
+        location.update({ config: { ...LONDON.config, location_name: "Greater London" } })
+      ).toBe(true);
+      expect(location.name).toBe("Greater London");
+    });
+
+    it("treats a hass object with no config as no location at all", () => {
+      const location = new ViewingLocation();
+      expect(location.update({})).toBe(false);
+      expect(location.data).toBeNull();
+      expect(location.name).toBeNull();
+    });
+  });
+
+  describe("configure", () => {
+    it("lets a configured location win per field, and flags the overridden zone", () => {
+      const location = new ViewingLocation();
+      location.update(LONDON);
+      location.configure({ lat: -34.9, lon: -56.2, timezone: "America/Montevideo" }, "Montevideo");
+      expect(location.data).toEqual({
+        lat: -34.9,
+        lon: -56.2,
+        timezone: "America/Montevideo",
+        zoneOverride: true,
+      });
+      expect(location.name).toBe("Montevideo");
+    });
+
+    it("keeps HA's own name when the override names no location", () => {
+      const location = new ViewingLocation();
+      location.update(LONDON);
+      location.configure({ lat: -34.9, lon: -56.2, timezone: "America/Montevideo" }, null);
+      expect(location.name).toBe("London");
+    });
+
+    it("falls back to UTC when neither HA nor the override names a zone", () => {
+      const location = new ViewingLocation();
+      location.update({ config: { latitude: 10, longitude: 20 } });
+      expect(location.data?.timezone).toBe("UTC");
+      expect(location.data?.zoneOverride).toBe(false);
+    });
+  });
+
+  describe("hemisphere", () => {
+    it("reads north above the equator and south below it", () => {
+      const location = new ViewingLocation();
+      expect(location.hemisphere).toBe("north");
+      location.update(LONDON);
+      expect(location.hemisphere).toBe("north");
+      location.update({ config: { latitude: -33.9, longitude: 151.2 } });
+      expect(location.hemisphere).toBe("south");
+    });
+
+    it("follows the configured override, not HA's own latitude", () => {
+      const location = new ViewingLocation();
+      location.update(LONDON);
+      location.configure({ lat: -34.9, lon: -56.2, timezone: "America/Montevideo" }, null);
+      expect(location.hemisphere).toBe("south");
+    });
+  });
+
+  describe("skyFrame", () => {
+    // Geocentric and unlit is the honest frame to show when there is no observer to rotate or
+    // light for — not a rotation of zero that happens to look deliberate.
+    it("returns the geocentric frame on black with no location known", () => {
+      const location = new ViewingLocation();
+      expect(location.skyFrame(new Date("2026-03-05T12:00:00Z"))).toEqual({
+        rotation: 0,
+        belowHorizon: false,
+        background: "#000",
+      });
+    });
+
+    it("rotates the frame into the observer's own sky", () => {
+      const location = new ViewingLocation();
+      location.update(LONDON);
+      const frame = location.skyFrame(new Date("2026-03-05T22:00:00Z"));
+      expect(frame.rotation).not.toBe(0);
+      expect(Math.abs(frame.rotation)).toBeLessThanOrEqual(180);
+    });
+
+    it("backs a daytime sky with the day wash and a night one with black", () => {
+      const location = new ViewingLocation();
+      location.update(LONDON);
+      expect(location.skyFrame(new Date("2026-06-21T12:00:00Z")).background).toBe("#d0d0d0");
+      expect(location.skyFrame(new Date("2026-12-21T00:00:00Z")).background).toBe("#000000");
+    });
+
+    it("reports the Moon below the horizon without treating it as a failure", () => {
+      const location = new ViewingLocation();
+      location.update(LONDON);
+      // Sampled across a full day: at this latitude the Moon is up for part of it and down for
+      // the rest, so both states must be reachable.
+      const states = Array.from(
+        { length: 24 },
+        (_, hour) => location.skyFrame(new Date(Date.UTC(2026, 2, 5, hour))).belowHorizon
+      );
+      expect(states).toContain(true);
+      expect(states).toContain(false);
+    });
+  });
+});


### PR DESCRIPTION
## Why

The extraction campaign (#104–#114) pulled nav, zoom, gallery and the SVG seam out of the card element, but left the **observer** behind:

- the HA / `config.location` merge — `_hassLocation`, `_locationOverride`, `_locationNameOverride`, `_locationData`, `_effectiveLocationName`
- `_hemisphere`, assigned as a **side effect of `render()`**
- `_skyView()` — parallactic angle + solar elevation for the sky tile
- `MOON_SKY_BACKGROUND`, a five-colour sky palette

All of it could only be exercised by mounting a custom element in jsdom. The tests showed it: they wrote directly into private state (`card._hassLocation = {…}`) because there was no other way to set a location up.

## What

One `ViewingLocation` module answers where the user watches from and what their sky looks like:

```ts
update(hass): boolean          // returns whether anything moved
configure(override, nameOverride)
get data(): LocationData | null
get name(): string | null
get hemisphere(): Hemisphere
skyFrame(now: Date): SkyFrame
```

Named for the position rather than `Observer` — `renderer/observer.ts` already owns that word for the needle and visibility cone drawn on the solar view.

- **`update()` returns changed**, so the setter stays `if (this._location.update(hass)) this._render()`. HA reassigns `hass` on every state update in the system, far more often than the location changes.
- **`skyFrame(now)` takes the instant** rather than reading the clock, so a tile, its tint and the full-screen panel paint from one moment instead of three.
- It is passed as a **thunk, memoised per render** — the moon ephemeris behind it isn't worth running on cards with no sky tile, which re-render every second under `debug: true`.
- `render()` no longer mutates state.

Division of labour on the sky tile now reads cleanly: the catalog (#159) says *whether* a tile wants the observer's frame (`SOURCES[s].skyFrame`), `ViewingLocation` says *what* that frame is.

## ⚠️ One deliberate behaviour change

`hemisphere` is **derived** from the current latitude instead of cached. If HA's location goes away mid-session, the card now falls back to `north` (its own starting default) rather than keeping the last hemisphere's seasons on screen.

No test covered the old stickiness, and preserving it means keeping the mutable state this refactor exists to remove.

## Result

`card.ts` **558 → 464 lines**; it no longer imports any astronomy module. Tests now drive location through `card.hass = { config: {…} }` — the real interface HA uses — instead of writing into private fields.

- 946 tests pass (47 files), 13 of them new against the module's own interface
- Coverage 100% — statements, branches, functions, lines
- `check:ci` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)