### PR TITLE
docs: add design-notes index with a rendered-view link

### DIFF
--- a/design-notes/README.md
+++ b/design-notes/README.md
@@ -1,0 +1,13 @@
+# Design notes
+
+Standalone, self-contained HTML reference pages — rendered explorations of a design or
+implementation question, kept for future reference. Not ADRs (no decision log), not user-facing docs
+(that's `docs/`, published via GitHub Pages).
+
+GitHub only shows `.html` files as source, not rendered — click a link below to view instead.
+
+- [Mymoon tile color](https://htmlpreview.github.io/?https://raw.githubusercontent.com/marcintk/ha-planetary-solar-system-card/main/design-notes/mymoon-tint-model.html)
+  — the `mix-blend-mode: color` tint mechanism behind the `mymoon` gallery tile: the sun-elevation ×
+  moon-altitude matrix, the extinction falloff formula, and the achromatic-blend pitfall found while
+  researching
+  [#177](https://github.com/marcintk/ha-planetary-solar-system-card/issues/177)/[#178](https://github.com/marcintk/ha-planetary-solar-system-card/issues/178).


### PR DESCRIPTION
## Summary
- Adds `design-notes/README.md` so GitHub's folder view surfaces a working link to the mymoon tint page — GitHub renders `.html` as source, not live, so a plain repo browse can't otherwise see it.
- Links through htmlpreview.github.io for a rendered view without cloning.