### PR TITLE
docs: turn off all gallery sources on the live interactive demo

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -83,13 +83,9 @@
     import "./card.js";
 
     const card = document.getElementById("demo-card");
-    // mymoon is sky-relative and follows the real clock here (no fixed --at like the demo
-    // gif has), so it shows "No Moon Sky" for roughly half of any given visitor's session —
-    // off by default so the live demo doesn't look broken on a coin flip. moon/earth/sun
-    // have no such below-horizon gap, so they're on in its place.
     card.setConfig({
       default_zoom: 2,
-      gallery: { mymoon: false, moon: true, earth: true, sun: true },
+      gallery: { mymoon: false, moon: false, earth: false, sun: false },
     });
     card.hass = {
       config: {


### PR DESCRIPTION
## Summary
- All four `gallery.*` sources now false on `docs/index.html` (was moon/earth/sun true after #195) — the live demo shows no gallery thumbnails at all

## Test plan
- [x] `npm run check:ci` — green