### PR TITLE
feat: show Moon altitude in status bar

### DIFF
--- a/src/card/card-template.ts
+++ b/src/card/card-template.ts
@@ -1,5 +1,6 @@
 import type { TemplateResult } from "lit";
 import { html, nothing } from "lit";
+import { getMoonSkyAngles } from "../astronomy/parallactic.js";
 import {
   computeNextTransitionTime,
   computeSolarElevationDeg,
@@ -21,6 +22,9 @@ export function buildStatusBar(
   const elevDeg = computeSolarElevationDeg(locationData.lat, locationData.lon, currentDate);
   const mode = getSkyMode(elevDeg);
   const elevRounded = Math.round(elevDeg);
+  const moonElevRounded = Math.round(
+    getMoonSkyAngles(currentDate, locationData.lat, locationData.lon).altitudeDeg
+  );
   const next = computeNextTransitionTime(locationData.lat, locationData.lon, currentDate);
   const formatter = next
     ? new Intl.DateTimeFormat("en-US", {
@@ -38,7 +42,7 @@ export function buildStatusBar(
 
   const name = locationName || "";
   return html`<div class="status-bar">
-    <span>${name} | ${mode} (${elevRounded}°)</span>
+    <span>${name} | ${mode} (${elevRounded}°) | Moon (${moonElevRounded}°)</span>
     ${next && formatter ? html`<span>Next: ${next.toMode} (${formatter.format(next.time)})</span>` : nothing}
   </div>`;
 }

--- a/test/__snapshots__/snapshot.test.ts.snap
+++ b/test/__snapshots__/snapshot.test.ts.snap
@@ -2,21 +2,21 @@
 
 exports[`buildStatusBar snapshots > full status bar with Next transition 1`] = `
 "<!----><div class="status-bar">
-    <span><!--?-->London | <!--?-->Day (<!--?-->33°)</span>
+    <span><!--?-->London | <!--?-->Day (<!--?-->33°) | Moon (<!--?-->-40°)</span>
     <!--?--><span>Next: <!--?-->Civil Twilight (<!--?-->17:47)</span>
   </div>"
 `;
 
 exports[`buildStatusBar snapshots > null location name (empty before pipe) 1`] = `
 "<!----><div class="status-bar">
-    <span><!--?--> | <!--?-->Day (<!--?-->88°)</span>
+    <span><!--?--> | <!--?-->Day (<!--?-->88°) | Moon (<!--?-->69°)</span>
     <!--?--><span>Next: <!--?-->Civil Twilight (<!--?-->18:10)</span>
   </div>"
 `;
 
 exports[`buildStatusBar snapshots > single span (polar night, no transition) 1`] = `
 "<!----><div class="status-bar">
-    <span><!--?-->Arctic | <!--?-->Night (<!--?-->-22°)</span>
+    <span><!--?-->Arctic | <!--?-->Night (<!--?-->-22°) | Moon (<!--?-->23°)</span>
     <!--?-->
   </div>"
 `;

--- a/test/card/card-template.test.ts
+++ b/test/card/card-template.test.ts
@@ -79,6 +79,18 @@ describe("buildStatusBar", () => {
     expect(leftSpan.textContent).toMatch(/London \| .+ \(-?\d+°\)/);
   });
 
+  it("left span includes the Moon's altitude alongside the Sun's", () => {
+    const root = renderToDOM(
+      buildStatusBar(
+        { lat: 51.5, lon: -0.1, timezone: "Europe/London", zoneOverride: false },
+        "London",
+        new Date("2026-03-05T12:00:00Z")
+      )
+    );
+    const leftSpan = root.querySelector(".status-bar span:first-child");
+    expect(leftSpan.textContent).toMatch(/London \| .+ \(-?\d+°\) \| Moon \(-?\d+°\)/);
+  });
+
   it("includes Next: span when a transition exists within 24h", () => {
     const root = renderToDOM(
       buildStatusBar(

--- a/test/card/card.status-bar.test.ts
+++ b/test/card/card.status-bar.test.ts
@@ -42,6 +42,14 @@ describe("SolarViewCard status bar", () => {
       card.remove();
     });
 
+    it("left span contains the Moon's altitude alongside the Sun's", () => {
+      const card = createCardWithLocation();
+      const bar = card.shadowRoot.querySelector(".status-bar");
+      const leftSpan = bar.querySelector("span:first-child");
+      expect(leftSpan.textContent).toMatch(/London \| .+ \(-?\d+°\) \| Moon \(-?\d+°\)/);
+      card.remove();
+    });
+
     it("right span contains Next: <mode-name> (<HH:MM>)", () => {
       const card = createCardWithLocation();
       const bar = card.shadowRoot.querySelector(".status-bar");


### PR DESCRIPTION
## Summary
- Status bar left span now shows Moon altitude alongside Sun's: `Name | Day (33°) | Moon (-40°)`
- Reuses existing `getMoonSkyAngles` (parallactic.ts), no new astronomy code

## Test plan
- [x] Added regression test in `test/card/card-template.test.ts`
- [x] Added regression test in `test/card/card.status-bar.test.ts`
- [x] Updated `test/__snapshots__/snapshot.test.ts.snap`
- [x] `npm run test:coverage` — 100% coverage, all green
- [x] `npm run check:ci` — green