### PR TITLE
Deepen the gallery resolve() protocol and its tests

### DIFF
--- a/src/card/debug-view.ts
+++ b/src/card/debug-view.ts
@@ -2,12 +2,8 @@ import type { TemplateResult } from "lit";
 import { html } from "lit";
 import type { SourceDebugStats } from "./gallery/debug-stats.js";
 import type { DebugRowId } from "./gallery/sources.js";
+import { DEBUG_ROWS } from "./gallery/sources.js";
 import { formatDate, formatDuration } from "./relative-time.js";
-
-// The overlay's own row order and column headings. Which source reports into which row is
-// each source's own fact — see SourceSpec.debugRow in sources.ts, and the DebugRowId comment
-// there for why sun collapses both roles into one row and mymoon/moon collapse into each other.
-export const DEBUG_ROWS: DebugRowId[] = ["moon", "sun", "earth-url", "earth-img"];
 
 export const DEBUG_ROW_LABELS: Record<DebugRowId, string> = {
   moon: "SVS/M",
@@ -20,7 +16,7 @@ function formatMs(ms: number | null): string {
   return ms == null ? "—" : `${Math.round(ms)}ms`;
 }
 
-// refreshes max()s rather than sum()s: sun/earth-url tick in lockstep for "both"/"slide" modes
+// gets max()s rather than sum()s: sun/earth-url tick in lockstep for "both"/"slide" modes
 // (one refresh() call bumps both), so summing would double-count — max reads right there and
 // still reports correctly for a single-source mode, where the other rows stay 0. elapsed
 // avg()s each row's own average (not a token-weighted mean — kept simple since this overlay is
@@ -32,8 +28,9 @@ function summarizeDebugStats(stats: Record<DebugRowId, SourceDebugStats>): Sourc
   const sum = (pick: (row: SourceDebugStats) => number) =>
     rows.reduce((total, row) => total + pick(row), 0);
   return {
-    refreshes: Math.max(...rows.map((row) => row.refreshes)),
+    gets: Math.max(...rows.map((row) => row.gets)),
     cacheHits: sum((row) => row.cacheHits),
+    backoffs: sum((row) => row.backoffs),
     expired: sum((row) => row.expired),
     fetches: sum((row) => row.fetches),
     failures: sum((row) => row.failures),
@@ -45,7 +42,7 @@ function summarizeDebugStats(stats: Record<DebugRowId, SourceDebugStats>): Sourc
   };
 }
 
-// debug:true overlay — sun/earth's cumulative check vs. network-call counts, so refreshes ===
+// debug:true overlay — sun/earth's cumulative check vs. network-call counts, so gets ===
 // network is visible at a glance as "this source's cache isn't actually skipping the
 // network call". Cumulative since mount, not a rolling window — this card's timers are
 // coarse (minutes, not events-per-second) so a running total reads better than a windowed rate.
@@ -59,8 +56,9 @@ export function buildDebugOverlay(
     <table>
       <tr>
         <th>source</th>
-        <th>refresh</th>
+        <th>get</th>
         <th>cache</th>
+        <th>back</th>
         <th>expire</th>
         <th>fetch</th>
         <th>fail</th>
@@ -81,8 +79,9 @@ export function buildDebugOverlay(
         const canRetry = rowId === "sun";
         return html`<tr>
           <td>${DEBUG_ROW_LABELS[rowId]}</td>
-          <td>${s.refreshes}</td>
+          <td>${s.gets}</td>
           <td>${hasCacheStep ? s.cacheHits : "—"}</td>
+          <td>${s.backoffs}</td>
           <td>${hasCacheStep ? s.expired : "—"}</td>
           <td>${s.fetches}</td>
           <td>${s.failures}</td>
@@ -95,8 +94,9 @@ export function buildDebugOverlay(
         const total = summarizeDebugStats(stats);
         return html`<tr class="debug-total">
           <td>total</td>
-          <td>${total.refreshes}</td>
+          <td>${total.gets}</td>
           <td>${total.cacheHits}</td>
+          <td>${total.backoffs}</td>
           <td>${total.expired}</td>
           <td>${total.fetches}</td>
           <td>${total.failures}</td>

--- a/src/card/debug-view.ts
+++ b/src/card/debug-view.ts
@@ -2,7 +2,7 @@ import type { TemplateResult } from "lit";
 import { html } from "lit";
 import type { SourceDebugStats } from "./gallery/debug-stats.js";
 import type { DebugRowId } from "./gallery/sources.js";
-import { DEBUG_ROWS } from "./gallery/sources.js";
+import { DEBUG_ROW_SPECS, DEBUG_ROWS } from "./gallery/sources.js";
 import { formatDate, formatDuration } from "./relative-time.js";
 
 export const DEBUG_ROW_LABELS: Record<DebugRowId, string> = {
@@ -68,15 +68,10 @@ export function buildDebugOverlay(
       </tr>
       ${DEBUG_ROWS.map((rowId) => {
         const s = stats[rowId];
-        // The img row has no cache/URL-identity step of its own (that's the url row's job —
-        // see the DebugRowId comment) — showing 0 there would misleadingly imply "checked
-        // and found nothing", when really the question never applies to this row at all.
-        const hasCacheStep = rowId !== "earth-img";
-        // Only sun's resolver ever retries (recover()'s one-slot-back fallback — see
-        // source-resolver-sdo-sun.ts) — earth's and moon's default recover() just rethrows, so 0 there
-        // would misleadingly suggest "checked, never needed one" rather than "not a thing
-        // that can happen on this row".
-        const canRetry = rowId === "sun";
+        // Which columns this row can produce a real value for — see DEBUG_ROW_SPECS's own
+        // comment for why 0 would misleadingly read as "checked, found nothing" instead of
+        // "not a thing that can happen on this row".
+        const { hasCacheStep, canRetry } = DEBUG_ROW_SPECS[rowId];
         return html`<tr>
           <td>${DEBUG_ROW_LABELS[rowId]}</td>
           <td>${s.gets}</td>

--- a/src/card/gallery/debug-stats.ts
+++ b/src/card/gallery/debug-stats.ts
@@ -2,11 +2,14 @@
 // Nothing here draws anything — see card/debug-view.ts for that half.
 //
 // Cumulative, since the card was mounted — not a rolling window. Lets debug:true answer "is
-// this source's own cache actually saving anything" at a glance: `refreshes` vs. network calls
+// this source's own cache actually saving anything" at a glance: `gets` vs. network calls
 // equal means every refresh is hitting the network regardless of cache state. `cacheHits` is the
 // direct answer to that question — it counts every refresh SourceResolver.resolve() served straight
 // from that source's own cache, checked before any fetch is even attempted, so it should
-// climb steadily while `fetches` stays flat between a source's real TTL windows. `expired`
+// climb steadily while `fetches` stays flat between a source's real TTL windows. `backoffs`
+// counts a refresh served entirely from Backoff's last-confirmed image, without even checking
+// this source's own TTL cache — the source is sitting out a backoff window from prior failures.
+// `expired`
 // counts a resolved candidate whose URL turned out identical to the image already displayed,
 // found only after the TTL cache had already expired and forced a real fetchCandidateUrl()
 // call that ended up confirming nothing changed (for earth this still cost one real EPIC API
@@ -21,8 +24,9 @@
 // recent preload attempt, formatted at render time.
 // Field order matches the overlay's column order (buildDebugOverlay in card/debug-view.ts).
 export interface SourceDebugStats {
-  refreshes: number;
+  gets: number;
   cacheHits: number;
+  backoffs: number;
   expired: number;
   fetches: number;
   failures: number;
@@ -32,8 +36,9 @@ export interface SourceDebugStats {
 }
 
 export interface DebugAccumulator {
-  refreshes: number;
+  gets: number;
   cacheHits: number;
+  backoffs: number;
   expired: number;
   fetches: number;
   failures: number;
@@ -44,8 +49,9 @@ export interface DebugAccumulator {
 
 export function emptyDebugAccumulator(): DebugAccumulator {
   return {
-    refreshes: 0,
+    gets: 0,
     cacheHits: 0,
+    backoffs: 0,
     expired: 0,
     fetches: 0,
     failures: 0,
@@ -61,8 +67,9 @@ export function toDebugStats(acc: DebugAccumulator): SourceDebugStats {
   // only consumer.
   const succeeded = acc.fetches - acc.failures;
   return {
-    refreshes: acc.refreshes,
+    gets: acc.gets,
     cacheHits: acc.cacheHits,
+    backoffs: acc.backoffs,
     expired: acc.expired,
     fetches: acc.fetches,
     failures: acc.failures,

--- a/src/card/gallery/gallery-controller.ts
+++ b/src/card/gallery/gallery-controller.ts
@@ -1,5 +1,4 @@
-import type { DebugAccumulator, SourceDebugStats } from "./debug-stats.js";
-import { emptyDebugAccumulator, toDebugStats } from "./debug-stats.js";
+import type { SourceDebugStats } from "./debug-stats.js";
 import { ImageResolver } from "./image-resolver.js";
 import type { DebugRowId, ImageSource } from "./sources.js";
 import { IMAGE_SOURCES, SOURCES } from "./sources.js";
@@ -44,6 +43,44 @@ export interface GalleryViewModel {
   debugStartedAt: number;
 }
 
+// The full-screen panel's own state: which source (if any) it's showing, the image it has
+// settled on, and any error banner. Pulled out of GalleryController because every invariant
+// here is local to "what does the panel show" — closing always clears the same four fields
+// together, applying an image always clears `loaded` first — and a caller (GalleryController)
+// never needs to touch these one at a time.
+class PanelState {
+  mode: ImagePanelMode = "none";
+  url: string | null = null;
+  date: Date | null = null;
+  loaded = false;
+  error: string | null = null;
+
+  // Every caller preloads (via ImageResolver.resolve()) before this runs, so the pixels are
+  // already sitting in the browser's cache — `loaded` is set true right after, letting the
+  // visible <img> paint from that cache instead of a live fetch.
+  applyImage(url: string, date: Date): void {
+    this.loaded = false;
+    this.url = url;
+    this.date = date;
+  }
+
+  close(): void {
+    this.mode = "none";
+    this.url = null;
+    this.date = null;
+    this.error = null;
+  }
+
+  // Callers only ever invoke this once they've confirmed the failing source is the one
+  // currently shown, so it always closes — there is no "fail a source that isn't open" case.
+  fail(message: string): void {
+    this.error = message;
+    this.mode = "none";
+    this.url = null;
+    this.date = null;
+  }
+}
+
 /**
  * Owns the gallery strip and full-screen image panel: which sources are fetched, which one
  * is displayed, and the retry protocol against each source's own cache. Previously this was
@@ -53,11 +90,7 @@ export interface GalleryViewModel {
  * callback pattern as DateNavigation/ZoomAnimator).
  */
 export class GalleryController {
-  private _panelMode: ImagePanelMode;
-  private _imageUrl: string | null;
-  private _imageDate: Date | null;
-  private _imageLoaded: boolean;
-  private _error: string | null;
+  private _panel: PanelState;
   private _open: boolean;
   private _images: Partial<Record<ImageSource, SourcedImage>>;
   private _mode: GalleryMode;
@@ -65,17 +98,16 @@ export class GalleryController {
   private _slideIndex: number;
   private _autoSwitchTimer: number | null;
   private _onChange: () => void;
-  private _debug: Record<DebugRowId, DebugAccumulator>;
   private _debugStartedAt: number;
   private _resolver: ImageResolver;
   private _sources: ImageSource[];
 
-  constructor(onChange: () => void) {
-    this._panelMode = "none";
-    this._imageUrl = null;
-    this._imageDate = null;
-    this._imageLoaded = false;
-    this._error = null;
+  // resolver defaults to a real, network-backed ImageResolver for production callers — tests
+  // that only exercise panel/strip/slide state can pass a fake instead (matching the pattern
+  // SourceResolver already uses for its own `cache` constructor param) and skip stubbing
+  // global Image/fetch entirely.
+  constructor(onChange: () => void, resolver: ImageResolver = new ImageResolver()) {
+    this._panel = new PanelState();
     this._open = false;
     this._mode = "off";
     this._sources = DEFAULT_GALLERY_SOURCES;
@@ -83,14 +115,8 @@ export class GalleryController {
     this._slideIndex = 0;
     this._autoSwitchTimer = null;
     this._onChange = onChange;
-    this._debug = {
-      moon: emptyDebugAccumulator(),
-      sun: emptyDebugAccumulator(),
-      "earth-url": emptyDebugAccumulator(),
-      "earth-img": emptyDebugAccumulator(),
-    };
     this._debugStartedAt = Date.now();
-    this._resolver = new ImageResolver();
+    this._resolver = resolver;
     // Recovers each source's still-fresh cache into this instance's own known-URL
     // state — without this, a remount (this._images always starts empty) would otherwise
     // force a redundant preload of bytes the module cache already confirmed are current.
@@ -98,19 +124,19 @@ export class GalleryController {
   }
 
   get panelMode(): ImagePanelMode {
-    return this._panelMode;
+    return this._panel.mode;
   }
   get imageUrl(): string | null {
-    return this._imageUrl;
+    return this._panel.url;
   }
   get imageDate(): Date | null {
-    return this._imageDate;
+    return this._panel.date;
   }
   get imageLoaded(): boolean {
-    return this._imageLoaded;
+    return this._panel.loaded;
   }
   get error(): string | null {
-    return this._error;
+    return this._panel.error;
   }
   get isOpen(): boolean {
     return this._open;
@@ -122,12 +148,7 @@ export class GalleryController {
     return this._images;
   }
   get debugStats(): Record<DebugRowId, SourceDebugStats> {
-    return {
-      moon: toDebugStats(this._debug.moon),
-      sun: toDebugStats(this._debug.sun),
-      "earth-url": toDebugStats(this._debug["earth-url"]),
-      "earth-img": toDebugStats(this._debug["earth-img"]),
-    };
+    return this._resolver.debugStats();
   }
 
   // Sources rendered as thumbnails right now — the configured list verbatim, except in
@@ -141,12 +162,12 @@ export class GalleryController {
   // that view instead, so it has no need to hide just because a panel opened.
   viewModel(position: GalleryPosition = "overlay"): GalleryViewModel {
     return {
-      error: this._error,
-      panelSource: this._panelMode,
-      imageUrl: this._imageUrl,
-      imageDate: this._imageDate,
-      imageLoaded: this._imageLoaded,
-      showStrip: this._open && (position === "below" || this._panelMode === "none"),
+      error: this._panel.error,
+      panelSource: this._panel.mode,
+      imageUrl: this._panel.url,
+      imageDate: this._panel.date,
+      imageLoaded: this._panel.loaded,
+      showStrip: this._open && (position === "below" || this._panel.mode === "none"),
       thumbnails: this.displaySources.map((source) => {
         const image = this._images[source];
         return { source, url: image?.url ?? null, date: image?.date ?? null };
@@ -199,7 +220,7 @@ export class GalleryController {
     if (!this._open) {
       this.closePanel();
     } else {
-      this._error = null;
+      this._panel.error = null;
       this._onChange();
       void this.refresh();
     }
@@ -217,35 +238,32 @@ export class GalleryController {
     // panelMode: in "overlay" position the strip is hidden while a panel is open, so its tiles
     // aren't there to re-click; in "below" they stay visible, and clicking the open one again
     // reads as "close it", not "open it again".
-    if (this._panelMode === mode) {
+    if (this._panel.mode === mode) {
       this.closePanel();
       return;
     }
-    this._panelMode = mode;
-    this._error = null;
+    this._panel.mode = mode;
+    this._panel.error = null;
     const known = this._images[mode];
     if (known) {
-      this._applyImage(known.url, known.date);
-      this._imageLoaded = true;
+      this._panel.applyImage(known.url, known.date);
+      this._panel.loaded = true;
     } else {
-      this._imageUrl = null;
-      this._imageDate = null;
-      this._imageLoaded = false;
+      this._panel.url = null;
+      this._panel.date = null;
+      this._panel.loaded = false;
       void this.refresh();
     }
     this._onChange();
   }
 
   closePanel(): void {
-    this._panelMode = "none";
-    this._imageUrl = null;
-    this._imageDate = null;
-    this._error = null;
+    this._panel.close();
     this._onChange();
   }
 
   onImageLoad(): void {
-    this._imageLoaded = true;
+    this._panel.loaded = true;
     this._onChange();
   }
 
@@ -254,11 +272,8 @@ export class GalleryController {
   // failure after the fact (e.g. the browser evicting its cache between preload and paint) —
   // no retry left to try, just surface the error banner.
   onImageLoadError(): void {
-    if (this._panelMode === "none") return;
-    this._error = `${SOURCES[this._panelMode].label} image unavailable`;
-    this._panelMode = "none";
-    this._imageUrl = null;
-    this._imageDate = null;
+    if (this._panel.mode === "none") return;
+    this._panel.fail(`${SOURCES[this._panel.mode].label} image unavailable`);
     this._onChange();
   }
 
@@ -292,15 +307,6 @@ export class GalleryController {
     this._onChange();
   }
 
-  // Every caller preloads (via ImageResolver.resolve()) before calling this, so the pixels are
-  // already sitting in the browser's cache — _imageLoaded is set true right after, letting
-  // the visible <img> paint from that cache instead of a live fetch.
-  private _applyImage(url: string, date: Date): void {
-    this._imageLoaded = false;
-    this._imageUrl = url;
-    this._imageDate = date;
-  }
-
   // Fetches every configured source — called on open (start/configure), on click for a
   // source that isn't known yet (openPanel), and on each auto-update tick while the strip or
   // a panel stays open. Each source is cache-guarded (earth hourly, sun every 15min —
@@ -310,21 +316,20 @@ export class GalleryController {
   // fetch/dedupe/retry mechanics live in ImageResolver — this only applies its settled
   // results to view state (which image is shown, which error banner, when to re-render).
   private async refresh(): Promise<void> {
-    const results = await this._resolver.resolveAll(this._sources, this._debug);
+    const results = await this._resolver.resolveAll(this._sources);
     for (const { source, result } of results) {
       if (result.status === "fulfilled") {
         this._images[source] = result.value;
-        if (this._panelMode === source) {
-          this._applyImage(result.value.url, result.value.date);
-          this._imageLoaded = true;
+        if (this._panel.mode === source) {
+          this._panel.applyImage(result.value.url, result.value.date);
+          this._panel.loaded = true;
         }
-      } else if (this._panelMode === source && !this._images[source]) {
+      } else if (this._panel.mode === source && !this._images[source]) {
         // The open panel is waiting on this exact source's first-ever fetch and it just
         // failed — nothing to fall back to, so surface the error instead of "loading…"
         // forever. A source that already has a known image just keeps showing it (matches
         // the old behavior: never swap to something that might not load).
-        this._panelMode = "none";
-        this._error = `${SOURCES[source].label} image unavailable`;
+        this._panel.fail(`${SOURCES[source].label} image unavailable`);
       }
     }
     this._onChange();

--- a/src/card/gallery/image-resolver.ts
+++ b/src/card/gallery/image-resolver.ts
@@ -1,10 +1,11 @@
-import type { DebugAccumulator } from "./debug-stats.js";
+import type { DebugAccumulator, SourceDebugStats } from "./debug-stats.js";
+import { emptyDebugAccumulator, toDebugStats } from "./debug-stats.js";
 import type { SourceResolver } from "./source-resolver.js";
 import { DscovrEarthResolver } from "./source-resolver-dscovr-earth.js";
 import { SdoSunResolver } from "./source-resolver-sdo-sun.js";
 import { SvsMoonResolver } from "./source-resolver-svs-moon.js";
 import type { DebugRowId, ImageSource } from "./sources.js";
-import { SOURCES } from "./sources.js";
+import { DEBUG_ROWS, SOURCES } from "./sources.js";
 import type { SourcedImage } from "./url-cache.js";
 
 // The single gateway to a resolved sun/earth image — dispatches to the per-source resolver
@@ -16,6 +17,11 @@ import type { SourcedImage } from "./url-cache.js";
 export class ImageResolver {
   private readonly _resolvers: Record<ImageSource, SourceResolver>;
   private readonly _inFlight: Partial<Record<ImageSource, boolean>> = {};
+  // Owned here rather than by the caller: this is the one place that knows which resolver
+  // writes into which row (SOURCES[source].debugRow), so it's also the natural owner of the
+  // counters those writes produce — a caller only ever wants the derived view (debugStats()),
+  // never the raw accumulators.
+  private readonly _debug: Record<DebugRowId, DebugAccumulator>;
 
   // Both moon resolvers ask for the current instant and land on the same NASA frame; they
   // differ only in which cache key they own, and card.ts rotates mymoon's copy to the
@@ -28,6 +34,15 @@ export class ImageResolver {
       earth: new DscovrEarthResolver(),
       sun: new SdoSunResolver(),
     };
+    this._debug = Object.fromEntries(
+      DEBUG_ROWS.map((row) => [row, emptyDebugAccumulator()])
+    ) as Record<DebugRowId, DebugAccumulator>;
+  }
+
+  debugStats(): Record<DebugRowId, SourceDebugStats> {
+    return Object.fromEntries(
+      DEBUG_ROWS.map((row) => [row, toDebugStats(this._debug[row])])
+    ) as Record<DebugRowId, SourceDebugStats>;
   }
 
   hydrate(sources: readonly ImageSource[]): Partial<Record<ImageSource, SourcedImage>> {
@@ -39,27 +54,26 @@ export class ImageResolver {
     return images;
   }
 
-  // Resolves every requested source concurrently, skipping any still mid-fetch from a
-  // previous call (that source keeps serving whatever's cached until the in-flight one
-  // settles, rather than stacking a second overlapping request) and any whose own cache is
-  // still current (nothing to learn by asking again before its TTL/publish window is up —
-  // sun's 15-min slot, earth's hourly EPIC poll, etc., each via that resolver's own
-  // isFresh()). Returns settled results only for the sources actually attempted this call, so
-  // the caller can tell "not requested" (skipped) apart from "requested and failed".
+  // Resolves every requested source concurrently, skipping only a source still mid-fetch from
+  // a previous call (that source keeps serving whatever's cached until the in-flight one
+  // settles, rather than stacking a second overlapping request). Every other source hits
+  // resolve() on every call, even one still well within its own TTL — that's deliberate: `gets`
+  // is meant to answer "how many ticks has this source seen", not "how many ticks needed a
+  // fetch" (that's what `cacheHits`/`fetches` are for). A cache-fresh source still resolves
+  // cheaply — resolve()'s own cache-hit phase returns without a network call. Returns settled
+  // results only for the sources actually attempted this call, so the caller can tell "not
+  // requested" (skipped, still in flight) apart from "requested and failed".
   async resolveAll(
-    sources: readonly ImageSource[],
-    debug: Record<DebugRowId, DebugAccumulator>
+    sources: readonly ImageSource[]
   ): Promise<{ source: ImageSource; result: PromiseSettledResult<SourcedImage> }[]> {
-    const pending = sources.filter(
-      (source) => !this._inFlight[source] && !this._resolvers[source].isFresh()
-    );
+    const pending = sources.filter((source) => !this._inFlight[source]);
     for (const source of pending) {
       this._inFlight[source] = true;
     }
     const settled = await Promise.allSettled(
       pending.map((source) => {
         const { url, img } = SOURCES[source].debugRow;
-        return this._resolvers[source].resolve(debug[url], debug[img]);
+        return this._resolvers[source].resolve(this._debug[url], this._debug[img]);
       })
     );
     return pending.map((source, i) => {

--- a/src/card/gallery/pad.ts
+++ b/src/card/gallery/pad.ts
@@ -1,0 +1,5 @@
+// Shared by the SDO sun and SVS moon resolvers, both of which build archive URLs from
+// zero-padded UTC calendar fields (sun's HHMMSS, moon's product-id path segments).
+export function padLeft(value: number, width = 2): string {
+  return String(value).padStart(width, "0");
+}

--- a/src/card/gallery/slot-search.ts
+++ b/src/card/gallery/slot-search.ts
@@ -1,0 +1,94 @@
+// Pure "which slot to try next" engine for a source published on a fixed time grid with
+// unknown publish lag (sun's 15-min SDO slots — see source-resolver-sdo-sun.ts). Knows nothing
+// about network, decoding, or images: the caller supplies a `probe` that answers "does this slot
+// exist" and gets back which slot to serve. That split is what makes the search strategy
+// (reach-doubling cold start, bisection narrowing) testable with a synchronous fake probe instead
+// of mocking Image.decode() per candidate slot.
+export interface SlotProbeResult {
+  hit: boolean;
+  // true aborts the whole search immediately (a dead host, not a missing slot) — see this
+  // module's caller for what "abort" means concretely. Ignored when hit is true.
+  abort?: boolean;
+  // Carried through to the exhausted-cold-start throw below; ignored when hit is true or the
+  // confirmed-branch's single probe misses (that path resolves with foundMs: null instead).
+  error?: unknown;
+}
+
+export type SlotProbe = (slotMs: number) => Promise<SlotProbeResult>;
+
+export interface SlotSearchResult {
+  // The newest slot confirmed to exist, or null when a confirmed frame was supplied and the one
+  // probe past it missed — nothing newer exists, the caller already has the right answer.
+  foundMs: number | null;
+  // The newest slot still known not to exist — only meaningful when foundMs is non-null, as the
+  // bisection's own upper bound.
+  missedMs: number;
+}
+
+export interface SlotSearchOptions {
+  // Last confirmed-good slot, or null for a cold start with nothing to anchor to.
+  confirmedMs: number | null;
+  // The candidate slot that was just tried and found missing — the search's starting point.
+  missedMs: number;
+  // Grid spacing (sun: 15 minutes).
+  slotMs: number;
+  // Cold-start reach ceiling — past this, the feed is treated as dead rather than lagging.
+  maxReachMs: number;
+  probe: SlotProbe;
+}
+
+function floorToGrid(ms: number, slotMs: number): number {
+  return Math.floor(ms / slotMs) * slotMs;
+}
+
+export async function findPublishedSlot(opts: SlotSearchOptions): Promise<SlotSearchResult> {
+  const { confirmedMs, slotMs, maxReachMs, probe } = opts;
+  let missed = opts.missedMs;
+  let lastError: unknown;
+
+  async function tryProbe(atMs: number): Promise<boolean> {
+    const result = await probe(atMs);
+    if (result.hit) return true;
+    if (result.abort) throw result.error;
+    lastError = result.error;
+    return false;
+  }
+
+  let loaded: number;
+  if (confirmedMs != null) {
+    // Everything at or below the confirmed slot is already answered — one probe past it settles
+    // whether anything newer has published.
+    const next = confirmedMs + slotMs;
+    const found = next < missed ? await tryProbe(next) : false;
+    if (!found) return { foundMs: null, missedMs: missed };
+    loaded = next;
+  } else {
+    // Cold start: double the reach each miss until something loads, or the ceiling is hit.
+    const origin = missed;
+    let reach = slotMs;
+    let found: number | null = null;
+    for (;;) {
+      const candidate = origin - reach;
+      if (await tryProbe(candidate)) {
+        found = candidate;
+        break;
+      }
+      missed = candidate;
+      if (reach === maxReachMs) break;
+      reach = Math.min(reach * 2, maxReachMs);
+    }
+    if (found == null) throw lastError;
+    loaded = found;
+  }
+
+  // Bisect the gap between a slot known to load and one known not to — logarithmic in the gap.
+  while (missed - loaded > slotMs) {
+    const mid = floorToGrid(loaded + (missed - loaded) / 2, slotMs);
+    if (await tryProbe(mid)) {
+      loaded = mid;
+    } else {
+      missed = mid;
+    }
+  }
+  return { foundMs: loaded, missedMs: missed };
+}

--- a/src/card/gallery/source-resolver-dscovr-earth.ts
+++ b/src/card/gallery/source-resolver-dscovr-earth.ts
@@ -66,14 +66,22 @@ export async function fetchLatestEarthImageUrl(
   if (!latest) {
     throw new Error("EPIC API returned no images");
   }
-  const { identifier } = latest;
+  const image = buildEpicImage(latest.identifier);
+  cache.set("earth", image);
+  return image;
+}
+
+// Pure identifier → URL/date math, split from the fetch/cache shell above so the format itself
+// (14-digit UTC timestamp, archive path shape) is testable with plain strings — no fetch mock
+// needed to prove a date parses correctly.
+export function buildEpicImage(identifier: string): SourcedImage {
   const year = identifier.slice(0, 4);
   const month = identifier.slice(4, 6);
   const day = identifier.slice(6, 8);
   const hour = identifier.slice(8, 10);
   const minute = identifier.slice(10, 12);
   const second = identifier.slice(12, 14);
-  const image = {
+  return {
     url: `${EPIC_BASE_URL}/archive/natural/${year}/${month}/${day}/jpg/epic_1b_${identifier}.jpg`,
     date: new Date(
       Date.UTC(
@@ -86,6 +94,4 @@ export async function fetchLatestEarthImageUrl(
       )
     ),
   };
-  cache.set("earth", image);
-  return image;
 }

--- a/src/card/gallery/source-resolver-sdo-sun.ts
+++ b/src/card/gallery/source-resolver-sdo-sun.ts
@@ -1,5 +1,6 @@
 import type { DebugAccumulator } from "./debug-stats.js";
 import { padLeft } from "./pad.js";
+import type { SlotProbe } from "./slot-search.js";
 import { findPublishedSlot } from "./slot-search.js";
 import { IMAGE_TIMEOUT_MESSAGE, SourceResolver, timedPreload } from "./source-resolver.js";
 import type { SourcedImage, UrlCache } from "./url-cache.js";
@@ -66,27 +67,12 @@ export class SdoSunResolver extends SourceResolver {
     // known-good. Backoff only records a success after a real decode.
     const confirmed = this.cache.getStale(this.source);
 
-    // The search strategy itself (reach-doubling cold start, bisection narrowing) lives in
-    // slot-search.ts, pure and network-agnostic. This probe is the only place that knows what
-    // "does this slot exist" actually costs: one preload+decode, counted, with a timed-out
-    // attempt reported as `abort` so the search stops instead of treating a dead host as one
-    // more missing slot.
-    const probe = async (slotMs: number) => {
-      debug.retries++;
-      try {
-        await timedPreload(buildSunSlotImage(new Date(slotMs)).url, debug);
-        return { hit: true };
-      } catch (retryErr) {
-        return { hit: false, abort: isTimeout(retryErr), error: retryErr };
-      }
-    };
-
     const result = await findPublishedSlot({
       confirmedMs: confirmed ? confirmed.date.getTime() : null,
       missedMs: candidate.date.getTime(),
       slotMs: SUN_CACHE_TTL_MS,
       maxReachMs: SUN_MAX_REACH_MS,
-      probe,
+      probe: sunSlotProbe(debug),
     });
 
     // foundMs is only ever null when a confirmed frame was supplied and the one probe past it
@@ -115,6 +101,27 @@ export class SdoSunResolver extends SourceResolver {
 
 function isTimeout(err: unknown): boolean {
   return err instanceof Error && err.message === IMAGE_TIMEOUT_MESSAGE;
+}
+
+// The only place that knows what "does this slot exist" actually costs: one preload+decode,
+// counted, with a timed-out attempt reported as `abort` so slot-search's caller (recover(),
+// above) stops the whole search instead of treating a dead host as one more missing slot. Split
+// out from recover() so this NASA-specific hit/abort/error mapping is unit-testable with a fake
+// `preload` — a synchronous resolve/reject — instead of needing global.Image/decode() stubbing to
+// exercise it, the same split slot-search.ts's own search strategy already gets.
+export function sunSlotProbe(
+  debug: DebugAccumulator,
+  preload: (url: string, debug: DebugAccumulator) => Promise<void> = timedPreload
+): SlotProbe {
+  return async (slotMs: number) => {
+    debug.retries++;
+    try {
+      await preload(buildSunSlotImage(new Date(slotMs)).url, debug);
+      return { hit: true };
+    } catch (err) {
+      return { hit: false, abort: isTimeout(err), error: err };
+    }
+  };
 }
 
 // Anchored to the slot's own timestamp rather than a sliding "time since this call last ran"

--- a/src/card/gallery/source-resolver-sdo-sun.ts
+++ b/src/card/gallery/source-resolver-sdo-sun.ts
@@ -1,4 +1,6 @@
 import type { DebugAccumulator } from "./debug-stats.js";
+import { padLeft } from "./pad.js";
+import { findPublishedSlot } from "./slot-search.js";
 import { IMAGE_TIMEOUT_MESSAGE, SourceResolver, timedPreload } from "./source-resolver.js";
 import type { SourcedImage, UrlCache } from "./url-cache.js";
 import { urlCache } from "./url-cache.js";
@@ -59,67 +61,44 @@ export class SdoSunResolver extends SourceResolver {
     // Backoff's cooldown decide when to look again.
     if (isTimeout(err)) throw err;
 
-    let lastErr = err;
-    let missed = candidate.date.getTime(); // newest slot known not to be published
-    let found: SourcedImage | null = null;
-
-    // Returns the slot when it loads, null when it 404s; a timeout aborts the search entirely
-    // for the reason above.
-    const trySlot = async (slotMs: number): Promise<SourcedImage | null> => {
-      debug.retries++;
-      const slot = buildSunSlotImage(new Date(slotMs));
-      try {
-        await timedPreload(slot.url, debug);
-        return slot;
-      } catch (retryErr) {
-        if (isTimeout(retryErr)) throw retryErr;
-        lastErr = retryErr;
-        return null;
-      }
-    };
-
     // `lastConfirmed`, not the TTL entry — getSunImageUrl() writes its guess there before
     // anything has verified it loads, so the TTL entry is exactly the wrong thing to treat as
     // known-good. Backoff only records a success after a real decode.
     const confirmed = this.cache.getStale(this.source);
-    if (confirmed) {
-      // `next >= missed` covers both "the guess was only one slot ahead" and a backwards
-      // clock jump leaving the confirmed frame newer than the guess: either way there is no
-      // gap to search, and the frame we already have is the answer.
-      const next = confirmed.date.getTime() + SUN_CACHE_TTL_MS;
-      found = next < missed ? await trySlot(next) : null;
-      if (!found) {
-        // Nothing newer than the frame we already hold, so the gap below is known-empty and
-        // there is nothing to search. Re-commit it so the TTL entry stops advertising the
-        // guess that just 404'd, and stamp the check so freshCachedSlot() holds off re-probing
-        // for a full TTL instead of retrying on every tick (#152).
-        this.cache.set(this.source, confirmed);
-        this.cache.recordChecked(this.source);
-        return confirmed;
-      }
-    } else {
-      const origin = missed;
-      for (let reach = SUN_CACHE_TTL_MS; ; reach = Math.min(reach * 2, SUN_MAX_REACH_MS)) {
-        found = await trySlot(origin - reach);
-        if (found) break;
-        missed = origin - reach;
-        if (reach === SUN_MAX_REACH_MS) break;
-      }
-      if (!found) throw lastErr;
-    }
 
-    // Narrow to the newest slot that loads. Each step halves what is left between a slot known
-    // to load and one known not to, so the whole search stays logarithmic in the gap.
-    let loaded = found.date.getTime();
-    while (missed - loaded > SUN_CACHE_TTL_MS) {
-      const mid = floorToSlot(loaded + (missed - loaded) / 2);
-      const image = await trySlot(mid);
-      if (image) {
-        found = image;
-        loaded = mid;
-      } else {
-        missed = mid;
+    // The search strategy itself (reach-doubling cold start, bisection narrowing) lives in
+    // slot-search.ts, pure and network-agnostic. This probe is the only place that knows what
+    // "does this slot exist" actually costs: one preload+decode, counted, with a timed-out
+    // attempt reported as `abort` so the search stops instead of treating a dead host as one
+    // more missing slot.
+    const probe = async (slotMs: number) => {
+      debug.retries++;
+      try {
+        await timedPreload(buildSunSlotImage(new Date(slotMs)).url, debug);
+        return { hit: true };
+      } catch (retryErr) {
+        return { hit: false, abort: isTimeout(retryErr), error: retryErr };
       }
+    };
+
+    const result = await findPublishedSlot({
+      confirmedMs: confirmed ? confirmed.date.getTime() : null,
+      missedMs: candidate.date.getTime(),
+      slotMs: SUN_CACHE_TTL_MS,
+      maxReachMs: SUN_MAX_REACH_MS,
+      probe,
+    });
+
+    // foundMs is only ever null when a confirmed frame was supplied and the one probe past it
+    // missed — cold-start exhaustion rethrows lastError inside findPublishedSlot instead of
+    // returning here. Nothing newer than the frame we already hold, so the gap below is
+    // known-empty and there is nothing to search. Re-commit it so the TTL entry stops
+    // advertising the guess that just 404'd, and stamp the check so freshCachedSlot() holds off
+    // re-probing for a full TTL instead of retrying on every tick (#152).
+    if (result.foundMs == null) {
+      this.cache.set(this.source, confirmed as SourcedImage);
+      this.cache.recordChecked(this.source);
+      return confirmed as SourcedImage;
     }
 
     // Committed once, for the slot that won — an attempt that 404s never touches the shared
@@ -127,6 +106,7 @@ export class SdoSunResolver extends SourceResolver {
     // observe a still-unconfirmed guess. Also the cold-start search's only exit, so it needs
     // its own stamp here too (#152) — without it, a cold start that lands on an old/stalled
     // frame settles with no throttle behind it, and the very next tick re-probes from scratch.
+    const found = buildSunSlotImage(new Date(result.foundMs));
     this.cache.set(this.source, found);
     this.cache.recordChecked(this.source);
     return found;
@@ -171,15 +151,11 @@ function floorToSlot(ms: number): number {
   return Math.floor(ms / SUN_CACHE_TTL_MS) * SUN_CACHE_TTL_MS;
 }
 
-function pad(n: number): string {
-  return String(n).padStart(2, "0");
-}
-
 function buildSunSlotImage(slot: Date): SourcedImage {
   const year = slot.getUTCFullYear();
-  const month = pad(slot.getUTCMonth() + 1);
-  const day = pad(slot.getUTCDate());
-  const hhmmss = `${pad(slot.getUTCHours())}${pad(slot.getUTCMinutes())}00`;
+  const month = padLeft(slot.getUTCMonth() + 1);
+  const day = padLeft(slot.getUTCDate());
+  const hhmmss = `${padLeft(slot.getUTCHours())}${padLeft(slot.getUTCMinutes())}00`;
   return {
     url: `${SDO_BROWSE_BASE_URL}/${year}/${month}/${day}/${year}${month}${day}_${hhmmss}_1024_HMIIC.jpg`,
     date: slot,

--- a/src/card/gallery/source-resolver-svs-moon.ts
+++ b/src/card/gallery/source-resolver-svs-moon.ts
@@ -1,3 +1,4 @@
+import { padLeft } from "./pad.js";
 import { SourceResolver } from "./source-resolver.js";
 import type { ImageSource } from "./sources.js";
 import type { SourcedImage, UrlCache } from "./url-cache.js";
@@ -83,10 +84,6 @@ export class SvsMoonResolver extends SourceResolver {
   // frame fixes. Fall through to the shared cooldown like any other source.
 }
 
-function pad(value: number, width: number): string {
-  return String(value).padStart(width, "0");
-}
-
 /**
  * The frame for one instant, at one of the published resolutions.
  *
@@ -104,7 +101,7 @@ export function moonFrameUrl(at: Date, size: string): string {
   // Products are filed in hundreds: 5587 lives under a005500/a005587.
   const group = Math.floor(product / 100) * 100;
   const frame = Math.floor((at.getTime() - Date.UTC(year, 0, 1)) / MOON_FRAME_MS) + 1;
-  return `${SVS_BASE_URL}/a${pad(group, 6)}/a${pad(product, 6)}/frames/${size}/moon.${pad(frame, 4)}.jpg`;
+  return `${SVS_BASE_URL}/a${padLeft(group, 6)}/a${padLeft(product, 6)}/frames/${size}/moon.${padLeft(frame, 4)}.jpg`;
 }
 
 /**

--- a/src/card/gallery/source-resolver.ts
+++ b/src/card/gallery/source-resolver.ts
@@ -45,29 +45,30 @@ export abstract class SourceResolver {
     return this.source;
   }
 
+  // Required hook #1. Answers "do we already have a still-valid candidate?" without touching
+  // the network — null means "go compute one". Each source picks its own definition of valid:
+  // sun anchors to its 15-min slot's own timestamp, earth is a plain elapsed-time TTL, moon is
+  // URL-string identity with no clock at all. May return a URL nothing has confirmed decodes
+  // yet (see fetchCandidateUrl's own contract below) — resolve() re-checks that separately via
+  // isDecoded() before ever trusting this as a finished answer.
   protected abstract getCached(): SourcedImage | null;
+
+  // Required hook #2. Called only when getCached() returned null — computes this tick's best
+  // guess at the current image and, conventionally, writes it to `this.cache` optimistically
+  // (before anything has proven it loads), the same pattern sun and moon both use. Wrap any
+  // real network call in `timedAttempt`/`timedPreload` from this module so it's counted the
+  // same way the shared preload step below is; a pure-math guess (sun, moon) needs no such
+  // wrapping and costs no `fetches` counter.
   protected abstract fetchCandidateUrl(debug: DebugAccumulator): Promise<SourcedImage>;
 
-  // Lets a caller skip calling resolve() at all while this source's own cache is still
-  // current — image-resolver.ts's resolveAll() uses this the same way it already skips a
-  // source still mid-fetch, so a tick that has nothing new to do leaves no trace (no debug
-  // counters move, no resolve() call happens) instead of running the whole cache-check
-  // protocol just to immediately return the same cached image.
-  //
-  // Deliberately checks isDecoded() too, not just getCached() alone: getCached() can be
-  // non-null for a URL a resolver wrote optimistically before anything confirmed it loads
-  // (see getSunImageUrl() / fetchLatestEarthImageUrl()'s own comments). Skipping on that
-  // alone would mean a failed fetch "poisons" every following tick into silently doing
-  // nothing instead of retrying — this mirrors exactly what resolve() itself treats as an
-  // instant-success shortcut, so isFresh() is true only when resolve() would be a no-op.
-  isFresh(): boolean {
-    const cached = this.getCached();
-    return cached != null && this.cache.isDecoded(this.cacheKey, cached.url);
-  }
-
-  // Only sun overrides this: one-step fallback to the previous 15-min slot when the computed
-  // one 404s. Earth's URL is already confirmed by a real API lookup, so the default (rethrow)
-  // is correct for it.
+  // Optional hook. Called with the preload/decode error, the candidate that failed, and the
+  // image-side debug accumulator, only after a real decode attempt has failed. Return a
+  // replacement SourcedImage to recover the tick (it gets committed exactly like a normal
+  // success); rethrow (the default, below) to give up — the caller's outer catch takes it from
+  // there and arms backoff. Earth and moon never override this: their engine-default rethrow
+  // is this exact function, unmodified. Only sun overrides it, walking backward through 15-min
+  // slots (source-resolver-sdo-sun.ts) — the only source where an older candidate is ever a
+  // better guess than giving up.
   protected recover(
     err: unknown,
     _candidate: SourcedImage,
@@ -99,56 +100,91 @@ export abstract class SourceResolver {
   // EPIC API call, separate from the image byte fetch); sun's caller passes the same one
   // twice, since its candidate URL is pure math with nothing to separate out.
   //
-  // Owns `refreshes` itself (bumped unconditionally below) rather than leaving it to the
+  // Owns `gets` itself (bumped unconditionally below) rather than leaving it to the
   // caller — every call here is one refresh attempt for this source, so the counter and the
   // attempt it counts live in the same place instead of two files staying in sync by
   // convention (ImageResolver used to bump this before ever calling resolve()).
   async resolve(urlDebug: DebugAccumulator, imgDebug: DebugAccumulator): Promise<SourcedImage> {
-    urlDebug.refreshes++;
-    // A source that just failed repeatedly skips the network entirely for a backoff window
-    // (see UrlCache.recordFailure) — serving the last known-good image instead of hammering
-    // NASA every refresh_mins tick during an outage or rate-limit.
-    if (this.cache.inCooldown(this.cacheKey)) {
-      const stale = this.cache.getStale(this.cacheKey);
-      if (stale) return stale;
-      throw new Error(`${this.source} is in cooldown after repeated failures`);
-    }
+    urlDebug.gets++;
+    // Checked — and left — outside the try/catch below on purpose: cooldown itself is not a
+    // failure to record (Backoff already recorded the failures that armed it), so this must
+    // never reach the catch's own recordFailure() call.
+    const stale = this.checkCooldown(urlDebug);
+    if (stale) return stale;
     try {
-      // Checked before any fetch is attempted, so `cacheHits` climbs on every refresh that's
-      // served straight from cache — the direct answer to "is this source's TTL actually
-      // skipping the network" that `refreshes` vs. `fetches` alone only implies.
-      const cached = this.getCached();
-      if (cached) urlDebug.cacheHits++;
-      const candidate = cached ?? (await this.fetchCandidateUrl(urlDebug));
+      const { image: candidate, fromCache } = await this.resolveCandidate(urlDebug);
       // URL identity is already the cache — skip re-decoding an image already confirmed to
-      // load (bytes that would've been re-fetched and re-decoded for nothing). Only counted
-      // when the TTL cache had just expired (`expired`): a real fetchCandidateUrl() call that
-      // ended up confirming nothing changed. The cache-still-fresh case needs no counter of its
-      // own — `cacheHits` already answers that question.
+      // load (bytes that would've been re-fetched and re-decoded for nothing). `expired` counts
+      // only the case where the TTL cache had just expired and a real fetchCandidateUrl() call
+      // confirmed nothing changed — the cache-still-fresh case needs no counter of its own,
+      // `cacheHits` already answers that question.
       if (this.cache.isDecoded(this.cacheKey, candidate.url)) {
-        if (!cached) urlDebug.expired++;
-        this.cache.recordSuccess(this.cacheKey, candidate);
-        return candidate;
+        if (!fromCache) urlDebug.expired++;
+        return this.commit(candidate);
       }
       // sun's imgDebug is the same object as urlDebug (see the accumulator comment above), so
-      // it's already been bumped by the unconditional refreshes++ above — only earth's
+      // it's already been bumped by the unconditional gets++ above — only earth's
       // split-off img row needs its own count of "an image refresh was actually needed" here.
-      if (imgDebug !== urlDebug) imgDebug.refreshes++;
-      try {
-        await timedPreload(candidate.url, imgDebug);
-        this.cache.markDecoded(this.cacheKey, candidate.url);
-        this.cache.recordSuccess(this.cacheKey, candidate);
-        return candidate;
-      } catch (err) {
-        const recovered = await this.recover(err, candidate, imgDebug);
-        this.cache.markDecoded(this.cacheKey, recovered.url);
-        this.cache.recordSuccess(this.cacheKey, recovered);
-        return recovered;
-      }
+      if (imgDebug !== urlDebug) imgDebug.gets++;
+      return await this.fetchAndDecode(candidate, imgDebug);
     } catch (err) {
       this.cache.recordFailure(this.cacheKey, retryAfterMsFrom(err));
       throw err;
     }
+  }
+
+  // Phase 1: is this source sitting out a backoff window from prior failures? A source that
+  // just failed repeatedly skips the network entirely (see UrlCache.recordFailure) — serving
+  // the last known-good image instead of hammering NASA every tick during an outage or
+  // rate-limit. Returns the stale image to short-circuit resolve() entirely, or null to
+  // continue on to the cache/fetch phases below.
+  private checkCooldown(debug: DebugAccumulator): SourcedImage | null {
+    if (!this.cache.inCooldown(this.cacheKey)) return null;
+    debug.backoffs++;
+    const stale = this.cache.getStale(this.cacheKey);
+    if (stale) return stale;
+    throw new Error(`${this.source} is in cooldown after repeated failures`);
+  }
+
+  // Phase 2: this source's own getCached()/fetchCandidateUrl() hooks, wrapped with the one
+  // counter (`cacheHits`) and the fromCache flag every source shares regardless of what those
+  // hooks actually do. Checked before any fetch is attempted, so `cacheHits` climbs on every
+  // refresh that's served straight from cache — the direct answer to "is this source's TTL
+  // actually skipping the network" that `refreshes` vs. `fetches` alone only implies.
+  private async resolveCandidate(
+    debug: DebugAccumulator
+  ): Promise<{ image: SourcedImage; fromCache: boolean }> {
+    const cached = this.getCached();
+    if (cached) debug.cacheHits++;
+    const image = cached ?? (await this.fetchCandidateUrl(debug));
+    return { image, fromCache: cached != null };
+  }
+
+  // Phase 3: the real network cost every source pays the same way — preload, decode, and on
+  // failure the recover() hook (default: rethrow; only sun overrides it). Both outcomes commit
+  // through the same phase 4 below, so a recovered image is indistinguishable from a normal
+  // success by the time it's cached.
+  private async fetchAndDecode(
+    candidate: SourcedImage,
+    imgDebug: DebugAccumulator
+  ): Promise<SourcedImage> {
+    try {
+      await timedPreload(candidate.url, imgDebug);
+      return this.commit(candidate);
+    } catch (err) {
+      const recovered = await this.recover(err, candidate, imgDebug);
+      return this.commit(recovered);
+    }
+  }
+
+  // Phase 4: the one place every successful path ends, dup or freshly decoded — confirms this
+  // exact URL decodes (markDecoded) and tells Backoff this is the new stale-fallback
+  // (recordSuccess), clearing any cooldown. Reached from the dup check above, hits the same
+  // markDecoded() write it already implies — cheap and idempotent, not a second decode.
+  private commit(image: SourcedImage): SourcedImage {
+    this.cache.markDecoded(this.cacheKey, image.url);
+    this.cache.recordSuccess(this.cacheKey, image);
+    return image;
   }
 }
 

--- a/src/card/gallery/sources.ts
+++ b/src/card/gallery/sources.ts
@@ -29,6 +29,26 @@ export type DebugRowId = "moon" | "sun" | "earth-url" | "earth-img";
 export const DEBUG_ROWS: DebugRowId[] = ["moon", "sun", "earth-url", "earth-img"];
 
 /**
+ * Which overlay columns a debug row's own resolve() can actually produce a real value for —
+ * see debug-view.ts's own use of these. Row-level, not source-level: unlike SourceSpec above,
+ * these apply to DebugRowId (a row can be an earth split-half, or a moon pair collapsed into
+ * one), so they live beside DEBUG_ROWS rather than inside SOURCES.
+ */
+export interface DebugRowSpec {
+  /** False for earth-img: the image-byte fetch has no cache/URL-identity step of its own — see earth-url. */
+  hasCacheStep: boolean;
+  /** True only for sun: recover()'s one-slot-back fallback is the only resolver that ever retries. */
+  canRetry: boolean;
+}
+
+export const DEBUG_ROW_SPECS: Record<DebugRowId, DebugRowSpec> = {
+  moon: { hasCacheStep: true, canRetry: false },
+  sun: { hasCacheStep: true, canRetry: true },
+  "earth-url": { hasCacheStep: true, canRetry: false },
+  "earth-img": { hasCacheStep: false, canRetry: false },
+};
+
+/**
  * Everything the rest of the card needs to know about one source, in one place.
  *
  * These facts used to live in eight tables across five modules (labels and disc geometry in

--- a/src/card/gallery/sources.ts
+++ b/src/card/gallery/sources.ts
@@ -19,9 +19,14 @@ export const IMAGE_SOURCES: ImageSource[] = ["mymoon", "moon", "earth", "sun"];
 // two: they share a cache key (SvsMoonResolver's cacheKey, see source-resolver-svs-moon.ts) and
 // resolve to the same frame, so separate rows would show one real fetch as two — mymoon's own
 // row always at 0 fetches (permanent cache hit), reading as broken rather than shared. Both
-// still bump `refreshes` independently into the shared row, since each tile really does ask
+// still bump `gets` independently into the shared row, since each tile really does ask
 // once a tick; only the network-facing counters (fetches, cacheHits, ...) tell the merged story.
 export type DebugRowId = "moon" | "sun" | "earth-url" | "earth-img";
+
+// The canonical row set, in the overlay's own display order — the one place this list is
+// written out; every other consumer (GalleryController's debug bookkeeping, debug-view.ts's
+// overlay) iterates this instead of re-listing the same four keys.
+export const DEBUG_ROWS: DebugRowId[] = ["moon", "sun", "earth-url", "earth-img"];
 
 /**
  * Everything the rest of the card needs to know about one source, in one place.

--- a/test/card/card-template.test.ts
+++ b/test/card/card-template.test.ts
@@ -11,7 +11,7 @@ import type { GalleryViewModel } from "../../src/card/gallery/gallery-controller
 import { formatDate } from "../../src/card/relative-time.js";
 
 const zeroDebugStats: SourceDebugStats = {
-  refreshes: 0,
+  gets: 0,
   fetches: 0,
   failures: 0,
   retries: 0,

--- a/test/card/card.status-bar.test.ts
+++ b/test/card/card.status-bar.test.ts
@@ -178,7 +178,7 @@ describe("SolarViewCard status bar", () => {
       expect(rowText[2]).toContain("SDO/S");
       expect(rowText[3]).toContain("DSCOVR/E");
       expect(overlay.textContent).toContain("source");
-      expect(overlay.textContent).toContain("refresh");
+      expect(overlay.textContent).toContain("get");
       expect(overlay.textContent).toContain("fetch");
       expect(overlay.textContent).toContain("expire");
       expect(overlay.textContent).toMatch(/\d+ms/);

--- a/test/card/debug-view.test.ts
+++ b/test/card/debug-view.test.ts
@@ -5,8 +5,9 @@ import type { SourceDebugStats } from "../../src/card/gallery/debug-stats.js";
 import { formatDate } from "../../src/card/relative-time.js";
 
 const zeroDebugStats: SourceDebugStats = {
-  refreshes: 0,
+  gets: 0,
   cacheHits: 0,
+  backoffs: 0,
   fetches: 0,
   failures: 0,
   retries: 0,
@@ -27,8 +28,9 @@ describe("buildDebugOverlay", () => {
     "earth-url": zeroDebugStats,
     "earth-img": zeroDebugStats,
     sun: {
-      refreshes: 4,
+      gets: 4,
       cacheHits: 2,
+      backoffs: 2,
       fetches: 3,
       failures: 1,
       retries: 2,
@@ -85,16 +87,19 @@ describe("buildDebugOverlay", () => {
     expect(cells).toEqual([
       // The moon row can't retry either: every frame of the year is pre-published, so an
       // earlier one is never a better guess (see source-resolver-svs-moon.ts).
-      ["SVS/M", "0", "0", "0", "0", "0", "—", "—", "—"],
-      ["SDO/S", "4", "2", "5", "3", "1", "2", "123ms", "5m"],
+      ["SVS/M", "0", "0", "0", "0", "0", "0", "—", "—", "—"],
+      // backoffs isn't gated by hasCacheStep — it's the same "did resolve() even get past the
+      // top gate" question as gets, so it lands right after cache like sun's non-zero 2.
+      ["SDO/S", "4", "2", "2", "5", "3", "1", "2", "123ms", "5m"],
       // Neither earth row can retry (only sun's resolver ever does) — retry shows "—".
-      ["DSCOVR/E url", "0", "0", "0", "0", "0", "—", "—", "—"],
-      // earth-img also has no cache/URL-identity step of its own — those columns show "—" too.
-      ["DSCOVR/E img", "0", "—", "—", "0", "0", "—", "—", "—"],
-      // total: refreshes max()s (4 vs. 0 vs. 0) rather than summing, cacheHits/others sum
-      // the raw underlying values (not the dashed display), elapsed avg()s the non-null
+      ["DSCOVR/E url", "0", "0", "0", "0", "0", "0", "—", "—", "—"],
+      // earth-img also has no cache/URL-identity step of its own — those columns show "—" too,
+      // but backoffs still shows a real 0 since it applies before the cache step ever runs.
+      ["DSCOVR/E img", "0", "—", "0", "—", "0", "0", "—", "—", "—"],
+      // total: gets max()s (4 vs. 0 vs. 0) rather than summing, cacheHits/backoffs/others
+      // sum the raw underlying values (not the dashed display), elapsed avg()s the non-null
       // values (just sun's 123.4 here), last is always "—" — see summarizeDebugStats.
-      ["total", "4", "2", "5", "3", "1", "2", "123ms", "—"],
+      ["total", "4", "2", "2", "5", "3", "1", "2", "123ms", "—"],
     ]);
   });
 
@@ -110,11 +115,11 @@ describe("buildDebugOverlay", () => {
     expect(sunRow[sunRow.length - 1]).toBe("45s");
   });
 
-  it("sums the total row's refreshes with max() instead of add(), for lockstep both/slide modes", () => {
+  it("sums the total row's gets with max() instead of add(), for lockstep both/slide modes", () => {
     const lockstep = {
       moon: zeroDebugStats,
-      sun: { ...zeroDebugStats, refreshes: 5, elapsed: 100 },
-      "earth-url": { ...zeroDebugStats, refreshes: 5, elapsed: 200 },
+      sun: { ...zeroDebugStats, gets: 5, elapsed: 100 },
+      "earth-url": { ...zeroDebugStats, gets: 5, elapsed: 200 },
       "earth-img": zeroDebugStats,
     };
     const root = renderToDOM(buildDebugOverlay(lockstep, Date.now()));
@@ -122,6 +127,6 @@ describe("buildDebugOverlay", () => {
     const totalRow = [...rows[rows.length - 1].children].map((td) => td.textContent);
     // max(5, 5, 0) = 5, not 10 — and elapsed averages the two non-null values,
     // (100 + 200) / 2 = 150ms.
-    expect(totalRow).toEqual(["total", "5", "0", "0", "0", "0", "0", "150ms", "—"]);
+    expect(totalRow).toEqual(["total", "5", "0", "0", "0", "0", "0", "0", "150ms", "—"]);
   });
 });

--- a/test/card/gallery/gallery-controller.test.ts
+++ b/test/card/gallery/gallery-controller.test.ts
@@ -379,7 +379,8 @@ describe("GalleryController.viewModel", () => {
     const gallery = new GalleryController(() => {});
     gallery.configure("show", IMAGE_SOURCES, 60000);
     gallery.openPanel("earth");
-    (gallery as unknown as { _error: string | null })._error = "Earth image unavailable";
+    (gallery as unknown as { _panel: { error: string | null } })._panel.error =
+      "Earth image unavailable";
     expect(gallery.viewModel().error).toBe("Earth image unavailable");
   });
 
@@ -445,8 +446,9 @@ describe("GalleryController.viewModel", () => {
 
 describe("GalleryController.debugStats", () => {
   const zeroStats = {
-    refreshes: 0,
+    gets: 0,
     cacheHits: 0,
+    backoffs: 0,
     fetches: 0,
     failures: 0,
     retries: 0,
@@ -465,7 +467,7 @@ describe("GalleryController.debugStats", () => {
     });
   });
 
-  it("skips a source entirely on the next tick while its own cache is still current", async () => {
+  it("still resolves a source on the next tick while its own cache is current, but hits cache instead of the network", async () => {
     const gallery = new GalleryController(() => {});
     gallery.configure("show", IMAGE_SOURCES, 60000);
     gallery.start();
@@ -481,10 +483,19 @@ describe("GalleryController.debugStats", () => {
     await Promise.resolve();
 
     // Both sources are still within their own TTL/publish window and already confirmed to
-    // decode, so resolveAll() never even calls resolve() for them this tick — every counter
-    // is untouched, not just the network-facing ones. This is the whole point of isFresh():
-    // a tick with nothing new to do should leave no trace, not just skip the real fetch.
-    expect(gallery.debugStats).toEqual(afterFirstTick);
+    // decode — `gets` still climbs every tick regardless (that's the whole point: it counts
+    // ticks, not fetch attempts), but resolve()'s own cache-hit phase answers it without ever
+    // reaching the network, so `fetches` stays put and `cacheHits` climbs instead.
+    const afterSecondTick = gallery.debugStats;
+    expect(afterSecondTick["earth-url"].gets).toBe(afterFirstTick["earth-url"].gets + 1);
+    expect(afterSecondTick["earth-url"].cacheHits).toBe(1);
+    expect(afterSecondTick["earth-url"].fetches).toBe(afterFirstTick["earth-url"].fetches);
+    expect(afterSecondTick.sun.gets).toBe(afterFirstTick.sun.gets + 1);
+    expect(afterSecondTick.sun.cacheHits).toBe(1);
+    expect(afterSecondTick.sun.fetches).toBe(afterFirstTick.sun.fetches);
+    // earth-img's own `gets` only moves when a real image fetch was actually attempted — a
+    // cache hit on the URL commits before that branch is ever reached, so it stays put.
+    expect(afterSecondTick["earth-img"].gets).toBe(afterFirstTick["earth-img"].gets);
   });
 
   it("skips a source still mid-fetch instead of stacking a second overlapping request", async () => {
@@ -500,26 +511,35 @@ describe("GalleryController.debugStats", () => {
     const gallery = new GalleryController(() => {});
     gallery.configure("show", IMAGE_SOURCES, 60000);
     gallery.start();
-    await vi.waitFor(() => expect(gallery.debugStats["earth-url"].refreshes).toBe(1));
+    await vi.waitFor(() => expect(gallery.debugStats["earth-url"].gets).toBe(1));
 
     // First fetch is still in flight (unresolved) — a second tick must not start another.
     gallery.tick();
     await Promise.resolve();
-    expect(gallery.debugStats["earth-url"].refreshes).toBe(1);
+    expect(gallery.debugStats["earth-url"].gets).toBe(1);
 
     resolveFetch({ ok: true, json: () => Promise.resolve([{ identifier: "20260810234950" }]) });
     await vi.waitFor(() => expect(gallery.images.earth).toBeDefined());
 
-    // Now that it settled, earth is confirmed and within its own 1-hour TTL — isFresh() skips
-    // it, same as any other still-current source, regardless of the in-flight guard clearing.
+    // Now that it settled, the in-flight guard clears — the very next tick calls resolve()
+    // again even though earth is still well within its own 1-hour TTL: `gets` climbs, but the
+    // cache-hit phase answers it with no new network call.
     gallery.tick();
-    await Promise.resolve();
-    expect(gallery.debugStats["earth-url"].refreshes).toBe(1);
+    await vi.waitFor(() => expect(gallery.debugStats["earth-url"].cacheHits).toBe(1));
+    expect(gallery.debugStats["earth-url"].gets).toBe(2);
+    expect(gallery.debugStats["earth-url"].fetches).toBe(1);
 
-    // Only once its TTL has actually elapsed does a tick attempt it again.
+    // Only once its TTL has actually elapsed does a tick reach a real second fetch.
     vi.spyOn(Date, "now").mockReturnValue(Date.now() + EARTH_CACHE_TTL_MS + 1);
-    gallery.tick();
-    await vi.waitFor(() => expect(gallery.debugStats["earth-url"].refreshes).toBe(2));
+    // `gets`/`cacheHits` above bump synchronously at the top of resolve(), before that
+    // source's own promise (and the in-flight clear that follows it inside resolveAll()) has
+    // actually settled — a single tick() right after can still find earth marked in-flight
+    // and skip it. Retrying the tick alongside the assertion rides that out instead of
+    // guessing at a fixed delay.
+    await vi.waitFor(() => {
+      gallery.tick();
+      expect(gallery.debugStats["earth-url"].fetches).toBe(2);
+    });
   });
 
   it("counts a failed image preload as a fetch distinct from the EPIC API call", async () => {
@@ -530,13 +550,13 @@ describe("GalleryController.debugStats", () => {
     await vi.waitFor(() => expect(gallery.debugStats["earth-img"].failures).toBe(1));
 
     // Each phase is its own row now: 1 fetch on the url row (EPIC API lookup, succeeded),
-    // 1 fetch on the img row (image preload, failed) — and the img row's own refreshes
+    // 1 fetch on the img row (image preload, failed) — and the img row's own gets
     // still moved, since a new URL genuinely needed a preload attempt regardless of outcome.
     expect(gallery.debugStats["earth-url"].fetches).toBe(1);
     expect(gallery.debugStats["earth-url"].failures).toBe(0);
     expect(gallery.debugStats["earth-url"].elapsed).not.toBeNull();
     expect(gallery.debugStats["earth-img"].fetches).toBe(1);
-    expect(gallery.debugStats["earth-img"].refreshes).toBe(1);
+    expect(gallery.debugStats["earth-img"].gets).toBe(1);
   });
 
   it("counts a retry when sun's primary slot guess fails and falls back", async () => {
@@ -560,8 +580,8 @@ describe("GalleryController.debugStats", () => {
     const gallery = new GalleryController(() => {});
     gallery.configure("slide", IMAGE_SOURCES, 60000);
     gallery.start();
-    await vi.waitFor(() => expect(gallery.debugStats["earth-url"].refreshes).toBe(1));
-    expect(gallery.debugStats.sun.refreshes).toBe(1);
-    expect(gallery.debugStats.moon.refreshes).toBe(2);
+    await vi.waitFor(() => expect(gallery.debugStats["earth-url"].gets).toBe(1));
+    expect(gallery.debugStats.sun.gets).toBe(1);
+    expect(gallery.debugStats.moon.gets).toBe(2);
   });
 });

--- a/test/card/gallery/slot-search.test.ts
+++ b/test/card/gallery/slot-search.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { findPublishedSlot } from "../../../src/card/gallery/slot-search.js";
+
+const SLOT_MS = 15 * 60000;
+const MAX_REACH_MS = 30 * 24 * 60 * 60000;
+
+// A fake probe driven entirely by a set of "which slots exist" — no Image, no network, no
+// timers. This is the whole point of extracting the search from SdoSunResolver.recover(): the
+// strategy is provable against plain numbers.
+function probeFor(existingSlots: Set<number>) {
+  return async (slotMs: number) => ({ hit: existingSlots.has(slotMs) });
+}
+
+describe("findPublishedSlot", () => {
+  it("with a confirmed slot, one probe past it settling a hit narrows to that slot", async () => {
+    const confirmedMs = 1000 * SLOT_MS;
+    const nextMs = confirmedMs + SLOT_MS;
+    const result = await findPublishedSlot({
+      confirmedMs,
+      missedMs: nextMs + 5 * SLOT_MS, // caller's original miss was further out
+      slotMs: SLOT_MS,
+      maxReachMs: MAX_REACH_MS,
+      probe: probeFor(new Set([nextMs])),
+    });
+
+    expect(result.foundMs).toBe(nextMs);
+  });
+
+  it("with a confirmed slot, a miss on the one probe past it resolves foundMs: null", async () => {
+    const confirmedMs = 1000 * SLOT_MS;
+    const result = await findPublishedSlot({
+      confirmedMs,
+      missedMs: confirmedMs + 5 * SLOT_MS,
+      slotMs: SLOT_MS,
+      maxReachMs: MAX_REACH_MS,
+      probe: probeFor(new Set()), // nothing newer exists
+    });
+
+    expect(result.foundMs).toBeNull();
+  });
+
+  it("with a confirmed slot and no gap to search (next >= missed), never calls probe", async () => {
+    const confirmedMs = 1000 * SLOT_MS;
+    let probeCalls = 0;
+    const result = await findPublishedSlot({
+      confirmedMs,
+      missedMs: confirmedMs + SLOT_MS, // equal to `next` — no gap
+      slotMs: SLOT_MS,
+      maxReachMs: MAX_REACH_MS,
+      probe: async () => {
+        probeCalls++;
+        return { hit: false };
+      },
+    });
+
+    expect(probeCalls).toBe(0);
+    expect(result.foundMs).toBeNull();
+  });
+
+  it("cold start doubles reach until a hit, then bisects to the newest loading slot", async () => {
+    const origin = 10_000 * SLOT_MS;
+    // Reach sequence from origin: -1, -2, -4 slots — the 3rd probe hits, landing exactly on the
+    // reach-doubling boundary, so bisection then narrows the gap against the prior miss at -2.
+    const hitAt = origin - 4 * SLOT_MS;
+    const result = await findPublishedSlot({
+      confirmedMs: null,
+      missedMs: origin,
+      slotMs: SLOT_MS,
+      maxReachMs: MAX_REACH_MS,
+      probe: probeFor(new Set([hitAt])),
+    });
+
+    expect(result.foundMs).toBe(hitAt);
+  });
+
+  it("cold start exhausted at maxReachMs with nothing found rethrows the last miss error", async () => {
+    const origin = 1000 * SLOT_MS;
+    await expect(
+      findPublishedSlot({
+        confirmedMs: null,
+        missedMs: origin,
+        slotMs: SLOT_MS,
+        maxReachMs: 2 * SLOT_MS, // reach maxes out after 2 probes
+        probe: async () => ({ hit: false, error: new Error("404") }),
+      })
+    ).rejects.toThrow("404");
+  });
+
+  it("an abort result stops the search immediately, without continuing to a wider reach", async () => {
+    let probeCalls = 0;
+    await expect(
+      findPublishedSlot({
+        confirmedMs: null,
+        missedMs: 1000 * SLOT_MS,
+        slotMs: SLOT_MS,
+        maxReachMs: MAX_REACH_MS,
+        probe: async () => {
+          probeCalls++;
+          return { hit: false, abort: true, error: new Error("timed out") };
+        },
+      })
+    ).rejects.toThrow("timed out");
+    expect(probeCalls).toBe(1);
+  });
+
+  it("bisection converges to the exact boundary between a known-loading and known-missing slot", async () => {
+    const loadedAt = 0;
+    const missedAt = 8 * SLOT_MS;
+    // Every slot from 1..8 in units of SLOT_MS "exists" except the boundary walk should land on
+    // the newest slot still <= missedAt that is NOT in the hit set — plant a hit only at 5.
+    const result = await findPublishedSlot({
+      confirmedMs: loadedAt - SLOT_MS, // forces the confirmed-branch to probe at `loadedAt`
+      missedMs: missedAt,
+      slotMs: SLOT_MS,
+      maxReachMs: MAX_REACH_MS,
+      probe: probeFor(new Set([loadedAt])),
+    });
+
+    expect(result.foundMs).toBe(loadedAt);
+  });
+});

--- a/test/card/gallery/source-resolver-dscovr-earth-identifier.test.ts
+++ b/test/card/gallery/source-resolver-dscovr-earth-identifier.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildEpicImage,
+  EPIC_BASE_URL,
+} from "../../../src/card/gallery/source-resolver-dscovr-earth.js";
+
+// Pure identifier → SourcedImage math, no fetch mock — see buildEpicImage's own comment for why
+// this was split out of fetchLatestEarthImageUrl.
+describe("buildEpicImage", () => {
+  it("builds the archive URL from the identifier's own date segments", () => {
+    const image = buildEpicImage("20260810234950");
+    expect(image.url).toBe(
+      `${EPIC_BASE_URL}/archive/natural/2026/08/10/jpg/epic_1b_20260810234950.jpg`
+    );
+  });
+
+  it("parses the identifier as a UTC timestamp, not local time", () => {
+    const image = buildEpicImage("20260810234950");
+    expect(image.date.toISOString()).toBe("2026-08-10T23:49:50.000Z");
+  });
+
+  it("keeps the zero-padded segments distinct (midnight, single-digit month/day)", () => {
+    const image = buildEpicImage("20260105000003");
+    expect(image.date.toISOString()).toBe("2026-01-05T00:00:03.000Z");
+    expect(image.url).toContain("/archive/natural/2026/01/05/jpg/epic_1b_20260105000003.jpg");
+  });
+});

--- a/test/card/gallery/source-resolver-sdo-sun.test.ts
+++ b/test/card/gallery/source-resolver-sdo-sun.test.ts
@@ -31,10 +31,10 @@ function stubImageDecode(...results: boolean[]) {
 }
 
 // Models the real browse archive rather than a fixed pass/fail sequence: a slot loads if and
-// only if NASA had actually published it. Needed for the stall fixture below, where "which
-// URLs exist" is the whole point and the resolver's request order is what's under test.
-function stubArchivePublishedUpTo(newestSlotIso: string) {
-  const newest = Date.parse(newestSlotIso);
+// only if `isPublished` says it exists yet. Shared engine behind stubArchivePublishedUpTo (a
+// flat cutoff) and stubArchiveWithRealPublishLag (the real 25/30-min rule) below — both just
+// supply a different one-line predicate over the same parse/probe/decide machinery.
+function stubArchive(isPublished: (slotMs: number) => boolean) {
   const state = { calls: 0, probes: [] as { slot: number; ok: boolean }[] };
   vi.stubGlobal(
     "Image",
@@ -46,13 +46,20 @@ function stubArchivePublishedUpTo(newestSlotIso: string) {
         if (!match) return Promise.reject(new Error("unparseable slot URL"));
         const [, y, mo, d, h, mi, sec] = match.map(Number);
         const slot = Date.UTC(y, mo - 1, d, h, mi, sec);
-        const ok = slot <= newest;
+        const ok = isPublished(slot);
         state.probes.push({ slot, ok });
         return ok ? Promise.resolve() : Promise.reject(new Error("404"));
       }
     }
   );
   return state;
+}
+
+// Needed for the stall fixture below, where "which URLs exist" is the whole point and the
+// resolver's request order is what's under test.
+function stubArchivePublishedUpTo(newestSlotIso: string) {
+  const newest = Date.parse(newestSlotIso);
+  return stubArchive((slot) => slot <= newest);
 }
 
 // This one test reports rather than merely asserts: its probe-by-probe trace is what a human
@@ -66,24 +73,7 @@ const print = (line: string) => console.log(line);
 // capture and a :00/:30 slot 30 minutes after (measured in #148, zero jitter). Existence is
 // therefore a function of the mocked clock, so the same stub serves a whole run of ticks.
 function stubArchiveWithRealPublishLag() {
-  const state = { calls: 0, probes: [] as { slot: number; ok: boolean }[] };
-  vi.stubGlobal(
-    "Image",
-    class {
-      src = "";
-      decode() {
-        state.calls++;
-        const match = /\/(\d{4})(\d{2})(\d{2})_(\d{2})(\d{2})(\d{2})_/.exec(this.src);
-        if (!match) return Promise.reject(new Error("unparseable slot URL"));
-        const [, y, mo, d, h, mi, sec] = match.map(Number);
-        const slot = Date.UTC(y, mo - 1, d, h, mi, sec);
-        const ok = Date.now() >= slot + publishLagMs(slot);
-        state.probes.push({ slot, ok });
-        return ok ? Promise.resolve() : Promise.reject(new Error("404"));
-      }
-    }
-  );
-  return state;
+  return stubArchive((slot) => Date.now() >= slot + publishLagMs(slot));
 }
 
 function publishLagMs(slot: number): number {

--- a/test/card/gallery/source-resolver-sdo-sun.test.ts
+++ b/test/card/gallery/source-resolver-sdo-sun.test.ts
@@ -1,11 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { emptyDebugAccumulator } from "../../../src/card/gallery/debug-stats.js";
-import { FETCH_TIMEOUT_MS } from "../../../src/card/gallery/source-resolver.js";
+import {
+  FETCH_TIMEOUT_MS,
+  IMAGE_TIMEOUT_MESSAGE,
+} from "../../../src/card/gallery/source-resolver.js";
 import {
   getSunImageUrl,
   SDO_BROWSE_BASE_URL,
   SdoSunResolver,
   SUN_CACHE_TTL_MS,
+  sunSlotProbe,
 } from "../../../src/card/gallery/source-resolver-sdo-sun.js";
 import { UrlCache } from "../../../src/card/gallery/url-cache.js";
 
@@ -87,6 +91,54 @@ function newestPublishedAt(now: number): number {
   while (now < slot + publishLagMs(slot)) slot -= SUN_CACHE_TTL_MS;
   return slot;
 }
+
+describe("sunSlotProbe", () => {
+  // Drives the SlotProbe contract with a synchronous fake `preload` — no global.Image/decode()
+  // stubbing needed, the same split slot-search.ts's own search strategy already gets from its
+  // fake `probe` in slot-search.test.ts.
+  it("reports a hit and counts the attempt when preload succeeds", async () => {
+    const debug = emptyDebugAccumulator();
+    const probe = sunSlotProbe(debug, () => Promise.resolve());
+
+    const result = await probe(Date.UTC(2026, 7, 15, 22, 0, 0));
+
+    expect(result).toEqual({ hit: true });
+    expect(debug.retries).toBe(1);
+  });
+
+  it("reports a miss without abort when preload fails with a non-timeout error", async () => {
+    const debug = emptyDebugAccumulator();
+    const err = new Error("404");
+    const probe = sunSlotProbe(debug, () => Promise.reject(err));
+
+    const result = await probe(Date.UTC(2026, 7, 15, 22, 0, 0));
+
+    expect(result).toEqual({ hit: false, abort: false, error: err });
+  });
+
+  it("reports a miss with abort when preload fails with a timeout, so the search stops", async () => {
+    const debug = emptyDebugAccumulator();
+    const err = new Error(IMAGE_TIMEOUT_MESSAGE);
+    const probe = sunSlotProbe(debug, () => Promise.reject(err));
+
+    const result = await probe(Date.UTC(2026, 7, 15, 22, 0, 0));
+
+    expect(result).toEqual({ hit: false, abort: true, error: err });
+  });
+
+  it("preloads the SDO browse-archive URL for the given slot", async () => {
+    const debug = emptyDebugAccumulator();
+    const seen: string[] = [];
+    const probe = sunSlotProbe(debug, (url) => {
+      seen.push(url);
+      return Promise.resolve();
+    });
+
+    await probe(Date.UTC(2026, 7, 15, 22, 0, 0));
+
+    expect(seen).toEqual([`${SDO_BROWSE_BASE_URL}/2026/08/15/20260815_220000_1024_HMIIC.jpg`]);
+  });
+});
 
 describe("source-resolver-sdo-sun", () => {
   // Each test gets its own UrlCache — SdoSunResolver/getSunImageUrl accept one explicitly, so

--- a/test/card/gallery/source-resolver.test.ts
+++ b/test/card/gallery/source-resolver.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DebugAccumulator } from "../../../src/card/gallery/debug-stats.js";
+import { emptyDebugAccumulator } from "../../../src/card/gallery/debug-stats.js";
+import { SourceResolver } from "../../../src/card/gallery/source-resolver.js";
+import type { SourcedImage, UrlCache } from "../../../src/card/gallery/url-cache.js";
+import { UrlCache as UrlCacheClass } from "../../../src/card/gallery/url-cache.js";
+
+// A synthetic tile: every hook is a plain field the test sets directly, so each test drives
+// resolve()'s shared engine through one specific branch without any real NASA-specific logic
+// (slot math, EPIC JSON, product-id tables) getting in the way of what's actually under test.
+class MockResolver extends SourceResolver {
+  readonly source = "sun" as const;
+  getCachedResult: SourcedImage | null = null;
+  fetchCandidateUrlImpl: (debug: DebugAccumulator) => Promise<SourcedImage> = () =>
+    Promise.reject(new Error("fetchCandidateUrl not configured"));
+  recoverImpl:
+    | ((err: unknown, candidate: SourcedImage, debug: DebugAccumulator) => Promise<SourcedImage>)
+    | null = null;
+
+  protected getCached(): SourcedImage | null {
+    return this.getCachedResult;
+  }
+
+  protected fetchCandidateUrl(debug: DebugAccumulator): Promise<SourcedImage> {
+    return this.fetchCandidateUrlImpl(debug);
+  }
+
+  protected recover(
+    err: unknown,
+    candidate: SourcedImage,
+    debug: DebugAccumulator
+  ): Promise<SourcedImage> {
+    return this.recoverImpl
+      ? this.recoverImpl(err, candidate, debug)
+      : super.recover(err, candidate, debug);
+  }
+}
+
+function image(url: string): SourcedImage {
+  return { url, date: new Date("2026-01-01T00:00:00Z") };
+}
+
+// Stubs the global Image constructor resolve() ends up calling via timedPreload — resolves
+// decode() for any URL in `okUrls`, rejects (onerror) for everything else.
+function stubImageDecode(okUrls: Set<string>): void {
+  vi.stubGlobal(
+    "Image",
+    class {
+      src = "";
+      onerror: (() => void) | null = null;
+      decode(): Promise<void> {
+        return okUrls.has(this.src)
+          ? Promise.resolve()
+          : Promise.reject(new Error("decode failed"));
+      }
+    }
+  );
+}
+
+describe("SourceResolver engine", () => {
+  let cache: UrlCache;
+
+  beforeEach(() => {
+    cache = new UrlCacheClass();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("a cache hit skips fetchCandidateUrl entirely and counts cacheHits, not fetches", async () => {
+    const resolver = new MockResolver(cache);
+    const cached = image("https://example.test/cached.jpg");
+    resolver.getCachedResult = cached;
+    cache.markDecoded("sun", cached.url); // already known to decode, so isDecoded() short-circuits too
+    const debug = emptyDebugAccumulator();
+
+    const result = await resolver.resolve(debug, debug);
+
+    expect(result).toEqual(cached);
+    expect(debug.cacheHits).toBe(1);
+    expect(debug.fetches).toBe(0);
+    expect(debug.expired).toBe(0);
+    expect(debug.gets).toBe(1);
+  });
+
+  it("a cache miss that resolves to an already-decoded URL counts expired, not cacheHits", async () => {
+    const resolver = new MockResolver(cache);
+    const known = image("https://example.test/known.jpg");
+    cache.markDecoded("sun", known.url);
+    resolver.fetchCandidateUrlImpl = () => Promise.resolve(known);
+    const debug = emptyDebugAccumulator();
+
+    const result = await resolver.resolve(debug, debug);
+
+    expect(result).toEqual(known);
+    expect(debug.cacheHits).toBe(0);
+    expect(debug.expired).toBe(1);
+    expect(debug.fetches).toBe(0); // MockResolver's own fetchCandidateUrl is free, like sun/moon
+  });
+
+  it("a new URL preloads, decodes, and commits — markDecoded + recordSuccess", async () => {
+    const resolver = new MockResolver(cache);
+    const fresh = image("https://example.test/fresh.jpg");
+    resolver.fetchCandidateUrlImpl = () => Promise.resolve(fresh);
+    stubImageDecode(new Set([fresh.url]));
+    const debug = emptyDebugAccumulator();
+
+    const result = await resolver.resolve(debug, debug);
+
+    expect(result).toEqual(fresh);
+    expect(debug.fetches).toBe(1);
+    expect(debug.failures).toBe(0);
+    expect(cache.isDecoded("sun", fresh.url)).toBe(true);
+    expect(cache.getStale("sun")).toEqual(fresh);
+  });
+
+  it("splits refreshes across urlDebug/imgDebug when they're different accumulators (earth's shape)", async () => {
+    const resolver = new MockResolver(cache);
+    const fresh = image("https://example.test/fresh.jpg");
+    resolver.fetchCandidateUrlImpl = () => Promise.resolve(fresh);
+    stubImageDecode(new Set([fresh.url]));
+    const urlDebug = emptyDebugAccumulator();
+    const imgDebug = emptyDebugAccumulator();
+
+    await resolver.resolve(urlDebug, imgDebug);
+
+    expect(urlDebug.gets).toBe(1);
+    expect(imgDebug.gets).toBe(1);
+    expect(imgDebug.fetches).toBe(1); // the preload cost lands on imgDebug, not urlDebug
+  });
+
+  it("does not double-count refreshes when urlDebug and imgDebug are the same accumulator (sun's shape)", async () => {
+    const resolver = new MockResolver(cache);
+    const fresh = image("https://example.test/fresh.jpg");
+    resolver.fetchCandidateUrlImpl = () => Promise.resolve(fresh);
+    stubImageDecode(new Set([fresh.url]));
+    const debug = emptyDebugAccumulator();
+
+    await resolver.resolve(debug, debug);
+
+    expect(debug.gets).toBe(1);
+  });
+
+  it("a decode failure with the default recover() rethrows, arming backoff", async () => {
+    const resolver = new MockResolver(cache);
+    const bad = image("https://example.test/bad.jpg");
+    resolver.fetchCandidateUrlImpl = () => Promise.resolve(bad);
+    stubImageDecode(new Set()); // nothing decodes
+    const debug = emptyDebugAccumulator();
+
+    await expect(resolver.resolve(debug, debug)).rejects.toThrow();
+
+    expect(debug.failures).toBe(1);
+    expect(cache.inCooldown("sun")).toBe(true);
+  });
+
+  it("a custom recover() that returns a replacement image commits it like a normal success", async () => {
+    const resolver = new MockResolver(cache);
+    const bad = image("https://example.test/bad.jpg");
+    const recovered = image("https://example.test/recovered.jpg");
+    resolver.fetchCandidateUrlImpl = () => Promise.resolve(bad);
+    resolver.recoverImpl = () => Promise.resolve(recovered);
+    stubImageDecode(new Set()); // bad.jpg never decodes; recover() bypasses it directly
+    const debug = emptyDebugAccumulator();
+
+    const result = await resolver.resolve(debug, debug);
+
+    expect(result).toEqual(recovered);
+    expect(cache.isDecoded("sun", recovered.url)).toBe(true);
+    expect(cache.getStale("sun")).toEqual(recovered);
+    expect(cache.inCooldown("sun")).toBe(false);
+  });
+
+  it("a custom recover() that also throws still arms backoff via the outer catch", async () => {
+    const resolver = new MockResolver(cache);
+    const bad = image("https://example.test/bad.jpg");
+    resolver.fetchCandidateUrlImpl = () => Promise.resolve(bad);
+    resolver.recoverImpl = () => Promise.reject(new Error("nothing left to try"));
+    stubImageDecode(new Set());
+    const debug = emptyDebugAccumulator();
+
+    await expect(resolver.resolve(debug, debug)).rejects.toThrow("nothing left to try");
+
+    expect(cache.inCooldown("sun")).toBe(true);
+  });
+
+  describe("cooldown", () => {
+    it("in cooldown with a confirmed image serves it, counts backoffs, and skips getCached/fetchCandidateUrl entirely", async () => {
+      const resolver = new MockResolver(cache);
+      const confirmed = image("https://example.test/confirmed.jpg");
+      resolver.fetchCandidateUrlImpl = () => Promise.resolve(confirmed);
+      stubImageDecode(new Set([confirmed.url]));
+      const seed = emptyDebugAccumulator();
+      await resolver.resolve(seed, seed); // establishes a confirmed image via recordSuccess
+
+      cache.recordFailure("sun"); // arms cooldown
+      resolver.getCachedResult = { url: "should-be-unreachable", date: new Date() };
+      resolver.fetchCandidateUrlImpl = () => Promise.reject(new Error("must not be called"));
+      const debug = emptyDebugAccumulator();
+
+      const result = await resolver.resolve(debug, debug);
+
+      expect(result).toEqual(confirmed);
+      expect(debug.backoffs).toBe(1);
+      expect(debug.cacheHits).toBe(0);
+      expect(debug.fetches).toBe(0);
+    });
+
+    it("in cooldown with nothing ever confirmed throws, without re-recording another failure", async () => {
+      const resolver = new MockResolver(cache);
+      cache.recordFailure("sun");
+      const failuresBefore = cache.inCooldown("sun");
+      const debug = emptyDebugAccumulator();
+
+      await expect(resolver.resolve(debug, debug)).rejects.toThrow(/cooldown/);
+
+      expect(debug.backoffs).toBe(1);
+      expect(failuresBefore).toBe(true); // cooldown was already armed going in, from the one recordFailure above
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Split `SourceResolver.resolve()` into named phases (cooldown/candidate/decode/commit), extracted `slot-search.ts` and `pad.ts` so sun's backward-search math and formatting are unit-testable without DOM/Image mocking, and pulled `PanelState` + `debugStats()` ownership out of `GalleryController` into their proper owners.
- Extracted `sunSlotProbe()` from `SdoSunResolver.recover()` so its NASA-specific hit/abort mapping is testable with a fake preload instead of `global.Image`/`decode()` stubbing.
- Moved `debug-view.ts`'s hardcoded per-row display flags (`hasCacheStep`, `canRetry`) into `DEBUG_ROW_SPECS` in `sources.ts`, the catalog that already owns every other per-row fact.

## Test plan
- [x] `npm run test:coverage` — 1187 passed, 100% coverage
- [x] `npm run check:ci` — typecheck + biome + prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)