### PR TITLE
fix: apply sky-elevation wash to full-screen MY MOON panel

### DIFF
--- a/src/card/card-styles.ts
+++ b/src/card/card-styles.ts
@@ -107,11 +107,11 @@ export const cardStyles = css`
     cursor: pointer;
     display: block;
   }
-  /* #178: the Moon's own altitude-extinction tint, mirroring .gallery-thumb-tint's mix-blend-mode
-     trick but sized to the whole square frame rather than clipped to a disc — the panel image has
-     no circle crop to match (see discStyle()). Usually near-zero strength (see
-     moonExtinctionTint()), so covering the full square doesn't read as a wash the way the
-     day/twilight/night sky color would. */
+  /* The sky-elevation wash and #178's Moon altitude-extinction tint, same mix-blend-mode: color
+     trick as .gallery-thumb-tint but sized to the whole square frame rather than clipped to a
+     disc — the panel image has no circle crop to match (see discStyle()). Two stacked layers,
+     same order as the thumbnail: wash always on, extinction on top of it when
+     gallery.mymoon_tint is enabled (see card.ts). */
   .image-view-tint {
     position: absolute;
     inset: 0;

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -205,11 +205,19 @@ export class SolarViewCard extends LitElement {
                       @error=${this._onImageLoadError}
                     />
                     ${
-                      panelSky && this._mymoonTint
+                      panelSky
                         ? html`<div
-                            class="image-view-tint"
-                            style=${`background: ${panelSky.extinction}`}
-                          ></div>`
+                              class="image-view-tint"
+                              style=${`background: ${panelSky.background}`}
+                            ></div>
+                            ${
+                              this._mymoonTint
+                                ? html`<div
+                                    class="image-view-tint"
+                                    style=${`background: ${panelSky.extinction}`}
+                                  ></div>`
+                                : nothing
+                            }`
                         : nothing
                     }`
             }
@@ -358,12 +366,9 @@ export class SolarViewCard extends LitElement {
    * square like every other source's, unlike the thumbnail (which always circle-crops, see
    * discStyle()); only the rotated image inside it, not the frame's own shape, follows the
    * observer's orientation. Its own background is plain black (card-styles.ts), same as every
-   * other panel — unlike the thumbnail, the day/twilight/night sky wash doesn't extend here: the
-   * corners a rotated square swings away from are a much larger share of a full-screen frame than
-   * of a 104px tile, and a colored fill across that much of the screen reads as a wash over the
-   * view rather than a detail on a photo. The Moon's own altitude-extinction tint (#178,
-   * .image-view-tint) is added anyway despite that: it's usually near-zero strength and only
-   * strong close to the horizon, so it doesn't carry the same "wash over the whole view" risk.
+   * other panel — the day/twilight/night sky wash and the Moon's own altitude-extinction tint
+   * (#178) both paint as .image-view-tint overlays on top of the photo instead, same two-layer
+   * shape as the thumbnail's .gallery-thumb-tint pair (see _renderGalleryTile).
    */
   private _panelFrameStyle(): string | typeof nothing {
     return this._heightStyle || nothing;

--- a/test/__snapshots__/snapshot.test.ts.snap
+++ b/test/__snapshots__/snapshot.test.ts.snap
@@ -129,11 +129,11 @@ exports[`cardStyles > matches snapshot 1`] = `
     cursor: pointer;
     display: block;
   }
-  /* #178: the Moon's own altitude-extinction tint, mirroring .gallery-thumb-tint's mix-blend-mode
-     trick but sized to the whole square frame rather than clipped to a disc — the panel image has
-     no circle crop to match (see discStyle()). Usually near-zero strength (see
-     moonExtinctionTint()), so covering the full square doesn't read as a wash the way the
-     day/twilight/night sky color would. */
+  /* The sky-elevation wash and #178's Moon altitude-extinction tint, same mix-blend-mode: color
+     trick as .gallery-thumb-tint but sized to the whole square frame rather than clipped to a
+     disc — the panel image has no circle crop to match (see discStyle()). Two stacked layers,
+     same order as the thumbnail: wash always on, extinction on top of it when
+     gallery.mymoon_tint is enabled (see card.ts). */
   .image-view-tint {
     position: absolute;
     inset: 0;

--- a/test/card/card.gallery.test.ts
+++ b/test/card/card.gallery.test.ts
@@ -322,10 +322,8 @@ describe("SolarViewCard gallery", () => {
       card.remove();
     });
 
-    // Unlike the thumbnail, the full-screen panel never washes its backdrop by Sun elevation —
-    // the corners a rotated square swings away from are a much bigger share of a full-screen
-    // frame than of a 104px tile, and a colored fill across that much of the screen reads as a
-    // wash over the view rather than a detail on a photo. Plain black, same as every other panel.
+    // The frame itself (not the tint overlay) stays plain black, same as every other panel —
+    // the wash below paints as its own layer over the photo, not the frame's own background.
     it("keeps the full-screen panel's own background plain black, even for the sky tile", async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date("2026-08-22T18:00:00Z")); // Sun well up (irrelevant to the panel)
@@ -341,11 +339,12 @@ describe("SolarViewCard gallery", () => {
       vi.useRealTimers();
     });
 
-    // gallery.mymoon_tint defaults to false — the full-screen panel gets the same gating as the
-    // thumbnail, so no extinction layer appears until a user opts in.
-    it("omits the full-screen panel's altitude extinction tint by default", async () => {
+    // The full-screen panel now matches the thumbnail: the day/twilight/night wash is always on
+    // for the sky tile, independent of gallery.mymoon_tint (that flag only gates the second,
+    // altitude-extinction layer below).
+    it("tints the full-screen panel by the observer's own day/night, same as the thumbnail", async () => {
       vi.useFakeTimers();
-      vi.setSystemTime(new Date("2026-08-22T03:00:00Z")); // 22:00 CDT: Moon up at this site
+      vi.setSystemTime(new Date("2026-08-22T22:00:00Z")); // 17:00 CDT: Sun up, Moon just risen
       const card = createAndMount({
         gallery: { mode: "open" },
         location: { latitude: 33.2148, longitude: -97.1331, timezone: "America/Chicago" },
@@ -353,15 +352,16 @@ describe("SolarViewCard gallery", () => {
       await vi.advanceTimersByTimeAsync(0);
       card.shadowRoot.querySelector('[data-source="mymoon"]').click();
       await vi.advanceTimersByTimeAsync(0);
-      expect(card.shadowRoot.querySelector(".image-view-tint")).toBeNull();
+      const tints = card.shadowRoot.querySelectorAll(".image-view-tint");
+      expect(tints.length).toBe(1);
+      expect(tints[0].getAttribute("style")).toContain("background: #d0d0d0");
       card.remove();
       vi.useRealTimers();
     });
 
-    // #178: unlike the elevation wash above, the Moon's own altitude-extinction tint does extend
-    // to the full-screen panel — it's usually near-zero strength, so it doesn't carry the same
-    // "wash over the whole view" risk the elevation color does.
-    it("tints the full-screen panel by the Moon's own altitude extinction when gallery.mymoon_tint is enabled", async () => {
+    // #178: a second, independent tint layer stacked on the sky-elevation one, gated behind
+    // gallery.mymoon_tint — same two-layer shape as the thumbnail's .gallery-thumb-tint pair.
+    it("stacks the altitude extinction tint on top of the wash when gallery.mymoon_tint is enabled", async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date("2026-08-22T03:00:00Z")); // 22:00 CDT: Moon up at this site
       const card = createAndMount({
@@ -371,9 +371,9 @@ describe("SolarViewCard gallery", () => {
       await vi.advanceTimersByTimeAsync(0);
       card.shadowRoot.querySelector('[data-source="mymoon"]').click();
       await vi.advanceTimersByTimeAsync(0);
-      expect(card.shadowRoot.querySelector(".image-view-tint").getAttribute("style")).toMatch(
-        /background: rgba\(255, 102, 26, 0\.\d\d\)/
-      );
+      const tints = card.shadowRoot.querySelectorAll(".image-view-tint");
+      expect(tints.length).toBe(2);
+      expect(tints[1].getAttribute("style")).toMatch(/background: rgba\(255, 102, 26, 0\.\d\d\)/);
       card.remove();
       vi.useRealTimers();
     });


### PR DESCRIPTION
## Summary
- Full-screen MY MOON panel only carried the near-invisible altitude-extinction tint; the thumbnail's always-on day/night elevation wash was deliberately skipped there (#178), which made `gallery.mymoon_tint` look like a no-op most of the time in full screen.
- Panel now stacks both layers in the same order as the thumbnail: wash always on, extinction tint on top when `mymoon_tint` is enabled.

## Test plan
- [x] Added/updated tests in `test/card/card.gallery.test.ts` asserting the wash layer always renders and extinction stacks as a second layer
- [x] `npm run test:coverage` — 1204 passed, 100% coverage
- [x] `npm run check:ci` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)