### PR TITLE
ci: pin workflows to ha-card-shared v2.0.1

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: marcintk/ha-card-shared/.github/workflows/shared-build-and-test.yml@v2.0.0
+    uses: marcintk/ha-card-shared/.github/workflows/shared-build-and-test.yml@v2.0.1
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/hacs-validation.yml
+++ b/.github/workflows/hacs-validation.yml
@@ -11,4 +11,4 @@ on:
 jobs:
   validate:
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
-    uses: marcintk/ha-card-shared/.github/workflows/shared-hacs-validation.yml@v2.0.0
+    uses: marcintk/ha-card-shared/.github/workflows/shared-hacs-validation.yml@v2.0.1

--- a/.github/workflows/migration-check.yml
+++ b/.github/workflows/migration-check.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   check:
-    uses: marcintk/ha-card-shared/.github/workflows/shared-migration-check.yml@v2.0.0
+    uses: marcintk/ha-card-shared/.github/workflows/shared-migration-check.yml@v2.0.1

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   release:
-    uses: marcintk/ha-card-shared/.github/workflows/shared-publish-release.yml@v2.0.0
+    uses: marcintk/ha-card-shared/.github/workflows/shared-publish-release.yml@v2.0.1
     permissions:
       contents: write


### PR DESCRIPTION
The v2.0.1 dependency bump (e5ac0e6) updated `package.json` but left
`.github/workflows/*.yml` pointing at the v2.0.0 shared workflows.

- build-and-test.yml
- hacs-validation.yml
- migration-check.yml
- publish-release.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)