### PR TITLE
feat: name the gallery tiles by where they look from, plus doc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ colors:
 type: custom:ha-planetary-solar-system-card
 gallery:
   mode: slide
+  mymoon: false
   moon: true
   earth: true
   sun: true

--- a/README.md
+++ b/README.md
@@ -70,25 +70,12 @@ location:
 ## Horizon Twilight Zones
 
 The visibility cone at Earth's orbit shades by how far the Sun is below your local horizon, using
-the standard astronomical twilight definitions.
-
-Both bodies are checked against the [US Naval Observatory][usno] almanac for Denton (US), Montevideo
-(UY) and Kraków (PL), across both solstices and an equinox. Altitude lands within **0.02°** for the
-Moon and **0.01°** for the Sun, over 62 sampled positions from -7° to +80°; rise and set times land
-within **1 minute** for both. The Moon marker and the drawn horizon line agree except within 5° of
-the horizon, where the Moon's 5.1° of ecliptic latitude has nowhere to go in a top-down view of the
-ecliptic plane.
-
-Day ends at the almanac's sunset — the Sun's centre at **-0.8333°**, where 34' of refraction plus
-the Sun's own 16' radius put the upper limb on the horizon. The -6°/-12°/-18° boundaries below are
-measured to the Sun's centre with no correction, so a civil-twilight interval has a refracted start
-and a geometric end. That asymmetry is the published convention, and it is what makes these
-transition times line up with any almanac you check them against.
+the standard astronomical twilight definitions:
 
 | Zone                  | Sun elevation | Meaning                                                          |
 | --------------------- | ------------- | ---------------------------------------------------------------- |
-| Day                   | ≥ 0°          | Sun is up                                                        |
-| Civil twilight        | 0° to -6°     | Bright enough for outdoor activity without lights                |
+| Day                   | ≥ -0.83°      | Sun is up — its upper limb still on the horizon                  |
+| Civil twilight        | -0.83° to -6° | Bright enough for outdoor activity without lights                |
 | Nautical twilight     | -6° to -12°   | Horizon still visible at sea; too dark for most outdoor activity |
 | Astronomical twilight | -12° to -18°  | Sky background glow, faint stars washed out                      |
 | Night                 | < -18°        | Full dark; the Sun no longer lights the sky                      |
@@ -210,7 +197,6 @@ a pipeline stall doesn't break the feed.
 [my-hacs-shield]: https://my.home-assistant.io/badges/hacs_repository.svg
 [epic]: https://epic.gsfc.nasa.gov/
 [sdo]: https://sdo.gsfc.nasa.gov/
-[usno]: https://aa.usno.navy.mil/data/RS_OneDay
 [svs]: https://svs.gsfc.nasa.gov/5587/
 [repo]: https://github.com/marcintk/ha-planetary-solar-system-card
 [license]: https://github.com/marcintk/ha-planetary-solar-system-card/blob/main/LICENSE

--- a/README.md
+++ b/README.md
@@ -112,12 +112,12 @@ full-screen. Which tiles appear is `gallery.mymoon` / `gallery.moon` / `gallery.
 
 | Thumbnail | Source            | Shows                                                   | We fetch | Age of what you see |
 | --------- | ----------------- | ------------------------------------------------------- | -------- | ------------------- |
-| MY-MOON   | [NASA SVS][svs]   | The Moon in my sky — hidden when it's below the horizon | Hourly   | Under an hour       |
+| MY MOON   | [NASA SVS][svs]   | The Moon in my sky — hidden when it's below the horizon | Hourly   | Under an hour       |
 | MOON      | [NASA SVS][svs]   | The Moon from Earth's centre — no Earth in frame        | Hourly   | Under an hour       |
 | DSCOVR/E  | [NASA EPIC][epic] | Earth's sunlit side, from L1                            | Hourly   | 1-2 days            |
 | SDO/S     | [NASA SDO][sdo]   | The Sun, from geosync orbit                             | 15 min   | 25-55 min           |
 
-> **MY-MOON is beta.** Its rotation (matching what you'd see looking up, right now, from your
+> **MY MOON is beta.** Its rotation (matching what you'd see looking up, right now, from your
 > location) is still being verified against real skies over time. If it looks off, please
 > [open a GitHub issue](https://github.com/marcintk/ha-planetary-solar-system-card/issues/new) with
 > your location and the time you checked.
@@ -187,7 +187,7 @@ a pipeline stall doesn't break the feed.
 | `gallery.position`            | string  | `"overlay"` | `"overlay"` floats the strip over the solar view, `"below"` puts it underneath and grows the card by its height      |
 | `gallery.shape`               | string  | `"square"`  | `"square"` shows the frame as its source publishes it, `"circle"` crops each tile to the body itself                 |
 | `gallery.slide_interval_secs` | number  | `60`        | How often `slide` mode advances to the next enabled source                                                           |
-| `gallery.mymoon`              | boolean | `true`      | Show the MY-MOON tile                                                                                                |
+| `gallery.mymoon`              | boolean | `true`      | Show the MY MOON tile                                                                                                |
 | `gallery.moon`                | boolean | `false`     | Show the MOON tile                                                                                                   |
 | `gallery.earth`               | boolean | `false`     | Show the EARTH tile                                                                                                  |
 | `gallery.sun`                 | boolean | `false`     | Show the SUN tile                                                                                                    |

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ the date you were already viewing:
 
 | Last navigation     | Replay covers        | Each frame advances | Press                      |
 | ------------------- | -------------------- | ------------------- | -------------------------- |
-| hour steps, or none | last 12 hours        | 20 minutes          | **<** or **>**, then **↺** |
+| hour steps, or none | last 12 hours        | 20 minutes          | **↺** alone — the default  |
 | day steps           | last 36 days         | 1 day               | **≪** or **≫**, then **↺** |
 | month steps         | last 180 days (~6mo) | 5 days              | **⋘** or **⋙**, then **↺** |
 

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -305,7 +305,7 @@ export class SolarViewCard extends LitElement {
     return html`<button
       class="gallery-thumb ${this._galleryShape === "circle" ? "gallery-thumb-circle" : ""}"
       data-source=${source}
-      title=${`Show ${SOURCES[source].tile}`}
+      title=${SOURCES[source].tooltip}
       @click=${this._onGalleryClick}
     >
       ${

--- a/src/card/gallery/sources.ts
+++ b/src/card/gallery/sources.ts
@@ -45,7 +45,14 @@ export interface SourceSpec {
   body: string;
   /** Earth and Sun tiles show photographs; the Moon tiles show renders. */
   verb: "captured" | "rendered";
-  /** The instrument credited in the full-screen status bar. */
+  /**
+   * The instrument credited in the full-screen status bar: agency, mission, instrument.
+   *
+   * DSCOVR is NOAA's, not NASA's — NASA built and launched it, then handed operations to
+   * NOAA's Space Weather Prediction Center in October 2015. The pictures still come from EPIC,
+   * a NASA instrument aboard it, which is why the mission and the instrument need naming
+   * separately rather than crediting one agency for both.
+   */
   instrument: string;
   /**
    * The fraction of its own frame this source's disc spans **at its largest**.
@@ -140,7 +147,7 @@ export const SOURCES: Record<ImageSource, SourceSpec> = {
     tooltip: "Earth from Sun–Earth L1 · DSCOVR spacecraft",
     body: "EARTH",
     verb: "captured",
-    instrument: "NASA DSCOVR",
+    instrument: "NOAA DSCOVR EPIC",
     disc: 0.82,
     target: 0.87,
     onByDefault: false,

--- a/src/card/gallery/sources.ts
+++ b/src/card/gallery/sources.ts
@@ -89,6 +89,13 @@ export interface SourceSpec {
    * screen the way moon/earth/sun's NASA photographs are optional extras), so it alone ships on.
    */
   onByDefault: boolean;
+  /**
+   * Hover text on the tile's button. One shape for all four — `<body> from <vantage> · <who>` —
+   * because the set is read as a row, and a shared shape is what makes the vantage the thing
+   * that stands out rather than the phrasing. "render" against "spacecraft" is doing work too:
+   * the Moon tiles are computed from LRO topography, the other two are photographs.
+   */
+  tooltip: string;
   /** Which debug row(s) this source's resolve() call reports into — see DebugRowId. */
   debugRow: { url: DebugRowId; img: DebugRowId };
   /**
@@ -103,7 +110,8 @@ export interface SourceSpec {
 export const SOURCES: Record<ImageSource, SourceSpec> = {
   mymoon: {
     label: "NASA SVS Moon",
-    tile: "MY-MOON",
+    tile: "MY MOON",
+    tooltip: "Moon from your sky · NASA SVS render",
     body: "MOON",
     verb: "rendered",
     instrument: "NASA SVS",
@@ -116,6 +124,7 @@ export const SOURCES: Record<ImageSource, SourceSpec> = {
   moon: {
     label: "NASA SVS Moon",
     tile: "MOON",
+    tooltip: "Moon from Earth's centre · NASA SVS render",
     body: "MOON",
     verb: "rendered",
     instrument: "NASA SVS",
@@ -128,6 +137,7 @@ export const SOURCES: Record<ImageSource, SourceSpec> = {
   earth: {
     label: "DSCOVR Earth",
     tile: "EARTH",
+    tooltip: "Earth from Sun–Earth L1 · DSCOVR spacecraft",
     body: "EARTH",
     verb: "captured",
     instrument: "NASA DSCOVR",
@@ -140,6 +150,7 @@ export const SOURCES: Record<ImageSource, SourceSpec> = {
   sun: {
     label: "SDO HMI Continuum",
     tile: "SUN",
+    tooltip: "Sun from Earth geosync orbit · SDO spacecraft",
     body: "SUN",
     verb: "captured",
     instrument: "NASA SDO HMI",

--- a/test/card/card-template.test.ts
+++ b/test/card/card-template.test.ts
@@ -231,11 +231,13 @@ describe("discStyle", () => {
 describe("buildImageStatusBar", () => {
   const now = new Date("2026-08-12T12:00:00Z");
 
-  it("labels the earth source with EARTH · NASA DSCOVR, target body first, probe name after", () => {
+  it("labels the earth source with EARTH · NOAA DSCOVR EPIC, target body first, probe name after", () => {
     const root = renderToDOM(
       buildImageStatusBar("earth", "26-08-10 18:49", new Date("2026-08-10T18:49:00Z"), now, true)
     );
-    expect(root.querySelector(".status-bar span").textContent).toContain("EARTH · NASA DSCOVR");
+    expect(root.querySelector(".status-bar span").textContent).toContain(
+      "EARTH · NOAA DSCOVR EPIC"
+    );
   });
 
   it("labels the sun source with SUN · NASA SDO HMI, target body first, probe name after", () => {
@@ -250,7 +252,7 @@ describe("buildImageStatusBar", () => {
       buildImageStatusBar("earth", "26-08-11 06:00", new Date("2026-08-11T06:00:00Z"), now, true)
     );
     expect(root.querySelector(".status-bar span").textContent).toBe(
-      "EARTH · NASA DSCOVR · captured 26-08-11 06:00 · 30h ago"
+      "EARTH · NOAA DSCOVR EPIC · captured 26-08-11 06:00 · 30h ago"
     );
   });
 

--- a/test/card/card.gallery.test.ts
+++ b/test/card/card.gallery.test.ts
@@ -602,7 +602,7 @@ describe("SolarViewCard gallery", () => {
         `${EPIC_BASE_URL}/archive/natural/2026/08/10/jpg/epic_1b_20260810234950.jpg`
       );
       expect(card.shadowRoot.querySelector(".status-bar").textContent).toContain(
-        "EARTH · NASA DSCOVR"
+        "EARTH · NOAA DSCOVR EPIC"
       );
       card.remove();
     });

--- a/test/card/card.gallery.test.ts
+++ b/test/card/card.gallery.test.ts
@@ -142,7 +142,8 @@ describe("SolarViewCard gallery", () => {
         const card = mountAt(DOWN);
         await vi.advanceTimersByTimeAsync(0);
         const tile = card.shadowRoot.querySelector('[data-source="mymoon"]');
-        expect(tile.querySelector(".gallery-label").textContent).toBe("MY-MOON");
+        expect(tile.querySelector(".gallery-label").textContent).toBe("MY MOON");
+        expect(tile.getAttribute("title")).toBe("Moon from your sky · NASA SVS render");
         expect(tile.querySelector(".gallery-age").textContent).toBe("15m ago");
         card.remove();
         vi.useRealTimers();
@@ -439,7 +440,7 @@ describe("SolarViewCard gallery", () => {
       const labelOf = (source) =>
         card.shadowRoot.querySelector(`[data-source="${source}"] .gallery-label`).textContent;
       expect(labelOf("moon")).toBe("MOON");
-      expect(labelOf("mymoon")).toBe("MY-MOON");
+      expect(labelOf("mymoon")).toBe("MY MOON");
       card.remove();
     });
 
@@ -474,7 +475,7 @@ describe("SolarViewCard gallery", () => {
       const thumbs = [...card.shadowRoot.querySelectorAll(".gallery-thumb")];
       expect(thumbs.map((t) => t.dataset.source)).toEqual(["mymoon", "moon", "earth", "sun"]);
       const labels = thumbs.map((t) => t.querySelector(".gallery-label").textContent);
-      expect(labels).toEqual(["MY-MOON", "MOON", "EARTH", "SUN"]);
+      expect(labels).toEqual(["MY MOON", "MOON", "EARTH", "SUN"]);
 
       // Each candidate is preloaded off-DOM before it's ever assigned to the thumbnail, so
       // by the time the fetch/preload chain settles the age is already known — no separate

--- a/test/card/gallery/sources.test.ts
+++ b/test/card/gallery/sources.test.ts
@@ -33,7 +33,9 @@ describe("SOURCES catalog", () => {
     expect(SOURCES.earth.verb).toBe("captured");
     expect(SOURCES.sun.verb).toBe("captured");
     expect(SOURCES.mymoon.instrument).toBe("NASA SVS");
-    expect(SOURCES.earth.instrument).toBe("NASA DSCOVR");
+    // NOAA, not NASA: NASA built and launched DSCOVR, then handed operations to NOAA in 2015.
+    // EPIC is the NASA instrument aboard it, so both get named.
+    expect(SOURCES.earth.instrument).toBe("NOAA DSCOVR EPIC");
     expect(SOURCES.sun.instrument).toBe("NASA SDO HMI");
   });
 

--- a/test/card/gallery/sources.test.ts
+++ b/test/card/gallery/sources.test.ts
@@ -12,8 +12,19 @@ describe("SOURCES catalog", () => {
     expect(SOURCES.earth.label).toBe("DSCOVR Earth");
     expect(SOURCES.sun.label).toBe("SDO HMI Continuum");
 
-    expect(IMAGE_SOURCES.map((s) => SOURCES[s].tile)).toEqual(["MY-MOON", "MOON", "EARTH", "SUN"]);
+    expect(IMAGE_SOURCES.map((s) => SOURCES[s].tile)).toEqual(["MY MOON", "MOON", "EARTH", "SUN"]);
     expect(IMAGE_SOURCES.map((s) => SOURCES[s].body)).toEqual(["MOON", "MOON", "EARTH", "SUN"]);
+  });
+
+  it("tells each tile apart by where it is looking from", () => {
+    // Four tiles, two of which show the same body, so the vantage is the only thing that
+    // distinguishes them — it has to be the part that varies, in the same slot every time.
+    expect(IMAGE_SOURCES.map((s) => SOURCES[s].tooltip)).toEqual([
+      "Moon from your sky · NASA SVS render",
+      "Moon from Earth's centre · NASA SVS render",
+      "Earth from Sun–Earth L1 · DSCOVR spacecraft",
+      "Sun from Earth geosync orbit · SDO spacecraft",
+    ]);
   });
 
   it("calls the moon frames renders and the photographs captures", () => {


### PR DESCRIPTION
Cosmetic pass on the gallery strip, plus the factual errors that turned up while checking it.

## Tooltips

The tile's hover text was `Show ${spec.tile}` — "Show MY-MOON", i.e. the label already printed on the tile with a verb in front. Each tile now names its vantage:

| tile | tooltip |
| --- | --- |
| MY MOON | Moon from your sky · NASA SVS render |
| MOON | Moon from Earth's centre · NASA SVS render |
| EARTH | Earth from Sun–Earth L1 · DSCOVR spacecraft |
| SUN | Sun from Earth geosync orbit · SDO spacecraft |

One shape throughout — `<body> from <vantage> · <who>`. Two of the four tiles show the same NASA render at the same instant, so the vantage is the *only* thing distinguishing them; a fixed slot is what makes it the part that reads. "render" against "spacecraft" carries a distinction the card makes elsewhere but never stated here: the Moon frames are computed from LRO topography, the other two are photographs.

Also renames the tile `MY-MOON` → `MY MOON`.

New test pins all four tooltips, and the gallery test now asserts the rendered `title` attribute — nothing covered it before, so the old text could have changed silently.

## DSCOVR credited to the wrong agency

The full-screen status bar read `EARTH · NASA DSCOVR`. NASA built and launched DSCOVR, then handed operations to NOAA's Space Weather Prediction Center in October 2015. The field is called `instrument`, and "DSCOVR" is the mission — the pictures come from EPIC, a NASA camera aboard a NOAA spacecraft.

Now `EARTH · NOAA DSCOVR EPIC`, matching the shape the Sun already used (`NASA SDO HMI`).

## Docs

- **Twilight section trimmed** back to its table. Two paragraphs of accuracy figures belonged in the tests that measure them, not in a setup guide. But the table itself still claimed **Day ≥ 0°**, which stopped being true when #166 moved that threshold — corrected to `-0.83°`, with civil twilight's start to match. Dropped the orphaned `[usno]` link definition.
- **`mymoon: false` added** to the slide-mode example. `mymoon` is the only source with `onByDefault: true`, so an example listing three sources as `true` actually produced four tiles.
- **Replay table** told readers to press `<` or `>` before `↺` on a row that covered "hour steps, **or none**". `date-navigation.ts:53` initialises `_navUnit` to `"hour"`, so an untouched card replays the last 12 hours from a single press.

🤖 Generated with [Claude Code](https://claude.com/claude-code)