### PR TITLE
feat: default periodic_zoom_change to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,35 +38,15 @@ Add the card to your dashboard:
 
 ```yaml
 type: custom:ha-planetary-solar-system-card
-default_zoom: 2
-```
-
-```yaml
-type: custom:ha-planetary-solar-system-card
-colors:
-  background: "#0d1117"
-  season_line: "rgba(100, 200, 255, 0.2)"
-  season_label: "#e0e0ff"
 ```
 
 ```yaml
 type: custom:ha-planetary-solar-system-card
 gallery:
-  mode: slide
-  mymoon: false
+  mymoon: true
   moon: true
   earth: true
   sun: true
-  slide_interval_secs: 30
-```
-
-```yaml
-type: custom:ha-planetary-solar-system-card
-location:
-  latitude: 51.5074
-  longitude: -0.1278
-  name: London
-  timezone: Europe/London
 ```
 
 ## Horizon Twilight Zones
@@ -137,7 +117,7 @@ a pipeline stall doesn't break the feed.
 | ---------------------- | ------- | ------- | ----------------------------------------------------------------------- |
 | `default_zoom`         | number  | `1`     | Starting zoom level, and the level the **Now** button returns to        |
 | `zoom_animate`         | boolean | `true`  | Animate zoom transitions                                                |
-| `periodic_zoom_change` | boolean | `false` | Cycle zoom levels on each refresh tick, until you aim the view yourself |
+| `periodic_zoom_change` | boolean | `true`  | Cycle zoom levels on each refresh tick, until you aim the view yourself |
 | `periodic_zoom_max`    | number  | `4`     | Maximum zoom level for auto-cycle (2–4)                                 |
 
 ### Appearance

--- a/src/card/card-config.ts
+++ b/src/card/card-config.ts
@@ -106,7 +106,7 @@ export function parseCardConfig(config: CardConfig): ParsedCardConfig {
   const rawRefresh = Number(config.refresh_mins);
   const refreshMs = Number.isFinite(rawRefresh) && rawRefresh >= 0.1 ? rawRefresh * 60000 : 60000;
 
-  const periodicZoomChange = config.periodic_zoom_change === true;
+  const periodicZoomChange = config.periodic_zoom_change !== false;
   const rawMax = Number(config.periodic_zoom_max);
   const periodicZoomMax =
     Number.isInteger(rawMax) && rawMax >= 2 && rawMax <= MAX_ZOOM ? rawMax : MAX_ZOOM;

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -499,7 +499,7 @@ export class SolarViewCard extends LitElement {
   static getStubConfig(): CardConfig {
     return {
       default_zoom: 2,
-      periodic_zoom_change: false,
+      periodic_zoom_change: true,
       periodic_zoom_max: 4,
       refresh_mins: 1,
       zoom_animate: true,

--- a/test/card/card-config.test.ts
+++ b/test/card/card-config.test.ts
@@ -7,7 +7,7 @@ describe("parseCardConfig", () => {
     expect(parsed).toEqual({
       zoomLevel: 1,
       refreshMs: 60000,
-      periodicZoomChange: false,
+      periodicZoomChange: true,
       periodicZoomMax: 4,
       zoomAnimate: true,
       colors: {},
@@ -57,11 +57,9 @@ describe("parseCardConfig", () => {
   });
 
   describe("periodicZoomChange / zoomAnimate", () => {
-    it("periodic_zoom_change defaults false, true only when === true", () => {
-      expect(
-        parseCardConfig({ periodic_zoom_change: "yes" as unknown as boolean }).periodicZoomChange
-      ).toBe(false);
-      expect(parseCardConfig({ periodic_zoom_change: true }).periodicZoomChange).toBe(true);
+    it("periodic_zoom_change defaults true, false only when === false", () => {
+      expect(parseCardConfig({ periodic_zoom_change: false }).periodicZoomChange).toBe(false);
+      expect(parseCardConfig({}).periodicZoomChange).toBe(true);
     });
     it("zoom_animate defaults true, false only when === false", () => {
       expect(parseCardConfig({ zoom_animate: false }).zoomAnimate).toBe(false);

--- a/test/card/card.auto-zoom.test.ts
+++ b/test/card/card.auto-zoom.test.ts
@@ -8,16 +8,16 @@ setupCardTest();
 // contract between the two in card.auto-behaviour.test.ts.
 describe("SolarViewCard auto_zoom", () => {
   describe("periodic_zoom_change configuration", () => {
-    it("defaults to false when not set", () => {
+    it("defaults to true when not set", () => {
       const card = document.createElement("ha-planetary-solar-system-card-test");
       card.setConfig({});
-      expect(card._zoom.periodicZoomChange).toBe(false);
+      expect(card._zoom.periodicZoomChange).toBe(true);
     });
 
-    it("is true when configured as true", () => {
+    it("is false when configured as false", () => {
       const card = document.createElement("ha-planetary-solar-system-card-test");
-      card.setConfig({ periodic_zoom_change: true });
-      expect(card._zoom.periodicZoomChange).toBe(true);
+      card.setConfig({ periodic_zoom_change: false });
+      expect(card._zoom.periodicZoomChange).toBe(false);
     });
   });
 

--- a/test/card/card.test.ts
+++ b/test/card/card.test.ts
@@ -182,7 +182,7 @@ describe("SolarViewCard", () => {
   it("getStubConfig returns default config with all options", () => {
     expect(SolarViewCard.getStubConfig()).toEqual({
       default_zoom: 2,
-      periodic_zoom_change: false,
+      periodic_zoom_change: true,
       periodic_zoom_max: 4,
       refresh_mins: 1,
       zoom_animate: true,


### PR DESCRIPTION
## Summary
- `periodic_zoom_change` now defaults to `true` (opt-out via `false`) instead of `false` (opt-in via `true`) — auto-cycling zoom is the more discoverable out-of-box experience
- Updated the visual-editor stub config, README table default, and README's usage examples (trimmed to 2, per follow-up request)
- Updated all tests asserting the old default

## Test plan
- [x] `npm run test:coverage` — 100% across all four metrics
- [x] `npm run check:ci` — typecheck/lint/format clean
- [x] `/ponytail-review` — lean, no cuts found

🤖 Generated with [Claude Code](https://claude.com/claude-code)