### PR TITLE
feat: fade moon extinction tint by sky brightness

### DIFF
--- a/design-notes/README.md
+++ b/design-notes/README.md
@@ -8,6 +8,7 @@ GitHub only shows `.html` files as source, not rendered — click a link below t
 
 - [Mymoon tile color](https://htmlpreview.github.io/?https://raw.githubusercontent.com/marcintk/ha-planetary-solar-system-card/main/design-notes/mymoon-tint-model.html)
   — the `mix-blend-mode: color` tint mechanism behind the `mymoon` gallery tile: the sun-elevation ×
-  moon-altitude matrix, the extinction falloff formula, and the achromatic-blend pitfall found while
-  researching
+  moon-altitude matrix, the extinction falloff formula, the contrast-fade coupling that lets a
+  bright sky wash out the extinction tint (toggleable on the page to compare with/without), and the
+  achromatic-blend pitfall found while researching
   [#177](https://github.com/marcintk/ha-planetary-solar-system-card/issues/177)/[#178](https://github.com/marcintk/ha-planetary-solar-system-card/issues/178).

--- a/design-notes/mymoon-tint-model.html
+++ b/design-notes/mymoon-tint-model.html
@@ -93,7 +93,7 @@
     max-width: 18ch;
   }
 
-  .lede { max-width: 62ch; color: var(--ink-soft); font-size: 1.1rem; margin: 0 0 3.5rem; }
+  .lede { max-width: 100%; color: var(--ink-soft); font-size: 1.1rem; margin: 0 0 3.5rem; }
   .lede strong { color: var(--ink); font-weight: 600; }
   .lede code { font-size: 0.85em; }
 
@@ -108,7 +108,7 @@
 
   section { margin-bottom: 4rem; }
 
-  .section-intro { color: var(--ink-soft); max-width: 60ch; margin: 0 0 1.75rem; }
+  .section-intro { color: var(--ink-soft); max-width: 100%; margin: 0 0 1.75rem; }
 
   code {
     font-family: "JetBrains Mono", monospace;
@@ -309,6 +309,40 @@
     width: 100%;
   }
   .control-row { display: grid; grid-template-columns: 1fr 1fr; gap: 0.75rem; }
+  .toggle-control {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    margin-top: 1.2rem;
+    padding: 0.9rem 1rem;
+    background: var(--paper-raised);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+  }
+  .toggle-control label {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    font-family: "JetBrains Mono", monospace;
+    font-size: 0.82rem;
+    color: var(--ink);
+    cursor: pointer;
+  }
+  .toggle-control input[type="checkbox"] { accent-color: var(--accent); width: 1rem; height: 1rem; }
+  .toggle-control .control-hint {
+    font-family: "Source Serif 4", serif;
+    font-size: 0.86rem;
+    color: var(--ink-soft);
+    line-height: 1.5;
+  }
+  .matrix-toggles {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+    margin-top: 1.5rem;
+  }
+  .matrix-toggles .toggle-control { margin-top: 0; }
+  @media (max-width: 640px) { .matrix-toggles { grid-template-columns: 1fr; } }
   .presets { display: flex; flex-wrap: wrap; gap: 0.4rem; }
   .presets button {
     font-family: "JetBrains Mono", monospace;
@@ -344,7 +378,7 @@
     color: var(--accent);
     margin: 0 0 0.5rem;
   }
-  .callout p { margin: 0; color: var(--ink); font-size: 0.95rem; max-width: 64ch; }
+  .callout p { margin: 0; color: var(--ink); font-size: 0.95rem; max-width: 100%; }
   .callout p + p { margin-top: 0.7rem; }
   .callout code { background: var(--paper-raised); }
 
@@ -368,7 +402,7 @@
     white-space: nowrap;
     padding-top: 0.2rem;
   }
-  .pointer p { margin: 0 0 0.75rem; color: var(--ink-soft); font-size: 0.95rem; max-width: 62ch; }
+  .pointer p { margin: 0 0 0.75rem; color: var(--ink-soft); font-size: 0.95rem; max-width: 100%; }
   .pointer p:last-child { margin-bottom: 0; }
   .pointer strong { color: var(--ink); }
 </style>
@@ -452,13 +486,36 @@
     <h2>The matrix, rendered live</h2>
     <p class="section-intro">
       Rows are the sky wash (<code>skyBackgroundForElevation()</code>, <code>viewing-location.ts</code>).
-      Columns are the extinction wash (<code>moonExtinctionTint()</code>, same file), strongest near the
-      horizon. Each disc below is the real blend — an actual grayscale photo texture with both
-      <code>mix-blend-mode: color</code> layers stacked on it, not a flat approximated swatch.
+      Columns are the Moon's altitude, strongest near the horizon — but the extinction wash
+      (<code>moonExtinctionTint()</code>, same file) is no longer purely column-driven: with contrast
+      fade on, the same column washes weaker in the brighter rows near the top than the darker rows
+      near the bottom (hover a disc for its exact strength). Each disc below is the real blend — an
+      actual grayscale photo texture with both <code>mix-blend-mode: color</code> layers stacked on
+      it, not a flat approximated swatch.
     </p>
     <div class="matrix-wrap">
       <div class="matrix" id="matrix">
         <div class="corner"></div>
+      </div>
+    </div>
+    <div class="matrix-toggles">
+      <div class="toggle-control">
+        <label for="moon-altitude-toggle">
+          <input type="checkbox" id="moon-altitude-toggle" checked>
+          Apply Moon-altitude extinction
+        </label>
+        <span class="control-hint">The airmass curve above — uncheck to remove the extinction
+          overlay entirely, leaving only the sky-wash layer (pure sun-elevation color, no Moon
+          input at all). Contrast fade has nothing left to fade once this is off.</span>
+      </div>
+      <div class="toggle-control">
+        <label for="contrast-fade-toggle">
+          <input type="checkbox" id="contrast-fade-toggle" checked>
+          Apply sky-brightness contrast fade
+        </label>
+        <span class="control-hint">See "Why a bright sky fades the tint too" below —
+          uncheck to see the Moon's tint as pure altitude-only extinction, ignoring how bright
+          the sky behind it is.</span>
       </div>
     </div>
   </section>
@@ -494,8 +551,42 @@
           much harder while keeping the same near-total saturation right at the horizon. The exponent
           is a perceptual calibration knob, not a cited constant the way the airmass formula is.
         </p>
+        <p>
+          "Apply Moon-altitude extinction" below the matrix toggles this whole curve off — the
+          extinction overlay disappears, leaving only the sky-wash layer's own sun-elevation
+          color, so the Moon still visibly differs across sun elevations even with no altitude
+          term at all.
+        </p>
       </div>
     </div>
+  </section>
+
+  <section>
+    <h2>Why a bright sky fades the tint too</h2>
+    <p class="section-intro">
+      The formula above gives the Moon's <em>true</em> extinction color — unaffected by the Sun,
+      since the reddening happens along the sightline to the Moon, not to the Sun. But how strongly
+      that true tint <em>reads</em> to an observer isn't independent of the Sun: a bright sky floods
+      the same sightline with scattered light (veiling luminance), and simultaneous contrast further
+      desaturates a tinted disc seen against a bright field — the same reason a red filter looks
+      vivid held against a dark wall and washed-out against a white one. Neither effect changes the
+      Moon's true color, both just fade how much of it survives to the eye — which is why this
+      multiplies the strength computed above rather than feeding into the airmass curve itself.
+    </p>
+    <div class="formula">
+      <span class="fx">brightness</span> <span class="op">=</span> (luma(sky) − luma(night)) / (luma(day) − luma(night)), clamped 0–1<br>
+      <span class="fx">visible strength</span> <span class="op">=</span> strength · (1 − brightness)
+    </div>
+    <p>
+      Reuses the same day/night luma extremes the sky wash itself renders, rather than a second
+      calibrated curve — the two washes should agree on what "day" and "night" brightness mean.
+      Linear in luma is a deliberately simple choice, a calibration knob like the exponent above, not
+      a photometrically derived one.
+    </p>
+    <p class="section-intro">
+      Toggle it live below the matrix — it's wired into every live demo on this page, so flip it
+      there and watch the playground, matrix, and real-date lookup all update together.
+    </p>
   </section>
 
   <section>
@@ -620,12 +711,40 @@
     }
     var EXTINCTION_RAMP_COEFFICIENT = 0.004; // perceptual calibration, not a cited constant
 
-    function moonExtinctionTint(altitudeDeg) {
+    // Both toggled from the controls below the matrix; every live demo on the page reads them
+    // through these two flags.
+    var moonAltitudeEnabled = true;
+    var contrastFadeEnabled = true;
+
+    function luma(rgb) { return 0.299 * rgb[0] + 0.587 * rgb[1] + 0.114 * rgb[2]; }
+    function hexToRgb(hex) {
+      return [
+        parseInt(hex.slice(1, 3), 16),
+        parseInt(hex.slice(3, 5), 16),
+        parseInt(hex.slice(5, 7), 16),
+      ];
+    }
+    var DAY_LUMA = luma(SKY_ANCHORS[0].rgb);
+    var NIGHT_LUMA = luma(NIGHT_RGB);
+    function skyBrightnessFraction(sunElevDeg) {
+      var currentLuma = luma(hexToRgb(skyBackgroundForElevation(sunElevDeg)));
+      return Math.max(0, Math.min(1, (currentLuma - NIGHT_LUMA) / (DAY_LUMA - NIGHT_LUMA)));
+    }
+
+    function extinctionStrength(altitudeDeg, sunElevDeg) {
+      // Off means no altitude-driven extinction at all (0), not "assume the worst" (1) — the
+      // extinction tint-layer sits on top of the sky-wash layer in mix-blend-mode: color, so a
+      // fully opaque top layer masks the sky wash's own hue completely. Defaulting to 1 here
+      // painted every disc the same opaque orange regardless of sun elevation, hiding the very
+      // sun-driven variation "just sun altitude" is supposed to show.
+      if (!moonAltitudeEnabled) return 0;
       var excess = airmass(altitudeDeg) - 1;
-      var strength = Math.max(
-        0,
-        Math.min(1, 1 - Math.exp(-EXTINCTION_RAMP_COEFFICIENT * excess * excess))
-      );
+      var raw = Math.max(0, Math.min(1, 1 - Math.exp(-EXTINCTION_RAMP_COEFFICIENT * excess * excess)));
+      return contrastFadeEnabled ? raw * (1 - skyBrightnessFraction(sunElevDeg)) : raw;
+    }
+
+    function moonExtinctionTint(altitudeDeg, sunElevDeg) {
+      var strength = extinctionStrength(altitudeDeg, sunElevDeg);
       var rgb = MOON_EXTINCTION_RGB;
       return "rgba(" + rgb[0] + ", " + rgb[1] + ", " + rgb[2] + ", " + strength.toFixed(2) + ")";
     }
@@ -723,7 +842,7 @@
     // ---- wire the two live disc previews ----
     function paint(swatchPrefix, sunElevDeg, moonAltDeg) {
       var sky = skyBackgroundForElevation(sunElevDeg);
-      var ext = moonExtinctionTint(moonAltDeg);
+      var ext = moonExtinctionTint(moonAltDeg, sunElevDeg);
       document.getElementById(swatchPrefix + "-sky-tint").style.background = sky;
       document.getElementById(swatchPrefix + "-ext-tint").style.background = ext;
       return { sky: sky, ext: ext };
@@ -780,66 +899,88 @@
       });
     });
 
+    // ---- the matrix: cols are Moon altitude, rows are Sun elevation (as the same anchors the
+    // sky wash uses), each cell's extinction wash computed live — not a hardcoded strength per
+    // column, since contrast fade means the same Moon altitude no longer washes the same across
+    // every row. ----
+    var MATRIX_COLS = [2, 8, 18, 35, 60, 85];
+    var MATRIX_ROWS = [
+      { label: "Day", deg: "0°", elevDeg: 0 },
+      { label: "Civil twilight", deg: "−6°", elevDeg: -6 },
+      { label: "Nautical twilight", deg: "−12°", elevDeg: -12 },
+      { label: "Astronomical twilight", deg: "−18°", elevDeg: -18 },
+      { label: "Night", deg: "−25°", elevDeg: -25 },
+    ];
+    var matrixEl = document.getElementById("matrix");
+
+    function buildMatrix() {
+      matrixEl.innerHTML = "";
+      var corner = document.createElement("div");
+      corner.className = "corner";
+      matrixEl.appendChild(corner);
+
+      MATRIX_COLS.forEach(function (altDeg) {
+        var head = document.createElement("div");
+        head.className = "col-head";
+        head.innerHTML = '<span class="deg">' + altDeg + '°</span><span class="lbl">moon alt</span>';
+        matrixEl.appendChild(head);
+      });
+
+      MATRIX_ROWS.forEach(function (row) {
+        var rowHead = document.createElement("div");
+        rowHead.className = "row-head";
+        rowHead.innerHTML = '<span class="lbl">' + row.label + '</span><span class="deg">' + row.deg + ' sun</span>';
+        matrixEl.appendChild(rowHead);
+
+        var sky = skyBackgroundForElevation(row.elevDeg);
+
+        MATRIX_COLS.forEach(function (altDeg) {
+          var s = extinctionStrength(altDeg, row.elevDeg);
+          var cell = document.createElement("div");
+          cell.className = "cell";
+          cell.title = row.label + " sky, Moon at " + altDeg + "° altitude — extinction strength " + s.toFixed(2);
+
+          var photo = document.createElement("div");
+          photo.className = "moon-photo";
+          cell.appendChild(photo);
+
+          var skyTint = document.createElement("div");
+          skyTint.className = "tint-layer";
+          skyTint.style.background = sky;
+          cell.appendChild(skyTint);
+
+          var extTint = document.createElement("div");
+          extTint.className = "tint-layer";
+          extTint.style.background = rgbToHex(MOON_EXTINCTION_RGB);
+          extTint.style.opacity = String(s);
+          cell.appendChild(extTint);
+
+          matrixEl.appendChild(cell);
+        });
+      });
+    }
+
+    function refreshAllDemos() {
+      updatePlayground();
+      updateRealTime();
+      buildMatrix();
+    }
+
+    var moonAltitudeToggle = document.getElementById("moon-altitude-toggle");
+    moonAltitudeToggle.addEventListener("change", function () {
+      moonAltitudeEnabled = moonAltitudeToggle.checked;
+      refreshAllDemos();
+    });
+
+    var contrastFadeToggle = document.getElementById("contrast-fade-toggle");
+    contrastFadeToggle.addEventListener("change", function () {
+      contrastFadeEnabled = contrastFadeToggle.checked;
+      refreshAllDemos();
+    });
+
     setWhenToNowUTC();
     updateRealTime();
-  })();
-
-  (function () {
-    var cols = [
-      { alt: 2,  s: 0.743 },
-      { alt: 8,  s: 0.128 },
-      { alt: 18, s: 0.019 },
-      { alt: 35, s: 0.002 },
-      { alt: 60, s: 0.000 },
-      { alt: 85, s: 0.001 }
-    ];
-    var extinction = "#b6602f";
-    var rows = [
-      { label: "Day", deg: "0°", sky: "#d0d0d0" },
-      { label: "Civil twilight", deg: "−6°", sky: "#8a6142" },
-      { label: "Nautical twilight", deg: "−12°", sky: "#3a4a6b" },
-      { label: "Astronomical twilight", deg: "−18°", sky: "#2a1f42" },
-      { label: "Night", deg: "−25°", sky: "#06050a" }
-    ];
-
-    var matrix = document.getElementById("matrix");
-
-    cols.forEach(function (col) {
-      var head = document.createElement("div");
-      head.className = "col-head";
-      head.innerHTML = '<span class="deg">' + col.alt + '°</span><span class="lbl">moon alt</span><span class="strength">s=' + col.s.toFixed(2) + '</span>';
-      matrix.appendChild(head);
-    });
-
-    rows.forEach(function (row) {
-      var rowHead = document.createElement("div");
-      rowHead.className = "row-head";
-      rowHead.innerHTML = '<span class="lbl">' + row.label + '</span><span class="deg">' + row.deg + ' sun</span>';
-      matrix.appendChild(rowHead);
-
-      cols.forEach(function (col) {
-        var cell = document.createElement("div");
-        cell.className = "cell";
-        cell.title = row.label + " sky, Moon at " + col.alt + "° altitude — extinction strength " + col.s.toFixed(2);
-
-        var photo = document.createElement("div");
-        photo.className = "moon-photo";
-        cell.appendChild(photo);
-
-        var skyTint = document.createElement("div");
-        skyTint.className = "tint-layer";
-        skyTint.style.background = row.sky;
-        cell.appendChild(skyTint);
-
-        var extTint = document.createElement("div");
-        extTint.className = "tint-layer";
-        extTint.style.background = extinction;
-        extTint.style.opacity = String(col.s);
-        cell.appendChild(extTint);
-
-        matrix.appendChild(cell);
-      });
-    });
+    buildMatrix();
   })();
 </script>
 

--- a/src/card/card-styles.ts
+++ b/src/card/card-styles.ts
@@ -107,6 +107,19 @@ export const cardStyles = css`
     cursor: pointer;
     display: block;
   }
+  /* #178: the Moon's own altitude-extinction tint, mirroring .gallery-thumb-tint's mix-blend-mode
+     trick but sized to the whole square frame rather than clipped to a disc — the panel image has
+     no circle crop to match (see discStyle()). Usually near-zero strength (see
+     moonExtinctionTint()), so covering the full square doesn't read as a wash the way the
+     day/twilight/night sky color would. */
+  .image-view-tint {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    mix-blend-mode: color;
+    pointer-events: none;
+  }
   /* Stands in for the image, in the tile and in the full-screen panel alike: fills whichever
      box it lands in and centres on both axes, so one rule serves a 104px thumbnail and a
      full-width panel without either needing to know about the other. */

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -192,15 +192,23 @@ export class SolarViewCard extends LitElement {
               panelSky?.belowHorizon
                 ? noMoonSky(this._onImageClick)
                 : html`<img
-                    id="image-view"
-                    class="image-view"
-                    style=${this._panelImageStyle(panelSky)}
-                    src=${gallery.imageUrl ? fullSizeMoonUrl(gallery.imageUrl) : nothing}
-                    alt=""
-                    @click=${this._onImageClick}
-                    @load=${this._onImageLoad}
-                    @error=${this._onImageLoadError}
-                  />`
+                      id="image-view"
+                      class="image-view"
+                      style=${this._panelImageStyle(panelSky)}
+                      src=${gallery.imageUrl ? fullSizeMoonUrl(gallery.imageUrl) : nothing}
+                      alt=""
+                      @click=${this._onImageClick}
+                      @load=${this._onImageLoad}
+                      @error=${this._onImageLoadError}
+                    />
+                    ${
+                      panelSky
+                        ? html`<div
+                            class="image-view-tint"
+                            style=${`background: ${panelSky.extinction}`}
+                          ></div>`
+                        : nothing
+                    }`
             }
           </div>
           ${
@@ -320,9 +328,13 @@ export class SolarViewCard extends LitElement {
             ${
               sky
                 ? html`<div
-                  class="gallery-thumb-tint"
-                  style=${`${discStyleValue}; background: ${sky.background}`}
-                ></div>`
+                    class="gallery-thumb-tint"
+                    style=${`${discStyleValue}; background: ${sky.background}`}
+                  ></div>
+                  <div
+                    class="gallery-thumb-tint"
+                    style=${`${discStyleValue}; background: ${sky.extinction}`}
+                  ></div>`
                 : nothing
             }`
       }
@@ -339,10 +351,12 @@ export class SolarViewCard extends LitElement {
    * square like every other source's, unlike the thumbnail (which always circle-crops, see
    * discStyle()); only the rotated image inside it, not the frame's own shape, follows the
    * observer's orientation. Its own background is plain black (card-styles.ts), same as every
-   * other panel — unlike the thumbnail, the sky tint doesn't extend here: the corners a rotated
-   * square swings away from are a much larger share of a full-screen frame than of a 104px
-   * tile, and a colored fill across that much of the screen reads as a wash over the view
-   * rather than a detail on a photo.
+   * other panel — unlike the thumbnail, the day/twilight/night sky wash doesn't extend here: the
+   * corners a rotated square swings away from are a much larger share of a full-screen frame than
+   * of a 104px tile, and a colored fill across that much of the screen reads as a wash over the
+   * view rather than a detail on a photo. The Moon's own altitude-extinction tint (#178,
+   * .image-view-tint) is added anyway despite that: it's usually near-zero strength and only
+   * strong close to the horizon, so it doesn't carry the same "wash over the whole view" risk.
    */
   private _panelFrameStyle(): string | typeof nothing {
     return this._heightStyle || nothing;

--- a/src/card/viewing-location.ts
+++ b/src/card/viewing-location.ts
@@ -54,6 +54,96 @@ function rgbToHex(rgb: readonly [number, number, number]): string {
   return `#${toHex(rgb[0])}${toHex(rgb[1])}${toHex(rgb[2])}`;
 }
 
+// #178: a rising/setting Moon looks orange/red from crossing more atmosphere near the horizon
+// (extinction) — a different phenomenon from twilight color: the tint itself is driven by the
+// Moon's own altitude, not the Sun's, and composes with skyBackgroundForElevation as a second
+// overlay rather than replacing it. Its visible *strength* isn't fully independent of the Sun
+// though — see the contrast-fade comment below moonExtinctionTint's ramp coefficient.
+const MOON_EXTINCTION_RGB: readonly [number, number, number] = [0xff, 0x66, 0x1a];
+
+// A first version of this used `(1 - sin(altitude))^1.5`, calibrated only by eye against two
+// sample altitudes — it gave a real, well-up Moon at 22deg an alpha of 0.49, roughly half
+// strength, when a Moon that high actually reads as close to white. Replaced with a curve
+// grounded in the real physics of why a low Moon reddens at all.
+//
+// airmass(): Kasten & Young 1989 — how many atmospheres-worth of air a sightline crosses,
+// stated to stay accurate all the way to the horizon (unlike the naive secant `1/sin(altitude)`,
+// which diverges to infinity there instead of the true, refraction-limited ~38).
+function airmass(altitudeDeg: number): number {
+  const altDeg = Math.max(altitudeDeg, 0);
+  const altRad = (altDeg * Math.PI) / 180;
+  return 1 / (Math.sin(altRad) + 0.50572 * (altDeg + 6.07995) ** -1.6364);
+}
+
+// A second version used `1 - exp(-k * (airmass - 1))` directly, k picked from a real published
+// differential-extinction coefficient (~0.15 mag/airmass) — physically grounded, but it still
+// overstated things: a Moon at 22deg (airmass 2.6) came out at 0.22 strength, a visible cast on
+// a Moon real observers report as reading white. The gap is that "magnitudes of physical
+// extinction" and "how much a UI overlay should visibly recolor a photo" aren't the same scale
+// — human color perception needs the airmass excess to build up well past the zenith baseline
+// before it reads as anything at all, then catches up fast right near the horizon. Squaring the
+// excess before the exponential is what buys that: it pushes the early/moderate range down much
+// harder than the plain linear version while keeping the same near-total saturation at the
+// horizon. The exponent is a perceptual calibration knob, not a cited constant the way the
+// airmass formula above is.
+const EXTINCTION_RAMP_COEFFICIENT = 0.004;
+
+// The extinction color above is the Moon's true tint — unaffected by the Sun's position, since
+// the reddening happens along the sightline to the Moon, not to the Sun. But how strongly that
+// true tint actually *reads* to an observer does depend on the Sun: a bright sky floods the same
+// sightline with scattered light (veiling luminance) and simultaneous-contrast perception further
+// desaturates a tinted object seen against a bright field — the same reason a red filter looks
+// vivid on a dark background and washed-out on a white one. Both effects fade the *visible*
+// strength of the true tint toward the sky's own brightness, they don't change the tint itself —
+// which is why this multiplies the strength computed above rather than feeding into it.
+//
+// Reuses the same day/night luma extremes as the sky wash rather than a second calibrated curve:
+// the two washes already agree on what "day" and "night" brightness mean, so the fade should too.
+const DAY_LUMA = luma(SKY_ANCHORS[0].rgb);
+const NIGHT_LUMA = luma(NIGHT_RGB);
+
+function luma(rgb: readonly [number, number, number]): number {
+  return 0.299 * rgb[0] + 0.587 * rgb[1] + 0.114 * rgb[2];
+}
+
+// 0 at night (no veiling, full contrast against a dark sky) to 1 in full daylight (sky luminance
+// swamps the Moon's own tint). Linear in luma rather than sun elevation directly, so it tracks
+// the same brightness the sky wash itself already renders instead of re-deriving twilight bands.
+function skyBrightnessFraction(sunElevDeg: number): number {
+  const currentLuma = luma(hexToRgb(skyBackgroundForElevation(sunElevDeg)));
+  return Math.max(0, Math.min(1, (currentLuma - NIGHT_LUMA) / (DAY_LUMA - NIGHT_LUMA)));
+}
+
+function hexToRgb(hex: string): [number, number, number] {
+  return [
+    Number.parseInt(hex.slice(1, 3), 16),
+    Number.parseInt(hex.slice(3, 5), 16),
+    Number.parseInt(hex.slice(5, 7), 16),
+  ];
+}
+
+/**
+ * How strongly the Moon's own altitude should redden/dim it right now, as an rgba() string
+ * whose alpha carries the strength — mix-blend-mode: color reads alpha as how much of the
+ * backdrop's own hue survives, so a fading alpha is a fading tint rather than a second color
+ * to mix by hand.
+ *
+ * `sunElevDeg` fades that strength toward zero as the sky brightens — see the contrast-fade
+ * comment above. It does not gate the tint on its own: even a bright sky still shows *some*
+ * extinction on a Moon right at the horizon, it just reads weaker than the same Moon would
+ * against a dark one.
+ */
+export function moonExtinctionTint(altitudeDeg: number, sunElevDeg: number): string {
+  const airmassExcess = airmass(altitudeDeg) - 1;
+  const rawStrength = Math.max(
+    0,
+    Math.min(1, 1 - Math.exp(-EXTINCTION_RAMP_COEFFICIENT * airmassExcess ** 2))
+  );
+  const strength = rawStrength * (1 - skyBrightnessFraction(sunElevDeg));
+  const [r, g, b] = MOON_EXTINCTION_RGB;
+  return `rgba(${r}, ${g}, ${b}, ${strength.toFixed(2)})`;
+}
+
 // HASS and config.location update independently (hass setter vs. setConfig), so each source
 // is kept as one grouped field rather than losing either one to an eager merge — `data` and
 // `name` below resolve them on read, override winning per-field.
@@ -78,6 +168,8 @@ export interface SkyFrame {
   belowHorizon: boolean;
   /** What the sky itself looks like right now, whether or not the Moon is up. */
   background: string;
+  /** How much the Moon's own altitude should redden/dim it right now — see moonExtinctionTint(). */
+  extinction: string;
 }
 
 /**
@@ -179,7 +271,14 @@ export class ViewingLocation {
    */
   skyFrame(now: Date): SkyFrame {
     const location = this.data;
-    if (!location) return { rotation: 0, belowHorizon: false, background: "#000" };
+    if (!location) {
+      return {
+        rotation: 0,
+        belowHorizon: false,
+        background: "#000",
+        extinction: "rgba(0, 0, 0, 0)",
+      };
+    }
 
     const { parallacticDeg, altitudeDeg } = getMoonSkyAngles(now, location.lat, location.lon);
     const sunElevDeg = computeSolarElevationDeg(location.lat, location.lon, now);
@@ -187,6 +286,7 @@ export class ViewingLocation {
       rotation: parallacticDeg,
       belowHorizon: altitudeDeg <= 0,
       background: skyBackgroundForElevation(sunElevDeg),
+      extinction: moonExtinctionTint(altitudeDeg, sunElevDeg),
     };
   }
 }

--- a/test/__snapshots__/snapshot.test.ts.snap
+++ b/test/__snapshots__/snapshot.test.ts.snap
@@ -129,6 +129,19 @@ exports[`cardStyles > matches snapshot 1`] = `
     cursor: pointer;
     display: block;
   }
+  /* #178: the Moon's own altitude-extinction tint, mirroring .gallery-thumb-tint's mix-blend-mode
+     trick but sized to the whole square frame rather than clipped to a disc — the panel image has
+     no circle crop to match (see discStyle()). Usually near-zero strength (see
+     moonExtinctionTint()), so covering the full square doesn't read as a wash the way the
+     day/twilight/night sky color would. */
+  .image-view-tint {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    mix-blend-mode: color;
+    pointer-events: none;
+  }
   /* Stands in for the image, in the tile and in the full-screen panel alike: fills whichever
      box it lands in and centres on both axes, so one rule serves a 104px thumbnail and a
      full-width panel without either needing to know about the other. */

--- a/test/card/card.gallery.test.ts
+++ b/test/card/card.gallery.test.ts
@@ -262,6 +262,25 @@ describe("SolarViewCard gallery", () => {
       vi.useRealTimers();
     });
 
+    // #178: a second, independent tint layer stacked on the sky-elevation one — the Moon's own
+    // altitude (extinction), not just what the sky looks like. High altitude, low horizon
+    // strength: rgba alpha should be near 0 rather than the near-full-strength it'd be low down.
+    it("stacks a second tint layer for the Moon's own altitude extinction", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-08-22T03:00:00Z")); // 22:00 CDT: Moon up at this site
+      const card = document.createElement("ha-planetary-solar-system-card-test");
+      card.setConfig({
+        gallery: { mode: "open" },
+        location: { latitude: 33.2148, longitude: -97.1331, timezone: "America/Chicago" },
+      });
+      document.body.appendChild(card);
+      const tints = card.shadowRoot.querySelectorAll('[data-source="mymoon"] .gallery-thumb-tint');
+      expect(tints.length).toBe(2);
+      expect(tints[1].getAttribute("style")).toMatch(/background: rgba\(255, 102, 26, 0\.\d\d\)/);
+      card.remove();
+      vi.useRealTimers();
+    });
+
     // No location means no observer to light the tint for, same reasoning as the unrotated
     // frame: the honest default, not a guess.
     it("falls back to a black tint with no location known", () => {
@@ -286,10 +305,10 @@ describe("SolarViewCard gallery", () => {
       card.remove();
     });
 
-    // Unlike the thumbnail, the full-screen panel never tints its backdrop — the corners a
-    // rotated square swings away from are a much bigger share of a full-screen frame than of a
-    // 104px tile, and a colored fill across that much of the screen reads as a wash over the
-    // view rather than a detail on a photo. Plain black, same as every other panel.
+    // Unlike the thumbnail, the full-screen panel never washes its backdrop by Sun elevation —
+    // the corners a rotated square swings away from are a much bigger share of a full-screen
+    // frame than of a 104px tile, and a colored fill across that much of the screen reads as a
+    // wash over the view rather than a detail on a photo. Plain black, same as every other panel.
     it("keeps the full-screen panel's own background plain black, even for the sky tile", async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date("2026-08-22T18:00:00Z")); // Sun well up (irrelevant to the panel)
@@ -301,6 +320,26 @@ describe("SolarViewCard gallery", () => {
       card.shadowRoot.querySelector('[data-source="mymoon"]').click();
       await vi.advanceTimersByTimeAsync(0);
       expect(card.shadowRoot.querySelector(".image-view-frame").getAttribute("style")).toBe(null);
+      card.remove();
+      vi.useRealTimers();
+    });
+
+    // #178: unlike the elevation wash above, the Moon's own altitude-extinction tint does extend
+    // to the full-screen panel — it's usually near-zero strength, so it doesn't carry the same
+    // "wash over the whole view" risk the elevation color does.
+    it("tints the full-screen panel by the Moon's own altitude extinction", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-08-22T03:00:00Z")); // 22:00 CDT: Moon up at this site
+      const card = createAndMount({
+        gallery: { mode: "open" },
+        location: { latitude: 33.2148, longitude: -97.1331, timezone: "America/Chicago" },
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      card.shadowRoot.querySelector('[data-source="mymoon"]').click();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(card.shadowRoot.querySelector(".image-view-tint").getAttribute("style")).toMatch(
+        /background: rgba\(255, 102, 26, 0\.\d\d\)/
+      );
       card.remove();
       vi.useRealTimers();
     });

--- a/test/card/viewing-location.test.ts
+++ b/test/card/viewing-location.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { skyBackgroundForElevation, ViewingLocation } from "../../src/card/viewing-location.js";
+import {
+  moonExtinctionTint,
+  skyBackgroundForElevation,
+  ViewingLocation,
+} from "../../src/card/viewing-location.js";
 
 const LONDON = {
   config: { latitude: 51.5, longitude: -0.1, time_zone: "Europe/London", location_name: "London" },
@@ -97,6 +101,7 @@ describe("ViewingLocation", () => {
         rotation: 0,
         belowHorizon: false,
         background: "#000",
+        extinction: "rgba(0, 0, 0, 0)",
       });
     });
 
@@ -153,6 +158,63 @@ describe("ViewingLocation", () => {
       );
       expect(states).toContain(true);
       expect(states).toContain(false);
+    });
+  });
+
+  // #178: real moonlight reddens/dims near the horizon from crossing more atmosphere
+  // (extinction) — the tint's *hue* is driven by the Moon's own altitude, not the Sun's, so it's
+  // a second overlay rather than a replacement for skyBackgroundForElevation. But its visible
+  // *strength* isn't fully independent of the Sun: a bright sky washes the same tint out
+  // (contrast fade, tested below), so a night-sky sunElevDeg is used here to isolate the
+  // altitude-only behavior these tests are about.
+  const NIGHT_SUN_DEG = -20;
+  const strengthOf = (rgba: string) => Number.parseFloat(rgba.split(",")[3]);
+
+  describe("moonExtinctionTint", () => {
+    it("has no strength at the zenith", () => {
+      expect(moonExtinctionTint(90, NIGHT_SUN_DEG)).toBe("rgba(255, 102, 26, 0.00)");
+    });
+
+    it("is at full strength right at the horizon, against a night sky", () => {
+      expect(moonExtinctionTint(0, NIGHT_SUN_DEG)).toBe("rgba(255, 102, 26, 1.00)");
+    });
+
+    it("weakens monotonically as altitude climbs, steeply near the horizon", () => {
+      const low = moonExtinctionTint(2, NIGHT_SUN_DEG);
+      const mid = moonExtinctionTint(10, NIGHT_SUN_DEG);
+      const high = moonExtinctionTint(30, NIGHT_SUN_DEG);
+      expect(strengthOf(low)).toBeGreaterThan(strengthOf(mid));
+      expect(strengthOf(mid)).toBeGreaterThan(strengthOf(high));
+      // A well-up Moon reads as essentially white: negligible strength by 30deg.
+      expect(strengthOf(high)).toBeLessThan(0.1);
+    });
+
+    it("stays essentially white for a Moon at typical viewing altitude", () => {
+      // #178 originally shipped a curve that gave a real, well-up 22deg Moon roughly half
+      // strength — visibly red when real observers report it reading white. This is the
+      // regression test for that: a well-up Moon must stay close to colorless.
+      expect(strengthOf(moonExtinctionTint(22, NIGHT_SUN_DEG))).toBeLessThan(0.05);
+    });
+
+    it("clamps rather than going negative below the horizon", () => {
+      expect(moonExtinctionTint(-10, NIGHT_SUN_DEG)).toBe("rgba(255, 102, 26, 1.00)");
+    });
+
+    // Contrast fade: the same low Moon reads weaker against a brighter sky, because the sky's
+    // own scattered light veils the tint (simultaneous contrast) rather than the Moon's true
+    // color actually changing.
+    it("fades a low Moon's tint toward zero as the sky brightens", () => {
+      const night = strengthOf(moonExtinctionTint(2, NIGHT_SUN_DEG));
+      const civilTwilight = strengthOf(moonExtinctionTint(2, -6));
+      const day = strengthOf(moonExtinctionTint(2, 10));
+      expect(night).toBeGreaterThan(civilTwilight);
+      expect(civilTwilight).toBeGreaterThan(day);
+      expect(day).toBe(0);
+    });
+
+    it("leaves the tint untouched at true night regardless of exact sun angle", () => {
+      // Below the -18deg anchor the sky wash is already a flat plateau, so the fade must be too.
+      expect(moonExtinctionTint(2, -19)).toBe(moonExtinctionTint(2, -25));
     });
   });
 });


### PR DESCRIPTION
## Summary
- `moonExtinctionTint(altitudeDeg, sunElevDeg)` now fades its strength toward zero as the sky brightens (simultaneous contrast / veiling luminance) — a bright sky washes out the Moon's own reddening, independent of the Moon's altitude alone.
- Wired into `card.ts`/`card-styles.ts` gallery thumbnail + full-screen panel tints (#178 follow-up).
- `design-notes/mymoon-tint-model.html`: mirrors the new formula, adds live toggles ("Apply Moon-altitude extinction", "Apply sky-brightness contrast fade") below the rendered matrix so the two effects can be isolated and compared.

## Test plan
- [x] `npm run test:coverage` — 1197 tests, 100% coverage
- [x] `npm run check:ci` — typecheck + biome + prettier clean
- [x] Verified design-notes page JS logic numerically matches the TS implementation (night/day/twilight cases, both toggles on/off)