### PR TITLE
chore: three loose ends from the architecture review

### DIFF
--- a/src/card/card-config.ts
+++ b/src/card/card-config.ts
@@ -1,7 +1,7 @@
 import type { CardConfig, Colors, ZoomLevel } from "../types.js";
 import type { GalleryMode, GalleryPosition, GalleryShape } from "./gallery/gallery-controller.js";
 import { DEFAULT_GALLERY_INTERVAL_MS } from "./gallery/gallery-controller.js";
-import type { GallerySource } from "./gallery/sources.js";
+import type { ImageSource } from "./gallery/sources.js";
 import { IMAGE_SOURCES, SOURCES } from "./gallery/sources.js";
 import { DEFAULT_ZOOM_LEVEL, MAX_ZOOM, MIN_ZOOM } from "./zoom-levels.js";
 
@@ -20,7 +20,7 @@ export interface ParsedCardConfig {
   galleryMode: GalleryMode;
   galleryPosition: GalleryPosition;
   galleryShape: GalleryShape;
-  gallerySources: GallerySource[];
+  gallerySources: ImageSource[];
   galleryIntervalMs: number;
 }
 
@@ -78,7 +78,7 @@ function resolveOverrideTimezone(timezone: string | undefined, lon: number): str
 // longer configurable now that each source is its own boolean rather than a position in a
 // list, so IMAGE_SOURCES' own order is the only order there is. Each source's own on/off
 // default is its `onByDefault` in the catalog (see sources.ts).
-function resolveGallerySources(gallery: CardConfig["gallery"]): GallerySource[] {
+function resolveGallerySources(gallery: CardConfig["gallery"]): ImageSource[] {
   return IMAGE_SOURCES.filter(
     (source) => (gallery?.[source] ?? SOURCES[source].onByDefault) === true
   );

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -14,7 +14,7 @@ import type {
 } from "./gallery/gallery-controller.js";
 import { GalleryController } from "./gallery/gallery-controller.js";
 import { fullSizeMoonUrl } from "./gallery/source-resolver-svs-moon.js";
-import type { GallerySource, ImageSource } from "./gallery/sources.js";
+import type { ImageSource } from "./gallery/sources.js";
 import { SOURCES } from "./gallery/sources.js";
 import { formatDate, formatRelativeWhen } from "./relative-time.js";
 import { SolarView } from "./solar-view.js";
@@ -272,7 +272,7 @@ export class SolarViewCard extends LitElement {
    * as every other empty/loading tile, instead of a flat color swatch with nothing on it.
    */
   private _renderGalleryTile(
-    source: GallerySource,
+    source: ImageSource,
     url: string | null,
     date: Date | null,
     skyFrame: () => SkyFrame,

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -5,7 +5,7 @@ import { parseCardConfig } from "./card-config.js";
 import { cardStyles } from "./card-styles.js";
 import { buildGalleryCaption, buildStatusBarView, discStyle } from "./card-template.js";
 import { DateNavigation } from "./date-navigation.js";
-import { buildDebugOverlay } from "./gallery/debug-view.js";
+import { buildDebugOverlay } from "./debug-view.js";
 import type {
   GalleryMode,
   GalleryPosition,

--- a/src/card/debug-view.ts
+++ b/src/card/debug-view.ts
@@ -1,8 +1,8 @@
 import type { TemplateResult } from "lit";
 import { html } from "lit";
-import { formatDate, formatDuration } from "../relative-time.js";
-import type { SourceDebugStats } from "./debug-stats.js";
-import type { DebugRowId } from "./sources.js";
+import type { SourceDebugStats } from "./gallery/debug-stats.js";
+import type { DebugRowId } from "./gallery/sources.js";
+import { formatDate, formatDuration } from "./relative-time.js";
 
 // The overlay's own row order and column headings. Which source reports into which row is
 // each source's own fact — see SourceSpec.debugRow in sources.ts, and the DebugRowId comment

--- a/src/card/gallery/debug-stats.ts
+++ b/src/card/gallery/debug-stats.ts
@@ -1,5 +1,5 @@
 // The counters the gallery fetch protocol keeps, and the snapshot the overlay renders from.
-// Nothing here draws anything — see debug-view.ts for that half.
+// Nothing here draws anything — see card/debug-view.ts for that half.
 //
 // Cumulative, since the card was mounted — not a rolling window. Lets debug:true answer "is
 // this source's own cache actually saving anything" at a glance: `refreshes` vs. network calls
@@ -19,7 +19,7 @@
 // (source-resolver-sdo-sun.ts) learns the feed's real lag; a rising rate means it is spending
 // its ticks probing rather than resting at the floor. `lastAttemptAt` is the raw timestamp of the most
 // recent preload attempt, formatted at render time.
-// Field order matches the overlay's column order (buildDebugOverlay in debug-view.ts).
+// Field order matches the overlay's column order (buildDebugOverlay in card/debug-view.ts).
 export interface SourceDebugStats {
   refreshes: number;
   cacheHits: number;

--- a/src/card/gallery/gallery-controller.ts
+++ b/src/card/gallery/gallery-controller.ts
@@ -1,7 +1,7 @@
 import type { DebugAccumulator, SourceDebugStats } from "./debug-stats.js";
 import { emptyDebugAccumulator, toDebugStats } from "./debug-stats.js";
 import { ImageResolver } from "./image-resolver.js";
-import type { DebugRowId, GallerySource, ImageSource } from "./sources.js";
+import type { DebugRowId, ImageSource } from "./sources.js";
 import { IMAGE_SOURCES, SOURCES } from "./sources.js";
 import type { SourcedImage } from "./url-cache.js";
 
@@ -27,7 +27,7 @@ export type GalleryShape = "circle" | "square";
 // The enabled set before setConfig's first call resolves gallery.<source> against each
 // source's own default (see card-config.ts) — mymoon only, so a card mounted with no config
 // at all still shows something rather than an empty strip.
-export const DEFAULT_GALLERY_SOURCES: GallerySource[] = ["mymoon"];
+export const DEFAULT_GALLERY_SOURCES: ImageSource[] = ["mymoon"];
 
 // Render-ready shape for card.ts's template — raw data only (dates, urls, booleans), no
 // formatting, so formatRelativeAge/date-formatting stays in card.ts alongside its other
@@ -40,7 +40,7 @@ export interface GalleryViewModel {
   imageDate: Date | null;
   imageLoaded: boolean;
   showStrip: boolean;
-  thumbnails: { source: GallerySource; url: string | null; date: Date | null }[];
+  thumbnails: { source: ImageSource; url: string | null; date: Date | null }[];
   debugStats: Record<DebugRowId, SourceDebugStats>;
   debugStartedAt: number;
 }
@@ -69,7 +69,7 @@ export class GalleryController {
   private _debug: Record<DebugRowId, DebugAccumulator>;
   private _debugStartedAt: number;
   private _resolver: ImageResolver;
-  private _sources: GallerySource[];
+  private _sources: ImageSource[];
 
   constructor(onChange: () => void) {
     this._panelMode = "none";
@@ -133,7 +133,7 @@ export class GalleryController {
 
   // Sources rendered as thumbnails right now — the configured list verbatim, except in
   // "slide" where only the source the rotation currently sits on is shown.
-  get displaySources(): GallerySource[] {
+  get displaySources(): ImageSource[] {
     return this._mode === "slide" ? [this._sources[this._slideIndex]] : this._sources;
   }
 
@@ -161,7 +161,7 @@ export class GalleryController {
   // resetting _galleryOpen from mode every call). Restarts the auto-switch timer if one is
   // already running, same as the old `if (this._autoSwitchTimer != null)
   // this._startAutoSwitchTimer()` in setConfig.
-  configure(mode: GalleryMode, sources: GallerySource[], autoIntervalMs: number): void {
+  configure(mode: GalleryMode, sources: ImageSource[], autoIntervalMs: number): void {
     this._mode = mode;
     this._sources = sources;
     this._autoIntervalMs = autoIntervalMs;

--- a/src/card/gallery/sources.ts
+++ b/src/card/gallery/sources.ts
@@ -5,11 +5,6 @@
 // geocentric, celestial-north-up; the sky tile rotates it into the observer's own orientation.
 export type ImageSource = "mymoon" | "moon" | "earth" | "sun";
 
-// Everything that can occupy a slot in the strip. Same set as ImageSource now that the
-// locally drawn disc is gone — kept as its own alias since the strip is the concept these
-// call sites care about, not the fetch mechanics.
-export type GallerySource = ImageSource;
-
 // The fixed render order — no longer configurable now that each source is its own
 // `gallery.<source>` boolean rather than a position in a list.
 export const IMAGE_SOURCES: ImageSource[] = ["mymoon", "moon", "earth", "sun"];

--- a/src/renderer/bodies.ts
+++ b/src/renderer/bodies.ts
@@ -1,4 +1,5 @@
 import type { CelestialBody, CometVisualEllipse } from "../types.js";
+import type { EclipticViewDirection } from "./svg-utils.js";
 import {
   BODY_LABEL_ATTRS,
   CENTER,
@@ -45,7 +46,7 @@ function verticalAxisIntersections(
 export function renderOrbit(
   svg: SVGElement,
   ellipse: CometVisualEllipse,
-  eclipticViewDirection: number
+  eclipticViewDirection: EclipticViewDirection
 ): void {
   const orbitColor = ORBIT_COLOR;
   const { aPx, bPx, cPx, rotationDeg } = ellipse;

--- a/src/renderer/comets.ts
+++ b/src/renderer/comets.ts
@@ -1,5 +1,6 @@
 import type { Comet, CometVisualEllipse } from "../types.js";
 import { ORBIT_COLOR } from "./bodies.js";
+import type { EclipticViewDirection } from "./svg-utils.js";
 import {
   auToRadius,
   BODY_LABEL_ATTRS,
@@ -41,7 +42,7 @@ export function computeCometVisualEllipse(comet: Comet): CometVisualEllipse {
 export function renderCometOrbit(
   svg: SVGElement,
   comet: Comet,
-  eclipticViewDirection: number
+  eclipticViewDirection: EclipticViewDirection
 ): void {
   const { aPx, bPx, cPx, rotationDeg } = computeCometVisualEllipse(comet);
 

--- a/src/renderer/observer.ts
+++ b/src/renderer/observer.ts
@@ -6,6 +6,7 @@ import {
   getLocalTimeInZone,
 } from "../astronomy/solar-position.js";
 import type { Colors, LocationData } from "../types.js";
+import type { EclipticViewDirection } from "./svg-utils.js";
 import { CENTER, createSvgElement, MAX_RADIUS, polarOffset, VIEW_SIZE } from "./svg-utils.js";
 
 const NEEDLE_COLOR = "color-mix(in srgb, currentColor 70%, transparent)";
@@ -140,7 +141,7 @@ function renderVisibilityCone(
   halfAngleDeg: number,
   clipId: string,
   fillColor: string,
-  eclipticViewDirection = -1
+  eclipticViewDirection: EclipticViewDirection = -1
 ): void {
   const D = VIEW_SIZE;
   const HALF_ANGLE = (halfAngleDeg * Math.PI) / 180;
@@ -181,7 +182,7 @@ export function renderDayNightSplit(
   date: Date,
   earthBodySize: number,
   locationData: LocationData | null,
-  eclipticViewDirection = -1,
+  eclipticViewDirection: EclipticViewDirection = -1,
   colors: Colors = {}
 ): void {
   const earthAngle = calculatePlanetPosition(EARTH, date);
@@ -292,7 +293,7 @@ export function renderObserverNeedle(
   earthY: number,
   observerAngle: number,
   earthSize: number,
-  eclipticViewDirection = -1
+  eclipticViewDirection: EclipticViewDirection = -1
 ): void {
   const tip = polarOffset(earthX, earthY, earthSize, observerAngle, eclipticViewDirection);
 

--- a/src/renderer/seasons.ts
+++ b/src/renderer/seasons.ts
@@ -1,4 +1,5 @@
 import type { Colors, Hemisphere } from "../types.js";
+import type { EclipticViewDirection } from "./svg-utils.js";
 import { CENTER, createSvgElement, MAX_RADIUS, VIEW_SIZE } from "./svg-utils.js";
 
 const DEFAULT_SEASON_LINE_COLOR = "color-mix(in srgb, currentColor 25%, transparent)";
@@ -9,7 +10,7 @@ export function renderSeasonOverlay(
   svg: SVGElement,
   hemisphere: Hemisphere,
   colors: Colors = {},
-  eclipticViewDirection = -1
+  eclipticViewDirection: EclipticViewDirection = -1
 ): void {
   const lineColor = colors.season_line ?? DEFAULT_SEASON_LINE_COLOR;
   const labelColor = colors.season_label ?? DEFAULT_SEASON_LABEL_COLOR;

--- a/src/renderer/svg-utils.ts
+++ b/src/renderer/svg-utils.ts
@@ -1,6 +1,13 @@
 import { PLANETS } from "../astronomy/planet-data.js";
 import type { CometVisualEllipse } from "../types.js";
 
+/**
+ * Which way the scene is mirrored: -1 for the default north-up view, +1 for the south-up
+ * ecliptic view. A literal union rather than `number` so a stray 0 or 2 — which would silently
+ * flatten or double every y-offset polarOffset produces — cannot be passed at all.
+ */
+export type EclipticViewDirection = 1 | -1;
+
 export const SVG_NS = "http://www.w3.org/2000/svg";
 export const DEFAULT_LABEL_COLOR = "currentColor";
 export const VIEW_SIZE = 800;
@@ -50,7 +57,7 @@ export function ellipseFromApsides(
  * A point `dist` away from (x, y) at `angle`, in the scene's own screen space.
  *
  * The single place the ecliptic-view mirror is applied. Screen y grows downward, so the
- * north view (eclipticViewDirection = -1) negates the sine and the south view (+1) doesn't
+ * north view (eclipticViewDirection: EclipticViewDirection = -1) negates the sine and the south view (+1) doesn't
  * — a *reflection*, not a rotation, which is why orbitTransformComponents below has to be
  * built to agree with this rather than derived as a plain rotate() (see its docstring, #94).
  * Every body position, cone edge, horizon arm and needle tip goes through here, so the
@@ -61,7 +68,7 @@ export function polarOffset(
   y: number,
   dist: number,
   angle: number,
-  eclipticViewDirection: number
+  eclipticViewDirection: EclipticViewDirection
 ): { x: number; y: number } {
   return {
     x: x + dist * Math.cos(angle),
@@ -83,7 +90,7 @@ export function polarFromFocus(
   ePx: number,
   trueAnomaly: number,
   angle: number,
-  eclipticViewDirection: number
+  eclipticViewDirection: EclipticViewDirection
 ): { x: number; y: number } {
   const radius = (aPx * (1 - ePx * ePx)) / (1 + ePx * Math.cos(trueAnomaly));
   return polarOffset(CENTER, CENTER, radius, angle, eclipticViewDirection);
@@ -103,7 +110,7 @@ export interface OrbitTransformComponents {
  * (rx=aPx, ry=bPx, drawn at cx=0, cy=0) so the Sun sits at one focus and the
  * ring exactly matches the marker's polar-from-focus formula: x = C + r·cosθ,
  * y = C + eclipticViewDirection·r·sinθ. That formula is a *reflection*
- * whenever eclipticViewDirection = -1 (determinant -1), not a rotation — a
+ * whenever eclipticViewDirection: EclipticViewDirection = -1 (determinant -1), not a rotation — a
  * plain rotate()/translate() (determinant +1) only agrees with it at
  * perihelion and aphelion, leaving the marker visibly off the drawn ring
  * everywhere else (#94). This is derived directly from that same formula so
@@ -114,7 +121,7 @@ export interface OrbitTransformComponents {
 export function orbitTransformComponents(
   cPx: number,
   rotationDeg: number,
-  eclipticViewDirection: number
+  eclipticViewDirection: EclipticViewDirection
 ): OrbitTransformComponents {
   const rotation = (rotationDeg * Math.PI) / 180;
   const cos = Math.cos(rotation);
@@ -132,7 +139,7 @@ export function orbitTransformComponents(
 export function orbitTransformMatrix(
   cPx: number,
   rotationDeg: number,
-  eclipticViewDirection: number
+  eclipticViewDirection: EclipticViewDirection
 ): string {
   const { a, b, c, d, e, f } = orbitTransformComponents(cPx, rotationDeg, eclipticViewDirection);
   return `matrix(${a}, ${b}, ${c}, ${d}, ${e}, ${f})`;

--- a/test/card/debug-view.test.ts
+++ b/test/card/debug-view.test.ts
@@ -1,8 +1,8 @@
 import { render } from "lit";
 import { describe, expect, it } from "vitest";
-import type { SourceDebugStats } from "../../../src/card/gallery/debug-stats.js";
-import { buildDebugOverlay } from "../../../src/card/gallery/debug-view.js";
-import { formatDate } from "../../../src/card/relative-time.js";
+import { buildDebugOverlay } from "../../src/card/debug-view.js";
+import type { SourceDebugStats } from "../../src/card/gallery/debug-stats.js";
+import { formatDate } from "../../src/card/relative-time.js";
 
 const zeroDebugStats: SourceDebugStats = {
   refreshes: 0,


### PR DESCRIPTION
Three small tidies that surfaced during #159–#163 but each belonged to a different concern than the PR that found it. **One commit each**, so they revert independently — bundled into one PR only because all three are mechanical and none changes behaviour.

## 1. `refactor: type the ecliptic direction as 1 | -1` (`ef65358`)

`eclipticViewDirection: number` accepts `0` and `2`, either of which would silently flatten or double every y-offset `polarOffset` produces. A literal union makes those unrepresentable.

Costs nothing at the call sites: every one already passes a literal, which TypeScript infers as the literal type — no test needed `as const`.

## 2. `refactor: drop the GallerySource alias` (`3888d11`)

`type GallerySource = ImageSource` existed while the strip could hold a locally drawn disc that was never fetched. #154 removed that, so the two names have described the same set ever since — one of them is a synonym a reader has to check.

`resolveGallerySources` keeps its name: it resolves which of the gallery's sources are enabled, which is still what it does.

## 3. `refactor: move debug-view out of gallery/` (`6ef47c0`)

The debug overlay renders card chrome — a Lit template in the status-bar row, mounted by `card.ts`. It sat under `gallery/` because its numbers come from the fetch protocol, but it was the only template in a directory that is otherwise fetching, caching and backoff.

The counters stay where they are produced (`gallery/debug-stats.ts`, five importers there); only the rendering half moves up beside `card-template.ts`.

## Result

No behaviour change in any of the three.

- 910 tests pass (46 files)
- Coverage 100% — statements, branches, functions, lines
- `check:ci` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)