### PR TITLE
refactor: name debug counters, dedupe grid-floor math

### DIFF
--- a/src/card/gallery/debug-stats.ts
+++ b/src/card/gallery/debug-stats.ts
@@ -1,27 +1,12 @@
 // The counters the gallery fetch protocol keeps, and the snapshot the overlay renders from.
 // Nothing here draws anything — see card/debug-view.ts for that half.
 //
-// Cumulative, since the card was mounted — not a rolling window. Lets debug:true answer "is
-// this source's own cache actually saving anything" at a glance: `gets` vs. network calls
-// equal means every refresh is hitting the network regardless of cache state. `cacheHits` is the
-// direct answer to that question — it counts every refresh SourceResolver.resolve() served straight
-// from that source's own cache, checked before any fetch is even attempted, so it should
-// climb steadily while `fetches` stays flat between a source's real TTL windows. `backoffs`
-// counts a refresh served entirely from Backoff's last-confirmed image, without even checking
-// this source's own TTL cache — the source is sitting out a backoff window from prior failures.
-// `expired`
-// counts a resolved candidate whose URL turned out identical to the image already displayed,
-// found only after the TTL cache had already expired and forced a real fetchCandidateUrl()
-// call that ended up confirming nothing changed (for earth this still cost one real EPIC API
-// request; for sun it's free, since its candidate URL is pure math) — the far more common case
-// (cache still fresh AND URL unchanged) needs no counter of its own, since `cacheHits` already
-// answers that question. `fetches` vs. `failures` separates "tried" from "failed", since a
-// failed preload (sun's retry path) previously vanished from the count entirely instead of
-// showing up as a real network cost. `retries` counts how often sun's primary guess missed and
-// fell back to a widened publish buffer — steady state should sit at zero, since the buffer
-// (source-resolver-sdo-sun.ts) learns the feed's real lag; a rising rate means it is spending
-// its ticks probing rather than resting at the floor. `lastAttemptAt` is the raw timestamp of the most
-// recent preload attempt, formatted at render time.
+// Cumulative, since the card was mounted — not a rolling window. Every field is written through
+// exactly one record function below — that function's own comment is the counter's full
+// contract (what it means, when it fires, what a healthy value looks like); nothing here
+// mutates a field directly. `fetches`/`failures`/`fetchMsTotal`/`lastAttemptAt` are the one
+// exception, owned entirely by timedAttempt() further down this file rather than a record*
+// function of their own, since that's already a single call site.
 // Field order matches the overlay's column order (buildDebugOverlay in card/debug-view.ts).
 export interface SourceDebugStats {
   gets: number;
@@ -59,6 +44,42 @@ export function emptyDebugAccumulator(): DebugAccumulator {
     fetchMsTotal: 0,
     lastAttemptAt: null,
   };
+}
+
+// Answers "how many ticks has this source seen", not "how many needed a fetch" — that's
+// cacheHits/fetches below.
+export function recordGet(debug: DebugAccumulator): void {
+  debug.gets++;
+}
+
+// Direct answer to "is this source's TTL actually skipping the network" — climbs steadily while
+// `fetches` stays flat between TTL windows.
+export function recordCacheHit(debug: DebugAccumulator): void {
+  debug.cacheHits++;
+}
+
+// Counts a refresh served entirely from Backoff's last-confirmed image, without even checking
+// this source's own TTL cache — the source is sitting out a backoff window from prior failures.
+export function recordBackoff(debug: DebugAccumulator): void {
+  debug.backoffs++;
+}
+
+// Counts a resolved candidate whose URL turned out identical to the image already displayed,
+// found only after the TTL cache had already expired and forced a real fetchCandidateUrl() call
+// that ended up confirming nothing changed (for earth this still cost one real EPIC API request;
+// for sun it's free, since its candidate URL is pure math). The far more common case — cache
+// still fresh AND URL unchanged — needs no counter of its own, since cacheHits already answers
+// that question.
+export function recordExpired(debug: DebugAccumulator): void {
+  debug.expired++;
+}
+
+// Counts how often sun's primary guess missed and fell back to searching for a published slot
+// (source-resolver-sdo-sun.ts). Steady state should sit at zero, since the publish buffer learns
+// the feed's real lag; a rising rate means it is spending its ticks probing rather than resting
+// at the floor.
+export function recordRetry(debug: DebugAccumulator): void {
+  debug.retries++;
 }
 
 export function toDebugStats(acc: DebugAccumulator): SourceDebugStats {

--- a/src/card/gallery/pad.ts
+++ b/src/card/gallery/pad.ts
@@ -3,3 +3,10 @@
 export function padLeft(value: number, width = 2): string {
   return String(value).padStart(width, "0");
 }
+
+// Shared by slot-search.ts's bisection, the sun resolver's own slot guess, and the moon
+// resolver's hourly frame lookup — all three need "which grid line does this instant fall on",
+// just with a different grid spacing each.
+export function floorToGrid(ms: number, gridMs: number): number {
+  return Math.floor(ms / gridMs) * gridMs;
+}

--- a/src/card/gallery/slot-search.ts
+++ b/src/card/gallery/slot-search.ts
@@ -1,3 +1,5 @@
+import { floorToGrid } from "./pad.js";
+
 // Pure "which slot to try next" engine for a source published on a fixed time grid with
 // unknown publish lag (sun's 15-min SDO slots — see source-resolver-sdo-sun.ts). Knows nothing
 // about network, decoding, or images: the caller supplies a `probe` that answers "does this slot
@@ -35,10 +37,6 @@ export interface SlotSearchOptions {
   // Cold-start reach ceiling — past this, the feed is treated as dead rather than lagging.
   maxReachMs: number;
   probe: SlotProbe;
-}
-
-function floorToGrid(ms: number, slotMs: number): number {
-  return Math.floor(ms / slotMs) * slotMs;
 }
 
 export async function findPublishedSlot(opts: SlotSearchOptions): Promise<SlotSearchResult> {

--- a/src/card/gallery/source-resolver-sdo-sun.ts
+++ b/src/card/gallery/source-resolver-sdo-sun.ts
@@ -1,5 +1,6 @@
 import type { DebugAccumulator } from "./debug-stats.js";
-import { padLeft } from "./pad.js";
+import { recordRetry } from "./debug-stats.js";
+import { floorToGrid, padLeft } from "./pad.js";
 import type { SlotProbe } from "./slot-search.js";
 import { findPublishedSlot } from "./slot-search.js";
 import { IMAGE_TIMEOUT_MESSAGE, SourceResolver, timedPreload } from "./source-resolver.js";
@@ -114,7 +115,7 @@ export function sunSlotProbe(
   preload: (url: string, debug: DebugAccumulator) => Promise<void> = timedPreload
 ): SlotProbe {
   return async (slotMs: number) => {
-    debug.retries++;
+    recordRetry(debug);
     try {
       await preload(buildSunSlotImage(new Date(slotMs)).url, debug);
       return { hit: true };
@@ -149,13 +150,11 @@ export function getSunImageUrl(cache: UrlCache = urlCache): SourcedImage {
   const cached = freshCachedSlot(cache);
   if (cached) return cached;
 
-  const image = buildSunSlotImage(new Date(floorToSlot(Date.now() - SUN_PUBLISH_BUFFER_MS)));
+  const image = buildSunSlotImage(
+    new Date(floorToGrid(Date.now() - SUN_PUBLISH_BUFFER_MS, SUN_CACHE_TTL_MS))
+  );
   cache.set("sun", image);
   return image;
-}
-
-function floorToSlot(ms: number): number {
-  return Math.floor(ms / SUN_CACHE_TTL_MS) * SUN_CACHE_TTL_MS;
 }
 
 function buildSunSlotImage(slot: Date): SourcedImage {

--- a/src/card/gallery/source-resolver-svs-moon.ts
+++ b/src/card/gallery/source-resolver-svs-moon.ts
@@ -1,4 +1,4 @@
-import { padLeft } from "./pad.js";
+import { floorToGrid, padLeft } from "./pad.js";
 import { SourceResolver } from "./source-resolver.js";
 import type { ImageSource } from "./sources.js";
 import type { SourcedImage, UrlCache } from "./url-cache.js";
@@ -110,7 +110,7 @@ export function moonFrameUrl(at: Date, size: string): string {
  * shown beneath it.
  */
 export function getMoonFrameImage(at: Date, size: string = MOON_THUMB_SIZE): SourcedImage {
-  const hour = new Date(Math.floor(at.getTime() / MOON_FRAME_MS) * MOON_FRAME_MS);
+  const hour = new Date(floorToGrid(at.getTime(), MOON_FRAME_MS));
   return { url: moonFrameUrl(hour, size), date: hour };
 }
 

--- a/src/card/gallery/source-resolver.ts
+++ b/src/card/gallery/source-resolver.ts
@@ -1,4 +1,5 @@
 import type { DebugAccumulator } from "./debug-stats.js";
+import { recordBackoff, recordCacheHit, recordExpired, recordGet } from "./debug-stats.js";
 import type { ImageSource } from "./sources.js";
 import type { SourcedImage, UrlCache } from "./url-cache.js";
 import { urlCache } from "./url-cache.js";
@@ -105,7 +106,7 @@ export abstract class SourceResolver {
   // attempt it counts live in the same place instead of two files staying in sync by
   // convention (ImageResolver used to bump this before ever calling resolve()).
   async resolve(urlDebug: DebugAccumulator, imgDebug: DebugAccumulator): Promise<SourcedImage> {
-    urlDebug.gets++;
+    recordGet(urlDebug);
     // Checked — and left — outside the try/catch below on purpose: cooldown itself is not a
     // failure to record (Backoff already recorded the failures that armed it), so this must
     // never reach the catch's own recordFailure() call.
@@ -119,13 +120,13 @@ export abstract class SourceResolver {
       // confirmed nothing changed — the cache-still-fresh case needs no counter of its own,
       // `cacheHits` already answers that question.
       if (this.cache.isDecoded(this.cacheKey, candidate.url)) {
-        if (!fromCache) urlDebug.expired++;
+        if (!fromCache) recordExpired(urlDebug);
         return this.commit(candidate);
       }
       // sun's imgDebug is the same object as urlDebug (see the accumulator comment above), so
-      // it's already been bumped by the unconditional gets++ above — only earth's
+      // it's already been bumped by the unconditional recordGet() above — only earth's
       // split-off img row needs its own count of "an image refresh was actually needed" here.
-      if (imgDebug !== urlDebug) imgDebug.gets++;
+      if (imgDebug !== urlDebug) recordGet(imgDebug);
       return await this.fetchAndDecode(candidate, imgDebug);
     } catch (err) {
       this.cache.recordFailure(this.cacheKey, retryAfterMsFrom(err));
@@ -140,7 +141,7 @@ export abstract class SourceResolver {
   // continue on to the cache/fetch phases below.
   private checkCooldown(debug: DebugAccumulator): SourcedImage | null {
     if (!this.cache.inCooldown(this.cacheKey)) return null;
-    debug.backoffs++;
+    recordBackoff(debug);
     const stale = this.cache.getStale(this.cacheKey);
     if (stale) return stale;
     throw new Error(`${this.source} is in cooldown after repeated failures`);
@@ -155,7 +156,7 @@ export abstract class SourceResolver {
     debug: DebugAccumulator
   ): Promise<{ image: SourcedImage; fromCache: boolean }> {
     const cached = this.getCached();
-    if (cached) debug.cacheHits++;
+    if (cached) recordCacheHit(debug);
     const image = cached ?? (await this.fetchCandidateUrl(debug));
     return { image, fromCache: cached != null };
   }


### PR DESCRIPTION
## Summary
- `DebugAccumulator` counters were raw fields mutated ad hoc across `source-resolver.ts` / `source-resolver-sdo-sun.ts`, with meaning explained in one shared 24-line comment instead of at each call site. Replaced with named record functions (`recordGet`, `recordCacheHit`, `recordBackoff`, `recordExpired`, `recordRetry`), each carrying its own short contract.
- `Math.floor(x / grid) * grid` was duplicated in `slot-search.ts`, `source-resolver-sdo-sun.ts`, and inlined in `source-resolver-svs-moon.ts`. Consolidated into `floorToGrid()` in `pad.ts`.
- No behavior change, no interface change for callers — existing test suite covers every touched line at 100%, no new tests added.

## Test plan
- [x] `npm run test:coverage` — 1201 passed, 100% coverage
- [x] `npm run check:ci` — typecheck + biome + prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)