### PR TITLE
docs: replace ad hoc extinction curve with airmass physics

### DIFF
--- a/design-notes/mymoon-tint-model.html
+++ b/design-notes/mymoon-tint-model.html
@@ -466,25 +466,30 @@
   <section>
     <h2>Why the falloff is steep, not linear</h2>
     <div class="falloff">
-      <svg viewBox="0 0 320 160" role="img" aria-label="Extinction strength drops sharply as altitude rises past about 20 degrees, and is nearly zero above 60 degrees">
+      <svg viewBox="0 0 320 160" role="img" aria-label="Extinction strength drops sharply as altitude rises past about 10 degrees, and is nearly zero above 40 degrees">
         <line class="axis-line" x1="20" y1="140" x2="300" y2="140"></line>
         <line class="axis-line" x1="20" y1="20" x2="20" y2="140"></line>
         <text class="axis-label" x="20" y="152">0°</text>
         <text class="axis-label" x="292" y="152">90°</text>
         <text class="axis-label" x="4" y="24">1.0</text>
         <text class="axis-label" x="4" y="144">0</text>
-        <polygon class="fill" points="23.1,23.1 35.6,35.4 51.1,49.9 66.7,63.4 82.2,75.9 113.3,97.5 144.4,114.4 175.6,126.4 206.7,134.1 237.8,138.2 268.9,139.8 300,140 300,140 20,140"></polygon>
-        <polyline class="curve" points="23.1,23.1 35.6,35.4 51.1,49.9 66.7,63.4 82.2,75.9 113.3,97.5 144.4,114.4 175.6,126.4 206.7,134.1 237.8,138.2 268.9,139.8 300,140"></polyline>
+        <polygon class="fill" points="23.1,22.7 35.6,49.7 51.1,80.3 66.7,98.7 82.2,110.2 113.3,123.4 144.4,130.4 175.6,134.6 206.7,137.3 237.8,138.9 268.9,139.7 300,140 300,140 20,140"></polygon>
+        <polyline class="curve" points="23.1,22.7 35.6,49.7 51.1,80.3 66.7,98.7 82.2,110.2 113.3,123.4 144.4,130.4 175.6,134.6 206.7,137.3 237.8,138.9 268.9,139.7 300,140"></polyline>
       </svg>
       <div class="falloff-text">
         <div class="formula">
-          <span class="fx">airmass</span> <span class="op">≈</span> 1 / sin(altitude)<br>
-          <span class="fx">strength</span> <span class="op">=</span> clamp(1 − sin(altitude), 0, 1) <span class="op">^</span> 1.5
+          <span class="fx">airmass</span> <span class="op">=</span> 1 / (sin(alt) + 0.50572·(alt+6.08)<span class="op">^</span>−1.6364)<br>
+          <span class="fx">strength</span> <span class="op">=</span> 1 − e<span class="op">^</span>(−0.15·(airmass − 1))
         </div>
         <p>
-          Airmass — how much atmosphere a sightline crosses — is steep near the horizon and flat above
-          roughly 30°. A linear fade reads as "a bit orange everywhere"; this curve keeps the wash
-          concentrated where extinction actually happens and leaves anything above ~60° essentially bare.
+          Kasten &amp; Young's airmass formula (1989) — steep near the horizon, flat above roughly 20°,
+          and finite even at the horizon itself (unlike the naive <code>1/sin(altitude)</code>, which
+          diverges to infinity there). 0.15 is a representative differential-extinction coefficient
+          (mag/airmass, standard photometric tables) — the gap between how much the atmosphere dims
+          blue versus red light, which is what actually produces the reddening. An earlier version of
+          this page used a bare <code>(1 − sin(altitude))^1.5</code> power law calibrated by eye; it
+          gave a real, well-up Moon at 22° an alpha of 0.49 — roughly half strength, when a Moon that
+          high actually looks close to white. This curve fixes that.
         </p>
       </div>
     </div>
@@ -604,9 +609,19 @@
       return rgbToHex(NIGHT_RGB);
     }
 
+    // Kasten & Young 1989 — airmass, finite at the horizon (unlike the naive secant 1/sin,
+    // which diverges to infinity there).
+    function airmass(altitudeDeg) {
+      var a = Math.max(altitudeDeg, 0);
+      return 1 / (Math.sin(a * DEG) + 0.50572 * Math.pow(a + 6.07995, -1.6364));
+    }
+    var DIFFERENTIAL_EXTINCTION_COEFFICIENT = 0.15; // representative mag/airmass, standard tables
+
     function moonExtinctionTint(altitudeDeg) {
-      var strength = Math.max(0, Math.min(1, 1 - Math.sin(altitudeDeg * DEG)));
-      strength = Math.pow(strength, 1.5);
+      var strength = Math.max(
+        0,
+        Math.min(1, 1 - Math.exp(-DIFFERENTIAL_EXTINCTION_COEFFICIENT * (airmass(altitudeDeg) - 1)))
+      );
       var rgb = MOON_EXTINCTION_RGB;
       return "rgba(" + rgb[0] + ", " + rgb[1] + ", " + rgb[2] + ", " + strength.toFixed(2) + ")";
     }
@@ -767,11 +782,11 @@
 
   (function () {
     var cols = [
-      { alt: 2,  s: 0.948 },
-      { alt: 8,  s: 0.799 },
-      { alt: 18, s: 0.574 },
-      { alt: 35, s: 0.279 },
-      { alt: 60, s: 0.049 },
+      { alt: 2,  s: 0.937 },
+      { alt: 8,  s: 0.585 },
+      { alt: 18, s: 0.282 },
+      { alt: 35, s: 0.105 },
+      { alt: 60, s: 0.023 },
       { alt: 85, s: 0.001 }
     ];
     var extinction = "#b6602f";


### PR DESCRIPTION
## Summary
- Real-world use of the shipped card surfaced that `(1-sin(altitude))^1.5` (a curve calibrated by eye against two sample altitudes) gave a real, well-up Moon at 22deg an alpha of 0.49 — roughly half strength, when a Moon that high actually reads as close to white.
- Replaces it with a physically grounded curve: airmass via Kasten & Young (1989, finite at the horizon, unlike the naive `1/sin`), strength as `1 - exp(-k*(airmass-1))` with a representative differential-extinction coefficient (~0.15 mag/airmass, standard photometric tables).
- Ports this page's inline copy of the formula, matrix numbers, and falloff chart to match — this doc mirrors the same fix landing in `viewing-location.ts` as part of #178.