### PR TITLE
fix: keep night sky tint chromatic so color-blend applies

### DIFF
--- a/src/card/viewing-location.ts
+++ b/src/card/viewing-location.ts
@@ -16,6 +16,12 @@ const SKY_ANCHORS: { elevDeg: number; rgb: readonly [number, number, number] }[]
   { elevDeg: -18, rgb: [0x2a, 0x1f, 0x42] }, // Astronomical Twilight
 ];
 
+// #177: mix-blend-mode: color (.gallery-thumb-tint) takes hue/saturation from this backdrop and
+// luminosity from the photo underneath — an achromatic (R===G===B) backdrop has no hue/saturation
+// to give, so it silently no-ops instead of darkening. Astronomical Twilight's own hue, scaled
+// near-black, keeps the plateau reading as "night" while staying chromatic enough to blend.
+const NIGHT_RGB: readonly [number, number, number] = [0x06, 0x05, 0x0a];
+
 function toHex(channel: number): string {
   return Math.round(channel).toString(16).padStart(2, "0");
 }
@@ -27,7 +33,7 @@ export function skyBackgroundForElevation(elevDeg: number): string {
   const first = SKY_ANCHORS[0];
   const last = SKY_ANCHORS[SKY_ANCHORS.length - 1];
   if (elevDeg >= first.elevDeg) return rgbToHex(first.rgb);
-  if (elevDeg < last.elevDeg) return "#000000";
+  if (elevDeg < last.elevDeg) return rgbToHex(NIGHT_RGB);
 
   for (let i = 0; i < SKY_ANCHORS.length - 1; i++) {
     const hi = SKY_ANCHORS[i];
@@ -41,7 +47,7 @@ export function skyBackgroundForElevation(elevDeg: number): string {
     }
   }
   /* v8 ignore next */
-  return "#000000";
+  return rgbToHex(NIGHT_RGB);
 }
 
 function rgbToHex(rgb: readonly [number, number, number]): string {

--- a/test/card/card.gallery.test.ts
+++ b/test/card/card.gallery.test.ts
@@ -257,7 +257,7 @@ describe("SolarViewCard gallery", () => {
       const nightCard = document.createElement("ha-planetary-solar-system-card-test");
       nightCard.setConfig(config);
       document.body.appendChild(nightCard);
-      expect(tintOf(nightCard)).toContain("background: #000000");
+      expect(tintOf(nightCard)).toContain("background: #06050a");
       nightCard.remove();
       vi.useRealTimers();
     });

--- a/test/card/viewing-location.test.ts
+++ b/test/card/viewing-location.test.ts
@@ -112,7 +112,7 @@ describe("ViewingLocation", () => {
       const location = new ViewingLocation();
       location.update(LONDON);
       expect(location.skyFrame(new Date("2026-06-21T12:00:00Z")).background).toBe("#d0d0d0");
-      expect(location.skyFrame(new Date("2026-12-21T00:00:00Z")).background).toBe("#000000");
+      expect(location.skyFrame(new Date("2026-12-21T00:00:00Z")).background).toBe("#06050a");
     });
 
     it("interpolates continuously across a twilight band rather than snapping", () => {
@@ -128,7 +128,18 @@ describe("ViewingLocation", () => {
       expect(skyBackgroundForElevation(-6)).toBe("#8a6142");
       expect(skyBackgroundForElevation(-12)).toBe("#3a4a6b");
       expect(skyBackgroundForElevation(-18)).toBe("#2a1f42");
-      expect(skyBackgroundForElevation(-30)).toBe("#000000");
+      expect(skyBackgroundForElevation(-30)).toBe("#06050a");
+    });
+
+    // #177: mix-blend-mode: color takes hue/saturation from the tint layer and no-ops on an
+    // achromatic (R === G === B) top layer, so a pure-black night anchor silently disabled the
+    // night tint. The plateau color below -18deg must carry some hue to actually blend.
+    it("keeps the night plateau chromatic so mix-blend-mode: color can still tint it", () => {
+      const night = skyBackgroundForElevation(-30);
+      const r = Number.parseInt(night.slice(1, 3), 16);
+      const g = Number.parseInt(night.slice(3, 5), 16);
+      const b = Number.parseInt(night.slice(5, 7), 16);
+      expect(new Set([r, g, b]).size).toBeGreaterThan(1);
     });
 
     it("reports the Moon below the horizon without treating it as a failure", () => {


### PR DESCRIPTION
## Summary
- `mix-blend-mode: color` (`.gallery-thumb-tint`) takes hue/saturation from the tint layer; pure `#000000` is achromatic, so the night plateau silently no-opped and never darkened the `mymoon` tile.
- Replaced the `#000000` night anchor with `NIGHT_RGB = [0x06, 0x05, 0x0a]`, a near-black scaled from the existing Astronomical Twilight hue — stays dark, still chromatic enough to blend.

Closes #177.

## Test plan
- [x] `npm run test:coverage` — 100% coverage, added a test asserting the night color isn't achromatic
- [x] `npm run check:ci`