### PR TITLE
chore(deps-dev): bump @vitest/coverage-v8 from 4.1.10 to 4.1.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@rollup/plugin-node-resolve": "^16.0.3",
         "@rollup/plugin-terser": "^1.0.0",
         "@rollup/plugin-typescript": "^12.3.0",
-        "@vitest/coverage-v8": "^4.1.10",
+        "@vitest/coverage-v8": "^4.1.11",
         "ha-card-shared": "github:marcintk/ha-card-shared#v1.4.1",
         "jsdom": "^30.0.1",
         "prettier": "^3.9.6",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-terser": "^1.0.0",
     "@rollup/plugin-typescript": "^12.3.0",
-    "@vitest/coverage-v8": "^4.1.10",
+    "@vitest/coverage-v8": "^4.1.11",
     "ha-card-shared": "github:marcintk/ha-card-shared#v1.4.1",
     "jsdom": "^30.0.1",
     "prettier": "^3.9.6",


### PR DESCRIPTION
Reopens dependabot#156 (branch was deleted, PR auto-closed) — cherry-picked the same commit onto a fresh branch off current main.

## Test plan
- [x] `npm run test:coverage` — 100% coverage, 1081 tests pass
- [x] `npm run check:ci` — typecheck/lint/format clean