### PR TITLE
refactor: give the ecliptic mirror one home

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,5 +21,12 @@ Durable visual/UX constraints. Preserve unless the user explicitly changes them.
 - **Synchronous render**: `_render()` calls `requestUpdate()` + `performUpdate()` back-to-back to
   force a synchronous Lit flush. Lit's default async microtask schedule breaks synchronous tests and
   delays the first frame in HA.
-- **Positions from renderer**: `renderSolarSystem()` returns `{ svg, positions }` — `positions` are
-  screen coordinates used for SVG hit-testing (click targets), not a rendering side-effect.
+- **Positions from renderer**: `renderSolarSystem()` returns `{ svg, positions, updateMarkers }`.
+  `positions` are screen coordinates: `updateMarkers` re-derives which bodies belong offscreen from
+  them, and tests read them to assert bodies never visually overlap at conjunction
+  (`test/renderer/collision.test.ts`, #62). No `src/` caller reads the field — there is no
+  click/hit-testing on the SVG.
+- **One mirror**: the ecliptic view is a `±1` (`eclipticViewDirection`), and every point derived
+  from an angle goes through `polarOffset()` in `renderer/svg-utils.ts`. Don't write
+  `y + dir * dist * Math.sin(angle)` by hand — `orbitTransformComponents()` is built to agree with
+  that exact expression (#94), so a second copy is how a marker drifts off its orbit ring.

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -25,6 +25,7 @@ import {
   createSvgElement,
   DEFAULT_LABEL_COLOR,
   polarFromFocus,
+  polarOffset,
   VIEW_SIZE,
 } from "./svg-utils.js";
 
@@ -142,8 +143,13 @@ export function renderSolarSystem(
   // room for the Moon's full circle on both sides, so it never needs
   // clamping into Venus's or Mars's orbit (#62).
   const moonAngle = calculateMoonPosition(date);
-  const moonX = earthX + MOON_PIXEL_OFFSET * Math.cos(moonAngle);
-  const moonY = earthY + eclipticViewDirection * MOON_PIXEL_OFFSET * Math.sin(moonAngle);
+  const { x: moonX, y: moonY } = polarOffset(
+    earthX,
+    earthY,
+    MOON_PIXEL_OFFSET,
+    moonAngle,
+    eclipticViewDirection
+  );
 
   positions.push({ name: MOON.name, x: moonX, y: moonY, color: MOON.color, offscreen: false });
   planetLabels.push({ name: MOON.name, x: moonX, y: moonY, radius: MOON.size });
@@ -195,5 +201,9 @@ export function renderSolarSystem(
     svg.appendChild(renderOffscreenMarkers(positions, viewState, aspect));
   }
 
+  // `positions` feeds updateMarkers above, and is returned so tests can measure real
+  // separation between bodies at conjunction (test/renderer/collision.test.ts, #62) from the
+  // same numbers the scene was drawn with, rather than reading coordinates back out of the
+  // SVG. No src/ caller reads it.
   return { svg, positions, updateMarkers };
 }

--- a/src/renderer/observer.ts
+++ b/src/renderer/observer.ts
@@ -6,7 +6,7 @@ import {
   getLocalTimeInZone,
 } from "../astronomy/solar-position.js";
 import type { Colors, LocationData } from "../types.js";
-import { CENTER, createSvgElement, MAX_RADIUS, VIEW_SIZE } from "./svg-utils.js";
+import { CENTER, createSvgElement, MAX_RADIUS, polarOffset, VIEW_SIZE } from "./svg-utils.js";
 
 const NEEDLE_COLOR = "color-mix(in srgb, currentColor 70%, transparent)";
 
@@ -151,15 +151,11 @@ function renderVisibilityCone(
   // flips too. Hardcoding sweep=1 only drew the correct wedge for the north (-1) case.
   const sweepFlag = eclipticViewDirection === -1 ? 1 : 0;
 
-  const leftAngle = observerAngle + HALF_ANGLE;
-  const rightAngle = observerAngle - HALF_ANGLE;
-  const leftX = anchorX + D * Math.cos(leftAngle);
-  const leftY = anchorY + eclipticViewDirection * D * Math.sin(leftAngle);
-  const rightX = anchorX + D * Math.cos(rightAngle);
-  const rightY = anchorY + eclipticViewDirection * D * Math.sin(rightAngle);
+  const left = polarOffset(anchorX, anchorY, D, observerAngle + HALF_ANGLE, eclipticViewDirection);
+  const right = polarOffset(anchorX, anchorY, D, observerAngle - HALF_ANGLE, eclipticViewDirection);
 
   // SVG path: MoveTo apex, LineTo left edge, Arc to right edge, ClosePath
-  const pathD = `M ${anchorX} ${anchorY} L ${leftX} ${leftY} A ${D} ${D} 0 ${largeArcFlag} ${sweepFlag} ${rightX} ${rightY} Z`;
+  const pathD = `M ${anchorX} ${anchorY} L ${left.x} ${left.y} A ${D} ${D} 0 ${largeArcFlag} ${sweepFlag} ${right.x} ${right.y} Z`;
 
   const defs =
     svg.querySelector("defs") || svg.insertBefore(createSvgElement("defs", {}), svg.firstChild);
@@ -196,16 +192,16 @@ export function renderDayNightSplit(
     locationData?.lon
   );
 
-  const earthDirX = Math.cos(earthAngle);
-  const earthDirY = Math.sin(earthAngle);
-  const obsDirX = Math.cos(observerAngle);
-  const obsDirY = Math.sin(observerAngle);
-
-  // Anchor point at Earth's surface
-  const earthOrbitalX = CENTER + earthRadius * earthDirX;
-  const earthOrbitalY = CENTER + eclipticViewDirection * earthRadius * earthDirY;
-  const anchorX = earthOrbitalX + earthBodySize * obsDirX;
-  const anchorY = earthOrbitalY + eclipticViewDirection * earthBodySize * obsDirY;
+  // Anchor point at Earth's surface: out to Earth's orbit, then out again by the body's own
+  // radius in the direction the observer faces.
+  const earthOrbital = polarOffset(CENTER, CENTER, earthRadius, earthAngle, eclipticViewDirection);
+  const { x: anchorX, y: anchorY } = polarOffset(
+    earthOrbital.x,
+    earthOrbital.y,
+    earthBodySize,
+    observerAngle,
+    eclipticViewDirection
+  );
 
   // Filled cone — colour determined by which twilight phase the solar elevation falls in.
   // Half-angle = 90° − elevationDeg expands the cone below the horizon during twilight.
@@ -255,57 +251,37 @@ export function renderDayNightSplit(
     "stroke-dasharray": "4, 4",
   };
 
+  // Where an arm cast from the anchor at `angle` meets the cone's clip circle, plus a margin.
+  // The unit direction handed to rayCircleDistance carries the same mirror as the endpoint it
+  // ends up producing, so both go through polarOffset rather than spelling the sine out twice.
+  const armEnd = (angle: number) => {
+    const dir = polarOffset(0, 0, 1, angle, eclipticViewDirection);
+    const dist = rayCircleDistance(anchorX, anchorY, dir.x, dir.y, CENTER, CENTER, CLIP_R) + EXTRA;
+    return polarOffset(anchorX, anchorY, dist, angle, eclipticViewDirection);
+  };
+
   // Horizon line — each arm extends to the cone clip circle edge + margin
-  const leftAngle = displayObserverAngle + Math.PI / 2;
-  const rightAngle = displayObserverAngle - Math.PI / 2;
-  const leftD =
-    rayCircleDistance(
-      anchorX,
-      anchorY,
-      Math.cos(leftAngle),
-      eclipticViewDirection * Math.sin(leftAngle),
-      CENTER,
-      CENTER,
-      CLIP_R
-    ) + EXTRA;
-  const rightD =
-    rayCircleDistance(
-      anchorX,
-      anchorY,
-      Math.cos(rightAngle),
-      eclipticViewDirection * Math.sin(rightAngle),
-      CENTER,
-      CENTER,
-      CLIP_R
-    ) + EXTRA;
+  const left = armEnd(displayObserverAngle + Math.PI / 2);
+  const right = armEnd(displayObserverAngle - Math.PI / 2);
   svg.appendChild(
     createSvgElement("line", {
       ...lineStyle,
-      x1: anchorX + leftD * Math.cos(leftAngle),
-      y1: anchorY + eclipticViewDirection * leftD * Math.sin(leftAngle),
-      x2: anchorX + rightD * Math.cos(rightAngle),
-      y2: anchorY + eclipticViewDirection * rightD * Math.sin(rightAngle),
+      x1: left.x,
+      y1: left.y,
+      x2: right.x,
+      y2: right.y,
     })
   );
 
   // Zenith line — from anchor skyward only (no nadir segment)
-  const zenithD =
-    rayCircleDistance(
-      anchorX,
-      anchorY,
-      Math.cos(displayObserverAngle),
-      eclipticViewDirection * Math.sin(displayObserverAngle),
-      CENTER,
-      CENTER,
-      CLIP_R
-    ) + EXTRA;
+  const zenith = armEnd(displayObserverAngle);
   svg.appendChild(
     createSvgElement("line", {
       ...lineStyle,
       x1: anchorX,
       y1: anchorY,
-      x2: anchorX + zenithD * Math.cos(displayObserverAngle),
-      y2: anchorY + eclipticViewDirection * zenithD * Math.sin(displayObserverAngle),
+      x2: zenith.x,
+      y2: zenith.y,
     })
   );
 }
@@ -318,15 +294,14 @@ export function renderObserverNeedle(
   earthSize: number,
   eclipticViewDirection = -1
 ): void {
-  const tipX = earthX + earthSize * Math.cos(observerAngle);
-  const tipY = earthY + eclipticViewDirection * earthSize * Math.sin(observerAngle);
+  const tip = polarOffset(earthX, earthY, earthSize, observerAngle, eclipticViewDirection);
 
   svg.appendChild(
     createSvgElement("line", {
       x1: earthX,
       y1: earthY,
-      x2: tipX,
-      y2: tipY,
+      x2: tip.x,
+      y2: tip.y,
       style: `stroke: ${NEEDLE_COLOR}`,
       "stroke-width": 2,
       "stroke-linecap": "round",
@@ -336,8 +311,8 @@ export function renderObserverNeedle(
   // Small dot at the tip for directionality
   svg.appendChild(
     createSvgElement("circle", {
-      cx: tipX,
-      cy: tipY,
+      cx: tip.x,
+      cy: tip.y,
       r: 2,
       style: `fill: ${NEEDLE_COLOR}`,
     })

--- a/src/renderer/svg-utils.ts
+++ b/src/renderer/svg-utils.ts
@@ -47,11 +47,36 @@ export function ellipseFromApsides(
 }
 
 /**
+ * A point `dist` away from (x, y) at `angle`, in the scene's own screen space.
+ *
+ * The single place the ecliptic-view mirror is applied. Screen y grows downward, so the
+ * north view (eclipticViewDirection = -1) negates the sine and the south view (+1) doesn't
+ * — a *reflection*, not a rotation, which is why orbitTransformComponents below has to be
+ * built to agree with this rather than derived as a plain rotate() (see its docstring, #94).
+ * Every body position, cone edge, horizon arm and needle tip goes through here, so the
+ * mirror cannot be applied inconsistently at one site and not another.
+ */
+export function polarOffset(
+  x: number,
+  y: number,
+  dist: number,
+  angle: number,
+  eclipticViewDirection: number
+): { x: number; y: number } {
+  return {
+    x: x + dist * Math.cos(angle),
+    y: y + eclipticViewDirection * dist * Math.sin(angle),
+  };
+}
+
+/**
  * A body's pixel position on its ellipse at the given true anomaly/angle — the polar
  * equation of an ellipse with the Sun at the focus, r = a(1-e²)/(1+e·cosθ), rotated into
  * screen space. Must stay derived identically for every body type: this is the same
  * formula orbitTransformComponents's matrix is built to agree with (see its docstring,
- * #94) — a marker computed any other way can drift off the drawn orbit ring.
+ * #94) — a marker computed any other way can drift off the drawn orbit ring. The final
+ * offset is polarOffset's, so "identically" is structural rather than a promise two
+ * copies of the same expression have to keep.
  */
 export function polarFromFocus(
   aPx: number,
@@ -61,10 +86,7 @@ export function polarFromFocus(
   eclipticViewDirection: number
 ): { x: number; y: number } {
   const radius = (aPx * (1 - ePx * ePx)) / (1 + ePx * Math.cos(trueAnomaly));
-  return {
-    x: CENTER + radius * Math.cos(angle),
-    y: CENTER + eclipticViewDirection * radius * Math.sin(angle),
-  };
+  return polarOffset(CENTER, CENTER, radius, angle, eclipticViewDirection);
 }
 
 export interface OrbitTransformComponents {

--- a/test/renderer/svg-utils.test.ts
+++ b/test/renderer/svg-utils.test.ts
@@ -8,6 +8,7 @@ import {
   MAX_RADIUS,
   MIN_RADIUS,
   polarFromFocus,
+  polarOffset,
   SVG_NS,
   VIEW_SIZE,
 } from "../../src/renderer/svg-utils.js";
@@ -93,6 +94,41 @@ describe("ellipseFromApsides", () => {
     const { aPx, bPx, cPx, ePx } = ellipseFromApsides(50, 150);
     expect(bPx).toBeCloseTo(Math.sqrt(aPx * aPx - cPx * cPx), 8);
     expect(ePx).toBeCloseTo(cPx / aPx, 8);
+  });
+});
+
+describe("polarOffset", () => {
+  it("walks the given distance along the angle, from the given point", () => {
+    expect(polarOffset(100, 200, 10, 0, -1)).toEqual({ x: 110, y: 200 });
+  });
+
+  // Screen y grows downward, so the north view negates the sine to put "up the page" at
+  // positive angles. The south view is the same scene mirrored, and only y moves.
+  it("mirrors only y when the direction flips", () => {
+    const north = polarOffset(100, 200, 10, Math.PI / 4, -1);
+    const south = polarOffset(100, 200, 10, Math.PI / 4, 1);
+    expect(south.x).toBeCloseTo(north.x, 12);
+    expect(south.y - 200).toBeCloseTo(-(north.y - 200), 12);
+  });
+
+  // A circular orbit puts the radius at aPx for every anomaly, so the composition can be
+  // asserted without restating the ellipse formula the test would then be checking against
+  // itself.
+  it("is what polarFromFocus offsets from CENTER with", () => {
+    const angle = 2.3;
+    expect(polarFromFocus(120, 0, 1.1, angle, -1)).toEqual(
+      polarOffset(CENTER, CENTER, 120, angle, -1)
+    );
+  });
+
+  // The unit vector rayCircleDistance is handed carries the same mirror as the endpoint it
+  // helps produce (see armEnd in observer.ts) — one primitive answers both.
+  it("gives the unit direction when distance is 1 from the origin", () => {
+    const angle = 0.7;
+    expect(polarOffset(0, 0, 1, angle, -1)).toEqual({
+      x: Math.cos(angle),
+      y: -Math.sin(angle),
+    });
   });
 });
 


### PR DESCRIPTION
## Why

`y = ay + dir * dist * Math.sin(angle)` — the ecliptic-view mirror — was written out **by hand at 8 sites**: cone edges ×2, Earth's orbital point, the observer anchor, both horizon arms, the zenith tip, the needle tip, and the Moon's position.

`polarFromFocus` already did exactly this, but hardcoded to `CENTER`, so every non-centred site re-derived it.

That matters beyond tidiness: `orbitTransformComponents` is deliberately built to agree with **that exact expression** (#94, a *reflection* not a rotation), and its own docstring warns the two must stay derived identically. A second hand-written copy is precisely how a marker drifts off its drawn orbit ring.

## What

```ts
// svg-utils.ts — the only place the mirror is applied
export function polarOffset(x, y, dist, angle, eclipticViewDirection) {
  return {
    x: x + dist * Math.cos(angle),
    y: y + eclipticViewDirection * dist * Math.sin(angle),
  };
}
```

- All 8 hand-written copies now go through it.
- `polarFromFocus` keeps its name, ellipse math and docstring — it just composes on `polarOffset` for the final offset, so "derived identically" is structural rather than a promise two copies have to keep.
- `rayCircleDistance` wants the same mirror as a **unit direction vector** (`polarOffset(0, 0, 1, angle, dir)`), which let the three horizon/zenith arms collapse into one `armEnd()` local — most of `observer.ts`'s **−62 lines**.

### Equivalence

The rendered SVG is **byte-identical**: same operations, same association order (`(dir * dist) * sin(angle)`). `test/snapshot.test.ts` is unchanged, and was treated as the oracle — a moved snapshot would have meant a defect in the refactor, not a snapshot to update.

## Also: a stale architecture note

`CLAUDE.md` described `renderSolarSystem()`'s `positions` as the seam for **SVG hit-testing (click targets)**. There is no hit-testing anywhere in the card.

What `positions` actually is: input to `updateMarkers` for offscreen markers, and an observation port so `test/renderer/collision.test.ts` can assert bodies never visually overlap at conjunction (#62) from the same numbers the scene was drawn with. Corrected in `CLAUDE.md` and documented at the return site.

A new note also records the rule this PR establishes — don't hand-write the mirror.

## Deliberately not done

**No `Projection` object** wrapping the `±1`. The matrix half is already owned by `orbitTransformComponents`, the mirror half is now owned by `polarOffset`, and the two remaining sign reads (`sweepFlag`, `isEcliptic`) are discrete chirality choices. Wrapping them would rename the type without removing a single call site.

The four `eclipticViewDirection = -1` defaults also stay: no `src/` caller omits the argument, and requiring it would add filler arguments to ~41 test calls to prevent a bug that cannot currently occur.

## Result

- 925 tests pass (47 files)
- Coverage 100% — statements, branches, functions, lines
- Statements 1452 → 1443 with identical output
- `check:ci` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)