### PR TITLE
feat: say "No Moon Sky" when the Moon is below the horizon

### DIFF
--- a/src/card/card-styles.ts
+++ b/src/card/card-styles.ts
@@ -86,6 +86,8 @@ export const cardStyles = css`
      because it never paints outside this frame's own box in the first place. */
   .image-view-frame {
     display: none;
+    /* Static by default, which would let .no-sky's inset escape to the card. */
+    position: relative;
     width: 100%;
     aspect-ratio: 1;
     overflow: hidden;
@@ -104,6 +106,35 @@ export const cardStyles = css`
     background: #000;
     cursor: pointer;
     display: block;
+  }
+  /* Stands in for the image, in the tile and in the full-screen panel alike: fills whichever
+     box it lands in and centres on both axes, so one rule serves a 104px thumbnail and a
+     full-width panel without either needing to know about the other. */
+  .no-sky {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 4px;
+    box-sizing: border-box;
+    background: #000;
+    /* Fixed white, not currentColor: the tile and the panel frame are #000 in every theme
+       (see .gallery-thumb / .image-view-frame), so a theme-following colour would resolve to
+       dark ink on black the moment the card is on a light theme. Same reasoning as
+       .gallery-label/.gallery-age below, just dimmer — this reads as an absence, not a label. */
+    color: rgba(255, 255, 255, 0.65);
+    line-height: 1.2;
+    cursor: pointer;
+    font-size: 1rem;
+  }
+  /* Only the tile scales with its own width, against the container query .gallery-thumb
+     already declares — floored in px so it stays legible on a narrow card. Deliberately not
+     on the shared rule above: .image-view-frame is not a query container, so cqw there would
+     resolve against the viewport and render the panel's copy many times too large. */
+  .gallery-thumb .no-sky {
+    font-size: max(9px, 13cqw);
   }
   .gallery {
     display: flex;

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -6,12 +6,7 @@ import { cardStyles } from "./card-styles.js";
 import { buildGalleryCaption, buildStatusBarView, discStyle } from "./card-template.js";
 import { DateNavigation } from "./date-navigation.js";
 import { buildDebugOverlay } from "./debug-view.js";
-import type {
-  GalleryMode,
-  GalleryPosition,
-  GalleryShape,
-  ImagePanelMode,
-} from "./gallery/gallery-controller.js";
+import type { GalleryMode, GalleryPosition, GalleryShape } from "./gallery/gallery-controller.js";
 import { GalleryController } from "./gallery/gallery-controller.js";
 import { fullSizeMoonUrl } from "./gallery/source-resolver-svs-moon.js";
 import type { ImageSource } from "./gallery/sources.js";
@@ -36,6 +31,18 @@ const SUSPENDS_AUTO_ZOOM = new Set([
   "month-back",
   "month-forward",
 ]);
+
+/**
+ * What the sky tile shows in place of the Moon while the Moon is below the horizon — in the
+ * thumbnail and in the full-screen panel, from one builder so the two can't drift apart.
+ *
+ * Only the panel's copy takes a handler: the thumbnail's sits inside a <button> that already
+ * closes over its own click, while the panel's stands in for the image that used to be the
+ * way back out, and has to carry that click itself.
+ */
+function noMoonSky(onClick?: (e: Event) => void): TemplateResult {
+  return html`<div class="no-sky" @click=${onClick}>No Moon Sky</div>`;
+}
 
 export class SolarViewCard extends LitElement {
   static styles = cardStyles;
@@ -150,6 +157,10 @@ export class SolarViewCard extends LitElement {
     const sky = () => (skyFrame ??= this._location.skyFrame(now));
 
     const gallery = this._gallery.viewModel(this._galleryPosition);
+    // The open panel's own sky, or null when the panel is closed or shows a source that has no
+    // observer frame — same question _renderGalleryTile asks per tile, asked once for the panel.
+    const panelSky =
+      gallery.panelSource !== "none" && SOURCES[gallery.panelSource].skyFrame ? sky() : null;
     const statusBar = buildStatusBarView(
       gallery,
       this._location.data,
@@ -175,16 +186,20 @@ export class SolarViewCard extends LitElement {
             class="image-view-frame ${gallery.panelSource === "none" ? "" : "visible"}"
             style=${this._panelFrameStyle()}
           >
-            <img
-              id="image-view"
-              class="image-view"
-              style=${this._panelImageStyle(gallery.panelSource, sky)}
-              src=${gallery.imageUrl ? fullSizeMoonUrl(gallery.imageUrl) : nothing}
-              alt=""
-              @click=${this._onImageClick}
-              @load=${this._onImageLoad}
-              @error=${this._onImageLoadError}
-            />
+            ${
+              panelSky?.belowHorizon
+                ? noMoonSky(this._onImageClick)
+                : html`<img
+                    id="image-view"
+                    class="image-view"
+                    style=${this._panelImageStyle(panelSky)}
+                    src=${gallery.imageUrl ? fullSizeMoonUrl(gallery.imageUrl) : nothing}
+                    alt=""
+                    @click=${this._onImageClick}
+                    @load=${this._onImageLoad}
+                    @error=${this._onImageLoadError}
+                  />`
+            }
           </div>
           ${
             gallery.showStrip
@@ -261,10 +276,12 @@ export class SolarViewCard extends LitElement {
    * a moon branch and an everything-else branch.
    *
    * The sky tile is the only one that differs, in two ways: it rotates the same frame `moon`
-   * shows into the observer's own orientation, and it leaves the image out entirely — rather
-   * than rendering a Moon that isn't there — while the Moon is below the horizon. The caption
-   * always reads the frame's own age, same as every other tile; the tile stays clickable
-   * either way, so the full-screen view still has the geocentric frame to show.
+   * shows into the observer's own orientation, and while the Moon is below the horizon it says
+   * so in words — rather than rendering a Moon that isn't there, or leaving a black square that
+   * reads as a tile which failed to load. The caption always reads the frame's own age, same as
+   * every other tile; the tile stays clickable either way, and the full-screen view carries the
+   * same message rather than falling back to the geocentric frame — a view the observer
+   * explicitly asked for their own sky is the wrong place to answer with someone else's.
    *
    * The sky's day/twilight/night color washes over the Moon photo itself (a
    * .gallery-thumb-tint layer, mix-blend-mode: color) rather than filling the tile behind it —
@@ -291,7 +308,7 @@ export class SolarViewCard extends LitElement {
     >
       ${
         sky?.belowHorizon
-          ? nothing
+          ? noMoonSky()
           : html`<img
               src=${url ?? nothing}
               alt=""
@@ -334,12 +351,9 @@ export class SolarViewCard extends LitElement {
    * what the thumbnail showed rather than snapping back to the geocentric frame the moment it
    * is opened. Every other source needs no style of its own here.
    */
-  private _panelImageStyle(
-    panelSource: ImagePanelMode,
-    skyFrame: () => SkyFrame
-  ): string | typeof nothing {
-    if (panelSource === "none" || !SOURCES[panelSource].skyFrame) return nothing;
-    return `transform: rotate(${skyFrame().rotation.toFixed(1)}deg)`;
+  private _panelImageStyle(panelSky: SkyFrame | null): string | typeof nothing {
+    if (!panelSky) return nothing;
+    return `transform: rotate(${panelSky.rotation.toFixed(1)}deg)`;
   }
 
   /**

--- a/test/__snapshots__/snapshot.test.ts.snap
+++ b/test/__snapshots__/snapshot.test.ts.snap
@@ -108,6 +108,8 @@ exports[`cardStyles > matches snapshot 1`] = `
      because it never paints outside this frame's own box in the first place. */
   .image-view-frame {
     display: none;
+    /* Static by default, which would let .no-sky's inset escape to the card. */
+    position: relative;
     width: 100%;
     aspect-ratio: 1;
     overflow: hidden;
@@ -126,6 +128,35 @@ exports[`cardStyles > matches snapshot 1`] = `
     background: #000;
     cursor: pointer;
     display: block;
+  }
+  /* Stands in for the image, in the tile and in the full-screen panel alike: fills whichever
+     box it lands in and centres on both axes, so one rule serves a 104px thumbnail and a
+     full-width panel without either needing to know about the other. */
+  .no-sky {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 4px;
+    box-sizing: border-box;
+    background: #000;
+    /* Fixed white, not currentColor: the tile and the panel frame are #000 in every theme
+       (see .gallery-thumb / .image-view-frame), so a theme-following colour would resolve to
+       dark ink on black the moment the card is on a light theme. Same reasoning as
+       .gallery-label/.gallery-age below, just dimmer — this reads as an absence, not a label. */
+    color: rgba(255, 255, 255, 0.65);
+    line-height: 1.2;
+    cursor: pointer;
+    font-size: 1rem;
+  }
+  /* Only the tile scales with its own width, against the container query .gallery-thumb
+     already declares — floored in px so it stays legible on a narrow card. Deliberately not
+     on the shared rule above: .image-view-frame is not a query container, so cqw there would
+     resolve against the viewport and render the panel's copy many times too large. */
+  .gallery-thumb .no-sky {
+    font-size: max(9px, 13cqw);
   }
   .gallery {
     display: flex;

--- a/test/card/card.gallery.test.ts
+++ b/test/card/card.gallery.test.ts
@@ -108,6 +108,109 @@ describe("SolarViewCard gallery", () => {
       vi.useRealTimers();
     });
 
+    // Below the horizon there is no Moon to show, but an empty black square reads as a tile
+    // that failed to load. The text says which of the two it is.
+    describe("no moon in the sky", () => {
+      const DOWN = "2026-08-22T10:15:00Z"; // Denton, Moon well below the horizon
+      const UP = "2026-08-22T02:15:00Z"; // same place, Moon up
+
+      function mountAt(iso) {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date(iso));
+        const card = document.createElement("ha-planetary-solar-system-card-test");
+        card.setConfig({
+          gallery: { mode: "open" },
+          location: { latitude: 33.2148, longitude: -97.1331, timezone: "America/Chicago" },
+        });
+        document.body.appendChild(card);
+        return card;
+      }
+
+      it("names the empty sky in the tile instead of leaving it blank", async () => {
+        const card = mountAt(DOWN);
+        await vi.advanceTimersByTimeAsync(0);
+        const tile = card.shadowRoot.querySelector('[data-source="mymoon"]');
+        expect(tile.querySelector("img")).toBeNull();
+        expect(tile.querySelector(".no-sky").textContent.trim()).toBe("No Moon Sky");
+        card.remove();
+        vi.useRealTimers();
+      });
+
+      // The caption is the tile's own line and stays put — the message replaces the image, not
+      // the label or the frame age every other tile also carries.
+      it("keeps the normal caption underneath it", async () => {
+        const card = mountAt(DOWN);
+        await vi.advanceTimersByTimeAsync(0);
+        const tile = card.shadowRoot.querySelector('[data-source="mymoon"]');
+        expect(tile.querySelector(".gallery-label").textContent).toBe("MYMOON");
+        expect(tile.querySelector(".gallery-age").textContent).toBe("15m ago");
+        card.remove();
+        vi.useRealTimers();
+      });
+
+      it("says the same thing full-screen, rather than the geocentric render", async () => {
+        const card = mountAt(DOWN);
+        await vi.advanceTimersByTimeAsync(0);
+        card.shadowRoot.querySelector('[data-source="mymoon"]').click();
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(card.shadowRoot.querySelector("#image-view")).toBeNull();
+        expect(card.shadowRoot.querySelector(".image-view-frame .no-sky").textContent.trim()).toBe(
+          "No Moon Sky"
+        );
+        card.remove();
+        vi.useRealTimers();
+      });
+
+      // The image it replaces was the way back out of the panel, so the message has to be too.
+      it("closes the panel when the message is clicked", async () => {
+        const card = mountAt(DOWN);
+        await vi.advanceTimersByTimeAsync(0);
+        card.shadowRoot.querySelector('[data-source="mymoon"]').click();
+        await vi.advanceTimersByTimeAsync(0);
+        expect(card._gallery.panelMode).toBe("mymoon");
+
+        card.shadowRoot.querySelector(".image-view-frame .no-sky").click();
+        await vi.advanceTimersByTimeAsync(0);
+        expect(card._gallery.panelMode).toBe("none");
+        card.remove();
+        vi.useRealTimers();
+      });
+
+      it("shows the Moon, and no message, once it is up", async () => {
+        const card = mountAt(UP);
+        await vi.advanceTimersByTimeAsync(0);
+        const tile = card.shadowRoot.querySelector('[data-source="mymoon"]');
+        expect(tile.querySelector("img")).not.toBeNull();
+        expect(tile.querySelector(".no-sky")).toBeNull();
+
+        tile.click();
+        await vi.advanceTimersByTimeAsync(0);
+        expect(card.shadowRoot.querySelector("#image-view")).not.toBeNull();
+        expect(card.shadowRoot.querySelector(".no-sky")).toBeNull();
+        card.remove();
+        vi.useRealTimers();
+      });
+
+      // Every other source is a photograph of a body that is always there to photograph.
+      it("never appears on a source that is not the observer's own sky", async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date(DOWN));
+        const card = document.createElement("ha-planetary-solar-system-card-test");
+        card.setConfig({
+          gallery: { mode: "open", moon: true, earth: true, sun: true },
+          location: { latitude: 33.2148, longitude: -97.1331, timezone: "America/Chicago" },
+        });
+        document.body.appendChild(card);
+        await vi.advanceTimersByTimeAsync(0);
+        for (const source of ["moon", "earth", "sun"]) {
+          expect(card.shadowRoot.querySelector(`[data-source="${source}"] .no-sky`)).toBeNull();
+        }
+        card.remove();
+        vi.useRealTimers();
+      });
+    });
+
     // Same location, an instant the Moon is actually up for: the caption falls back to the
     // normal frame-age phrasing, same as every other tile — it needs the resolved image date,
     // so unlike the below-horizon case this waits for the background fetch to land.
@@ -274,18 +377,25 @@ describe("SolarViewCard gallery", () => {
     });
 
     // Opening the sky tile must not snap back to the geocentric frame.
+    //
+    // Pinned to an instant the Moon is actually up: the panel only holds an image while it is,
+    // so on real wall-clock time this asserted against whichever sky the suite happened to run
+    // under, and would have started failing roughly half the day.
     it("carries the sky rotation into the full-screen view", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-08-22T02:15:00Z"));
       const card = createAndMount({
         gallery: { mode: "open" },
         location: { latitude: 33.2148, longitude: -97.1331, timezone: "America/Chicago" },
       });
-      await flush();
+      await vi.advanceTimersByTimeAsync(0);
       card.shadowRoot.querySelector('[data-source="mymoon"]').click();
-      await flush();
+      await vi.advanceTimersByTimeAsync(0);
       expect(card.shadowRoot.querySelector("#image-view").getAttribute("style")).toMatch(
         /transform: rotate\(-?\d+(\.\d+)?deg\)/
       );
       card.remove();
+      vi.useRealTimers();
     });
 
     // gallery.shape flips the crop between a round puck and a square one — both are scaled


### PR DESCRIPTION
## Why

The sky tile drew **nothing** while the Moon was below the horizon — a black square that reads as a tile which failed to load, not as an answer. It now says which of the two it is, centred where the image would have been.

## What

Text replaces the image, centred, in **both** the tile and the full-screen panel:

| | |
| --- | --- |
| **tile** | `No Moon Sky` centred; the `MYMOON` / frame-age caption is unchanged below it |
| **panel** | the same message, from the same builder, carrying the click that closes the panel |

The panel change reverses a deliberate choice — it used to fall back to the geocentric NASA render. The reasoning is now in the comment: *a view explicitly asked for as the observer's own sky is the wrong place to answer with someone else's.*

One builder serves both so they cannot drift. Only the panel's copy takes a click handler: the tile's sits inside a `<button>` that already has one, while the panel's stands in for the image that used to be the way back out.

## Two CSS bugs the test suite could not see

Both found by rendering the card in a real browser, not by a failing test:

1. **`currentColor` would have been invisible on a light theme.** The tile and panel frame are `#000` in *every* theme, so a theme-following colour resolves to dark ink on black. `.gallery-label` / `.gallery-age` are already a fixed `#fff` for exactly this reason; `.no-sky` now uses a fixed `rgba(255,255,255,0.65)` — dimmer, so it reads as an absence rather than a label.
2. **`13cqw` would have rendered ~78px in the panel.** It works in the tile because `.gallery-thumb` declares `container-type: inline-size`. `.image-view-frame` does not, so an unscoped `cqw` resolves against the *viewport*. The container-relative size is now scoped to `.gallery-thumb .no-sky`; the panel is a flat `1rem`.

## A latent flaky test this exposed

`"carries the sky rotation into the full-screen view"` ran on **real wall-clock time** and asserted `#image-view` exists — which is now false whenever the Moon is down. It would have started failing roughly half the day. Pinned to a fixed instant.

## Verification

Rendered headlessly at a pinned instant (Denton, Moon below horizon) and checked in **dark and light theme, tile and panel**.

- 916 tests pass (46 files), 6 new
- Coverage 100% — statements, branches, functions, lines
- `check:ci` clean
- Snapshot updated for the added CSS only — no existing rule changed

## Not addressed here

- **The panel status bar** still reads `MOON · NASA SVS · rendered … · 15m ago` while the panel says there is no Moon. It describes a frame that isn't shown. Outside the scope of this change, but it reads as contradictory.
- **Pre-existing flake:** `backoff-integration.test.ts > a sustained sun-source outage…` fails intermittently — measured at **2 failures in 5 full runs on `main`**, the same rate as on this branch. Not caused here, but it can redden CI at random.

🤖 Generated with [Claude Code](https://claude.com/claude-code)