### PR TITLE
docs: add mymoon tint design reference page

### DIFF
--- a/design-notes/mymoon-tint-model.html
+++ b/design-notes/mymoon-tint-model.html
@@ -1,0 +1,486 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Mymoon Tile Color</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,ital@9..144,300..700,0..1&family=Source+Serif+4:opsz,wght@8..60,400;8..60,600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+
+<style>
+  :root {
+    --paper: #eef0f4;
+    --paper-raised: #ffffff;
+    --ink: #1b1e2a;
+    --ink-soft: #5b6178;
+    --ink-faint: #8b90a6;
+    --line: #d3d7e1;
+    --accent: #b6602f;
+    --accent-soft: #e8c9ad;
+    --cool: #4f6fa8;
+    --warn-bg: #fbeee2;
+    --warn-line: #e3b98a;
+    --shadow: 0 1px 2px rgba(27,30,42,0.06), 0 8px 24px rgba(27,30,42,0.05);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --paper: #0f1117;
+      --paper-raised: #171a24;
+      --ink: #eceef4;
+      --ink-soft: #a8adc2;
+      --ink-faint: #6d7290;
+      --line: #2a2e3d;
+      --accent: #e08b52;
+      --accent-soft: #4a3628;
+      --cool: #8ca6da;
+      --warn-bg: #2e2318;
+      --warn-line: #6b4c2c;
+      --shadow: 0 1px 2px rgba(0,0,0,0.4), 0 12px 32px rgba(0,0,0,0.35);
+    }
+  }
+
+  :root[data-theme="dark"] {
+    --paper: #0f1117;
+    --paper-raised: #171a24;
+    --ink: #eceef4;
+    --ink-soft: #a8adc2;
+    --ink-faint: #6d7290;
+    --line: #2a2e3d;
+    --accent: #e08b52;
+    --accent-soft: #4a3628;
+    --cool: #8ca6da;
+    --warn-bg: #2e2318;
+    --warn-line: #6b4c2c;
+    --shadow: 0 1px 2px rgba(0,0,0,0.4), 0 12px 32px rgba(0,0,0,0.35);
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    background: var(--paper);
+    color: var(--ink);
+    font-family: "Source Serif 4", Georgia, "Times New Roman", serif;
+    font-size: 16px;
+    line-height: 1.6;
+    padding: 4.5rem 1.5rem 6rem;
+    -webkit-font-smoothing: antialiased;
+    margin: 0;
+  }
+
+  .page { max-width: 900px; margin: 0 auto; }
+
+  .mono { font-family: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace; font-variant-numeric: tabular-nums; }
+
+  .eyebrow {
+    font-family: "JetBrains Mono", monospace;
+    font-size: 0.72rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin: 0 0 0.9rem;
+  }
+
+  h1 {
+    font-family: "Fraunces", Georgia, serif;
+    font-weight: 600;
+    font-size: clamp(2.1rem, 5vw, 3rem);
+    line-height: 1.05;
+    letter-spacing: -0.01em;
+    margin: 0 0 1.1rem;
+    text-wrap: balance;
+    max-width: 18ch;
+  }
+
+  .lede { max-width: 62ch; color: var(--ink-soft); font-size: 1.1rem; margin: 0 0 3.5rem; }
+  .lede strong { color: var(--ink); font-weight: 600; }
+  .lede code { font-size: 0.85em; }
+
+  h2 {
+    font-family: "Fraunces", Georgia, serif;
+    font-weight: 600;
+    font-size: 1.5rem;
+    letter-spacing: -0.005em;
+    margin: 0 0 0.35rem;
+    text-wrap: balance;
+  }
+
+  section { margin-bottom: 4rem; }
+
+  .section-intro { color: var(--ink-soft); max-width: 60ch; margin: 0 0 1.75rem; }
+
+  code {
+    font-family: "JetBrains Mono", monospace;
+    font-size: 0.86em;
+    background: var(--paper-raised);
+    border: 1px solid var(--line);
+    padding: 0.1em 0.4em;
+    border-radius: 4px;
+  }
+
+  /* ---- mechanism strip ---- */
+
+  .mechanism {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.75rem;
+    background: var(--paper-raised);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    padding: 1.5rem;
+    box-shadow: var(--shadow);
+    align-items: center;
+  }
+  @media (max-width: 640px) { .mechanism { grid-template-columns: 1fr; } }
+
+  .mechanism .step { text-align: center; }
+  .mechanism .swatch {
+    width: 100%;
+    aspect-ratio: 1;
+    max-width: 96px;
+    margin: 0 auto 0.6rem;
+    border-radius: 50%;
+    position: relative;
+    overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.3);
+  }
+  .mechanism .step .cap {
+    font-family: "JetBrains Mono", monospace;
+    font-size: 0.72rem;
+    color: var(--ink-faint);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  .mechanism .plus, .mechanism .eq {
+    font-family: "Fraunces", serif;
+    font-size: 1.6rem;
+    color: var(--ink-faint);
+    text-align: center;
+    display: none;
+  }
+  @media (min-width: 641px) {
+    .mechanism { grid-template-columns: 1fr auto 1fr auto 1fr; }
+    .mechanism .plus, .mechanism .eq { display: block; }
+  }
+
+  .tint-layer { position: absolute; inset: 0; mix-blend-mode: color; }
+
+  /* ---- moon photo texture, shared everywhere ---- */
+
+  .moon-photo {
+    position: absolute; inset: 0;
+    background-color: #b9b9b4;
+    background-image:
+      radial-gradient(circle at 68% 62%, rgba(0,0,0,0.28) 0 5%, transparent 6%),
+      radial-gradient(circle at 40% 70%, rgba(0,0,0,0.22) 0 7%, transparent 8%),
+      radial-gradient(circle at 60% 30%, rgba(0,0,0,0.18) 0 4%, transparent 5%),
+      radial-gradient(circle at 25% 35%, rgba(0,0,0,0.15) 0 9%, transparent 10%),
+      radial-gradient(circle at 78% 22%, rgba(255,255,255,0.25) 0 10%, transparent 11%),
+      radial-gradient(circle at 30% 78%, rgba(0,0,0,0.12) 0 5%, transparent 6%),
+      radial-gradient(circle at 38% 32%, #cfcfc9, #97968f 55%, #6c6b64 100%);
+  }
+
+  /* ---- the matrix ---- */
+
+  .matrix-wrap {
+    overflow-x: auto;
+    background: var(--paper-raised);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    padding: 1.75rem;
+    box-shadow: var(--shadow);
+  }
+
+  .matrix {
+    display: grid;
+    grid-template-columns: 118px repeat(6, minmax(78px, 1fr));
+    gap: 6px;
+    min-width: 720px;
+  }
+
+  .matrix .col-head { text-align: center; padding-bottom: 0.4rem; }
+  .matrix .col-head .deg { font-family: "JetBrains Mono", monospace; font-size: 0.8rem; color: var(--ink); display: block; }
+  .matrix .col-head .lbl { font-size: 0.63rem; color: var(--ink-faint); text-transform: uppercase; letter-spacing: 0.04em; font-family: "JetBrains Mono", monospace; }
+  .matrix .col-head .strength { font-size: 0.64rem; color: var(--accent); font-family: "JetBrains Mono", monospace; }
+
+  .matrix .row-head { display: flex; flex-direction: column; justify-content: center; padding-right: 0.75rem; }
+  .matrix .row-head .lbl { font-family: "Fraunces", serif; font-weight: 600; font-size: 0.88rem; color: var(--ink); }
+  .matrix .row-head .deg { font-family: "JetBrains Mono", monospace; font-size: 0.7rem; color: var(--ink-faint); }
+
+  .cell {
+    aspect-ratio: 1;
+    border-radius: 50%;
+    position: relative;
+    overflow: hidden;
+    background: #000;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.35);
+  }
+
+  /* ---- falloff chart ---- */
+
+  .falloff {
+    display: grid;
+    grid-template-columns: 1.1fr 1fr;
+    gap: 2rem;
+    align-items: center;
+    background: var(--paper-raised);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    padding: 1.75rem;
+    box-shadow: var(--shadow);
+  }
+  @media (max-width: 640px) { .falloff { grid-template-columns: 1fr; } }
+
+  .falloff svg { width: 100%; height: auto; overflow: visible; }
+  .falloff .curve { fill: none; stroke: var(--accent); stroke-width: 2.5; stroke-linecap: round; stroke-linejoin: round; }
+  .falloff .axis-line { stroke: var(--line); stroke-width: 1; }
+  .falloff .axis-label { font-family: "JetBrains Mono", monospace; font-size: 8px; fill: var(--ink-faint); }
+  .falloff .fill { fill: var(--accent); opacity: 0.08; }
+
+  .falloff-text .formula {
+    font-family: "JetBrains Mono", monospace;
+    font-size: 0.85rem;
+    background: var(--paper);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 0.9rem 1rem;
+    margin: 0 0 1rem;
+    color: var(--ink);
+    line-height: 1.7;
+  }
+  .falloff-text .formula .fx { color: var(--ink-faint); }
+  .falloff-text .formula .op { color: var(--accent); }
+  .falloff-text p { color: var(--ink-soft); font-size: 0.92rem; margin: 0; }
+
+  /* ---- callout ---- */
+
+  .callout {
+    background: var(--warn-bg);
+    border: 1px solid var(--warn-line);
+    border-radius: 10px;
+    padding: 1.5rem 1.75rem;
+  }
+  .callout .eyebrow-sm {
+    font-family: "JetBrains Mono", monospace;
+    font-size: 0.68rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin: 0 0 0.5rem;
+  }
+  .callout p { margin: 0; color: var(--ink); font-size: 0.95rem; max-width: 64ch; }
+  .callout p + p { margin-top: 0.7rem; }
+  .callout code { background: var(--paper-raised); }
+
+  /* ---- pointer footer ---- */
+
+  .pointer {
+    border-top: 1px solid var(--line);
+    padding-top: 2rem;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 1.5rem;
+    align-items: start;
+  }
+  @media (max-width: 640px) { .pointer { grid-template-columns: 1fr; } }
+  .pointer .status {
+    font-family: "JetBrains Mono", monospace;
+    font-size: 0.68rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--cool);
+    white-space: nowrap;
+    padding-top: 0.2rem;
+  }
+  .pointer p { margin: 0 0 0.75rem; color: var(--ink-soft); font-size: 0.95rem; max-width: 62ch; }
+  .pointer p:last-child { margin-bottom: 0; }
+  .pointer strong { color: var(--ink); }
+</style>
+</head>
+<body>
+<div class="page">
+
+  <p class="eyebrow">the mymoon gallery tile — reference model</p>
+  <h1>What color should the Moon photo actually wear?</h1>
+  <p class="lede">
+    The <code>mymoon</code> tile washes a color over the real NASA photo with
+    <code>mix-blend-mode: color</code> — originally that overlay was driven only by <strong>Sun elevation</strong>.
+    A second, independent input belongs in the same wash: <strong>the Moon's own altitude</strong>, which
+    sets how much atmosphere its light crossed to reach the observer. This page renders the blend live,
+    the same CSS technique the card ships, across both — the exploration that shaped
+    <a href="https://github.com/marcintk/ha-planetary-solar-system-card/issues/177">#177</a> and
+    <a href="https://github.com/marcintk/ha-planetary-solar-system-card/issues/178">#178</a>, both now shipped.
+  </p>
+
+  <section>
+    <h2>How the wash is built</h2>
+    <p class="section-intro">Two color layers stack on the photo, each in <code>mix-blend-mode: color</code> — hue and saturation come from the layer, luminosity (the photo's own lit/dark shape) comes from underneath.</p>
+    <div class="mechanism">
+      <div class="step">
+        <div class="swatch"><div class="moon-photo"></div></div>
+        <div class="cap">photo</div>
+      </div>
+      <div class="plus">+</div>
+      <div class="step">
+        <div class="swatch">
+          <div class="moon-photo"></div>
+          <div class="tint-layer" style="background:#8a6142"></div>
+        </div>
+        <div class="cap">sky wash · sun elevation</div>
+      </div>
+      <div class="plus">+</div>
+      <div class="step">
+        <div class="swatch">
+          <div class="moon-photo"></div>
+          <div class="tint-layer" style="background:#8a6142"></div>
+          <div class="tint-layer" style="background:#b6602f; opacity:0.75"></div>
+        </div>
+        <div class="cap">extinction wash · moon altitude</div>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>The matrix, rendered live</h2>
+    <p class="section-intro">
+      Rows are the sky wash (<code>skyBackgroundForElevation()</code>, <code>viewing-location.ts</code>).
+      Columns are the extinction wash (<code>moonExtinctionTint()</code>, same file), strongest near the
+      horizon. Each disc below is the real blend — an actual grayscale photo texture with both
+      <code>mix-blend-mode: color</code> layers stacked on it, not a flat approximated swatch.
+    </p>
+    <div class="matrix-wrap">
+      <div class="matrix" id="matrix">
+        <div class="corner"></div>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Why the falloff is steep, not linear</h2>
+    <div class="falloff">
+      <svg viewBox="0 0 320 160" role="img" aria-label="Extinction strength drops sharply as altitude rises past about 20 degrees, and is nearly zero above 60 degrees">
+        <line class="axis-line" x1="20" y1="140" x2="300" y2="140"></line>
+        <line class="axis-line" x1="20" y1="20" x2="20" y2="140"></line>
+        <text class="axis-label" x="20" y="152">0°</text>
+        <text class="axis-label" x="292" y="152">90°</text>
+        <text class="axis-label" x="4" y="24">1.0</text>
+        <text class="axis-label" x="4" y="144">0</text>
+        <polygon class="fill" points="23.1,23.1 35.6,35.4 51.1,49.9 66.7,63.4 82.2,75.9 113.3,97.5 144.4,114.4 175.6,126.4 206.7,134.1 237.8,138.2 268.9,139.8 300,140 300,140 20,140"></polygon>
+        <polyline class="curve" points="23.1,23.1 35.6,35.4 51.1,49.9 66.7,63.4 82.2,75.9 113.3,97.5 144.4,114.4 175.6,126.4 206.7,134.1 237.8,138.2 268.9,139.8 300,140"></polyline>
+      </svg>
+      <div class="falloff-text">
+        <div class="formula">
+          <span class="fx">airmass</span> <span class="op">≈</span> 1 / sin(altitude)<br>
+          <span class="fx">strength</span> <span class="op">=</span> clamp(1 − sin(altitude), 0, 1) <span class="op">^</span> 1.5
+        </div>
+        <p>
+          Airmass — how much atmosphere a sightline crosses — is steep near the horizon and flat above
+          roughly 30°. A linear fade reads as "a bit orange everywhere"; this curve keeps the wash
+          concentrated where extinction actually happens and leaves anything above ~60° essentially bare.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <div class="callout">
+      <p class="eyebrow-sm">a real limitation, found and fixed (#177)</p>
+      <p>
+        <code>mix-blend-mode: color</code> takes hue and saturation from the top layer — an <strong>achromatic</strong>
+        color (no hue, no saturation) passes straight through untouched. The original Night anchor was
+        <code>#000000</code>, which is achromatic, so the sky wash silently no-opped at night instead of
+        darkening the <code>mymoon</code> photo. Fixed by swapping the anchor for a near-black color that
+        keeps Astronomical Twilight's own hue (<code>NIGHT_RGB</code> in <code>viewing-location.ts</code>) —
+        dark enough to still read as night, chromatic enough to actually blend.
+      </p>
+      <p>
+        The extinction wash added in #178 inherits the lesson: its hue
+        (<code>MOON_EXTINCTION_RGB = rgb(255, 102, 26)</code>) is deliberately saturated so it stays chromatic
+        across its whole strength range, and its strength is carried as the tint layer's own alpha
+        (an <code>rgba()</code> string) rather than a second color to mix by hand.
+      </p>
+    </div>
+  </section>
+
+  <div class="pointer">
+    <span class="status">shipped</span>
+    <div>
+      <p>
+        <strong>Sky wash needed no change in shape</strong> — <code>card.ts</code>'s
+        <code>.gallery-thumb-tint</code>, painted from <code>skyBackgroundForElevation(sunElevDeg)</code>,
+        stayed the base layer; only its night-anchor color changed (#177).
+      </p>
+      <p>
+        <strong>Moon altitude was already computed and unused</strong> — <code>getMoonSkyAngles()</code>
+        returns <code>altitudeDeg</code> in <code>viewing-location.ts</code>, previously spent only on the
+        <code>belowHorizon</code> show/hide check. <code>moonExtinctionTint(altitudeDeg)</code> now reads it
+        into a second tint div on both the gallery thumbnail and the full-screen panel (#178).
+      </p>
+    </div>
+  </div>
+
+</div>
+
+<script>
+  (function () {
+    var cols = [
+      { alt: 2,  s: 0.948 },
+      { alt: 8,  s: 0.799 },
+      { alt: 18, s: 0.574 },
+      { alt: 35, s: 0.279 },
+      { alt: 60, s: 0.049 },
+      { alt: 85, s: 0.001 }
+    ];
+    var extinction = "#b6602f";
+    var rows = [
+      { label: "Day", deg: "0°", sky: "#d0d0d0" },
+      { label: "Civil twilight", deg: "−6°", sky: "#8a6142" },
+      { label: "Nautical twilight", deg: "−12°", sky: "#3a4a6b" },
+      { label: "Astronomical twilight", deg: "−18°", sky: "#2a1f42" },
+      { label: "Night", deg: "−25°", sky: "#06050a" }
+    ];
+
+    var matrix = document.getElementById("matrix");
+
+    cols.forEach(function (col) {
+      var head = document.createElement("div");
+      head.className = "col-head";
+      head.innerHTML = '<span class="deg">' + col.alt + '°</span><span class="lbl">moon alt</span><span class="strength">s=' + col.s.toFixed(2) + '</span>';
+      matrix.appendChild(head);
+    });
+
+    rows.forEach(function (row) {
+      var rowHead = document.createElement("div");
+      rowHead.className = "row-head";
+      rowHead.innerHTML = '<span class="lbl">' + row.label + '</span><span class="deg">' + row.deg + ' sun</span>';
+      matrix.appendChild(rowHead);
+
+      cols.forEach(function (col) {
+        var cell = document.createElement("div");
+        cell.className = "cell";
+        cell.title = row.label + " sky, Moon at " + col.alt + "° altitude — extinction strength " + col.s.toFixed(2);
+
+        var photo = document.createElement("div");
+        photo.className = "moon-photo";
+        cell.appendChild(photo);
+
+        var skyTint = document.createElement("div");
+        skyTint.className = "tint-layer";
+        skyTint.style.background = row.sky;
+        cell.appendChild(skyTint);
+
+        var extTint = document.createElement("div");
+        extTint.className = "tint-layer";
+        extTint.style.background = extinction;
+        extTint.style.opacity = String(col.s);
+        cell.appendChild(extTint);
+
+        matrix.appendChild(cell);
+      });
+    });
+  })();
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds `design-notes/mymoon-tint-model.html`, a standalone rendered reference page for the `mymoon` tile's `mix-blend-mode: color` tint mechanism.
- Captures the sun-elevation x moon-altitude matrix, the extinction falloff formula, and the achromatic-blend pitfall found while researching #177/#178 (both now shipped).
- Docs-only; no source changes.