### PR TITLE
test: raise backoff-integration timeout to 30s

### DIFF
--- a/test/card/gallery/backoff-integration.test.ts
+++ b/test/card/gallery/backoff-integration.test.ts
@@ -33,7 +33,8 @@ describe("gallery backoff integration", () => {
 
   // Explicit timeout: this drives 360 simulated timer ticks through the real card, which
   // reliably finishes in ~1.5s alone but can cross vitest's 5s default under full-suite
-  // parallel load (many other test files' workers competing for CPU).
+  // parallel load (many other test files' workers competing for CPU) — even 15s proved
+  // too tight under heavy contention, so this is set well above the observed worst case.
   it("a sustained sun-source outage backs off instead of retrying every refresh_mins tick", async () => {
     // Real network attempts only, not decode-gate hits: every Image() construction is one
     // real probe of a candidate URL (the primary guess plus, on failure, every probe the
@@ -74,5 +75,5 @@ describe("gallery backoff integration", () => {
 
     card.remove();
     vi.useRealTimers();
-  }, 15000);
+  }, 30000);
 });


### PR DESCRIPTION
## Summary
- `backoff-integration.test.ts`'s 15s explicit timeout was still too tight under full-suite parallel-worker CPU contention, causing a deterministic (not flaky) pre-push timeout unrelated to the test's own pass/fail logic
- Raised to 30s; verified green across 3 consecutive full-suite runs (with and without coverage)

## Test plan
- [x] `npm test` — 50/50 files, 1204/1204 tests, 3x in a row
- [x] `npm run test:coverage` — 100% across all four metrics
- [x] `npm run check:ci` — typecheck/lint/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)