### PR TITLE
chore: upgrade ha-card-shared to v2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@rollup/plugin-terser": "^1.0.0",
         "@rollup/plugin-typescript": "^12.3.0",
         "@vitest/coverage-v8": "^4.1.11",
-        "ha-card-shared": "github:marcintk/ha-card-shared#v2.0.0",
+        "ha-card-shared": "github:marcintk/ha-card-shared#v2.0.1",
         "jsdom": "^30.0.1",
         "playwright": "^1.62.1",
         "prettier": "^3.9.6",
@@ -1749,8 +1749,8 @@
       }
     },
     "node_modules/ha-card-shared": {
-      "version": "2.0.0",
-      "resolved": "git+ssh://git@github.com/marcintk/ha-card-shared.git#3aa026356b454771e7da0c442c9a2cc9ccc8ffea",
+      "version": "2.0.1",
+      "resolved": "git+ssh://git@github.com/marcintk/ha-card-shared.git#b3cc56e83600d15b508994f44d7dc580133f2bf0",
       "dev": true,
       "hasInstallScript": true,
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@rollup/plugin-terser": "^1.0.0",
     "@rollup/plugin-typescript": "^12.3.0",
     "@vitest/coverage-v8": "^4.1.11",
-    "ha-card-shared": "github:marcintk/ha-card-shared#v2.0.0",
+    "ha-card-shared": "github:marcintk/ha-card-shared#v2.0.1",
     "jsdom": "^30.0.1",
     "playwright": "^1.62.1",
     "prettier": "^3.9.6",
@@ -47,6 +47,6 @@
     "lit": "^3.3.3"
   },
   "allowScripts": {
-    "github:marcintk/ha-card-shared#3aa026356b454771e7da0c442c9a2cc9ccc8ffea": true
+    "github:marcintk/ha-card-shared#b3cc56e83600d15b508994f44d7dc580133f2bf0": true
   }
 }


### PR DESCRIPTION
Bumps the `ha-card-shared` dev dependency from v2.0.0 to v2.0.1 and updates the `allowScripts` entry to the new tag SHA.

Build, full test suite (1244 tests), and `check:ci` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)