### PR TITLE
Ping-pong the periodic zoom auto-cycle and soften its easing

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -17,8 +17,8 @@ index.
   multi-rung jump, the exact lurch the ping-pong was meant to remove.
 - **Guardrail:** `ZoomController.advancePeriodic()` keeps a `_periodicDirection: 1 | -1` and moves
   **±1 from the actual current `_zoomLevel`**, flipping direction only when the next step would
-  overshoot an endpoint. Any external mutation of the level (or the bounds) just means the next
-  step eases one rung from wherever it now is; it self-corrects back into range without a jump.
+  overshoot an endpoint. Any external mutation of the level (or the bounds) just means the next step
+  eases one rung from wherever it now is; it self-corrects back into range without a jump.
   `test/card/zoom-controller.test.ts` — "steps one rung back into range after a config edit strands
   the level past the max" pins this; it's the assertion that distinguishes this approach from the
   stateless one. Rule: a bounded cycle that reverses at its ends is driven relative to its current

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -6,6 +6,26 @@ index.
 
 <!-- ponytail: single file; split by area if it outgrows one screen-scroll -->
 
+## A periodic / ping-pong animation cycle jumps several steps after a config change
+
+- **Root cause:** #222 turned the zoom auto-cycle from a wrap (`1→2→3→4→1`) into a ping-pong
+  (`1→2→3→4→3→2→1`). The tempting implementation is stateless — a step counter fed through a
+  triangle wave, or `next = f(counter, min, max)`. But the cycle's bounds are live config
+  (`default_zoom`, `periodic_zoom_max`, both editable from the Lovelace editor mid-run), and a
+  counter is blind to where the view actually sits. Lower `periodic_zoom_max` from 4 to 2 while the
+  cycle is parked at rung 4 and the next tick recomputes `f(counter, …)` to some far rung — a
+  multi-rung jump, the exact lurch the ping-pong was meant to remove.
+- **Guardrail:** `ZoomController.advancePeriodic()` keeps a `_periodicDirection: 1 | -1` and moves
+  **±1 from the actual current `_zoomLevel`**, flipping direction only when the next step would
+  overshoot an endpoint. Any external mutation of the level (or the bounds) just means the next
+  step eases one rung from wherever it now is; it self-corrects back into range without a jump.
+  `test/card/zoom-controller.test.ts` — "steps one rung back into range after a config edit strands
+  the level past the max" pins this; it's the assertion that distinguishes this approach from the
+  stateless one. Rule: a bounded cycle that reverses at its ends is driven relative to its current
+  state, never recomputed from an absolute counter.
+- **Ref:** [#222](https://github.com/marcintk/ha-planetary-solar-system-card/issues/222) ·
+  2026-09-07
+
 ## "Looks round" can't be separated from "looks lit" with an SVG gradient overlay — bake the sphere
 
 - **Root cause:** #199's `display: 3d` tried to make a flat disc read as a 3-D planet with a

--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ gallery:
 
 ### Zoom
 
-| Option                 | Type    | Default | Description                                                             |
-| ---------------------- | ------- | ------- | ----------------------------------------------------------------------- |
-| `default_zoom`         | number  | `1`     | Starting zoom level, and the level the **Now** button returns to        |
-| `zoom_animate`         | boolean | `true`  | Animate zoom transitions                                                |
-| `periodic_zoom_change` | boolean | `true`  | Cycle zoom levels on each refresh tick, until you aim the view yourself |
-| `periodic_zoom_max`    | number  | `4`     | Maximum zoom level for auto-cycle (2–4)                                 |
+| Option                 | Type    | Default | Description                                                                    |
+| ---------------------- | ------- | ------- | ------------------------------------------------------------------------------ |
+| `default_zoom`         | number  | `1`     | Starting zoom level, and the level the **Now** button returns to               |
+| `zoom_animate`         | boolean | `true`  | Animate zoom transitions                                                       |
+| `periodic_zoom_change` | boolean | `true`  | Cycle zoom levels on each refresh tick, until you aim the view yourself        |
+| `periodic_zoom_max`    | number  | `4`     | Far end of the auto-cycle; it ping-pongs between `default_zoom` and this (2–4) |
 
 ### Appearance
 

--- a/docs/design-notes/README.md
+++ b/docs/design-notes/README.md
@@ -45,5 +45,6 @@ has a rendered URL — link to that, since GitHub shows `.html` as source, not r
   with a ping-pong between `default_zoom` (near) and `periodic_zoom_max` (far) — `1→2→3→4→3→2→1→2…`,
   one rung per tick, a stored `_periodicDirection` that flips at each end and resets outward on
   "Now"; `default_zoom >= periodic_zoom_max` holds still. Plus `easeInOutCubic → easeInOutSine` in
-  `zoom-animator.ts` (no velocity spike), duration and 60 s cadence unchanged. Explain-diff `—` · PR
-  `—`.
+  `zoom-animator.ts` (no velocity spike), duration and 60 s cadence unchanged.
+  [Explain-diff](https://marcintk.github.io/ha-planetary-solar-system-card/design-notes/issue-222-explain-diff.html)
+  · [PR #223](https://github.com/marcintk/ha-planetary-solar-system-card/pull/223).

--- a/docs/design-notes/README.md
+++ b/docs/design-notes/README.md
@@ -38,3 +38,12 @@ has a rendered URL — link to that, since GitHub shows `.html` as source, not r
   stale gradient wording in `src/types.ts` and `README.md`.
   [Explain-diff](https://marcintk.github.io/ha-planetary-solar-system-card/design-notes/issue-211-explain-diff.html)
   · [PR #212](https://github.com/marcintk/ha-planetary-solar-system-card/pull/212).
+- [Ping-pong the zoom auto-cycle](https://marcintk.github.io/ha-planetary-solar-system-card/design-notes/issue-222-zoom-cycle-pingpong.html)
+  — _approved_ ([#222](https://github.com/marcintk/ha-planetary-solar-system-card/issues/222)) — the
+  periodic zoom cycle steps `1→2→3→4` then hard-snaps back to `1` (one 2 s tween over three ladder
+  rungs, never revisiting `default_zoom`). Replace the wrap in `ZoomController.advancePeriodic()`
+  with a ping-pong between `default_zoom` (near) and `periodic_zoom_max` (far) — `1→2→3→4→3→2→1→2…`,
+  one rung per tick, a stored `_periodicDirection` that flips at each end and resets outward on
+  "Now"; `default_zoom >= periodic_zoom_max` holds still. Plus `easeInOutCubic → easeInOutSine` in
+  `zoom-animator.ts` (no velocity spike), duration and 60 s cadence unchanged. Explain-diff `—` · PR
+  `—`.

--- a/docs/design-notes/issue-222-explain-diff.html
+++ b/docs/design-notes/issue-222-explain-diff.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Ping-pong the zoom auto-cycle</title>
+<style>
+  :root {
+    --bg: #fafaf8; --fg: #1a1a1a; --accent: #b5541f; --muted: #6b6b6b;
+    --code-bg: #282c34; --code-fg: #e6e6e6; --callout-bg: #fff4e8; --border: #e0ddd6;
+  }
+  body { font-family: Georgia, 'Times New Roman', serif; background: var(--bg); color: var(--fg);
+    max-width: 820px; margin: 0 auto; padding: 2rem 1.5rem 6rem; line-height: 1.65; }
+  h1 { font-size: 1.9rem; border-bottom: 3px solid var(--accent); padding-bottom: .5rem; }
+  h2 { font-size: 1.4rem; margin-top: 3rem; color: var(--accent); }
+  h3 { font-size: 1.1rem; margin-top: 1.8rem; }
+  code { font-family: 'SF Mono', Consolas, monospace; background: #eee; padding: .1rem .3rem;
+    border-radius: 3px; font-size: .92em; }
+  pre { background: var(--code-bg); color: var(--code-fg); padding: 1rem 1.2rem; border-radius: 8px;
+    overflow-x: auto; white-space: pre-wrap; font-family: 'SF Mono', Consolas, monospace;
+    font-size: .88rem; line-height: 1.5; }
+  pre code { background: none; padding: 0; color: inherit; }
+  .callout { background: var(--callout-bg); border-left: 4px solid var(--accent); padding: .9rem 1.2rem;
+    border-radius: 0 6px 6px 0; margin: 1.2rem 0; }
+  .toc { background: #fff; border: 1px solid var(--border); border-radius: 8px; padding: 1rem 1.5rem; margin: 1.5rem 0; }
+  .toc a { color: var(--accent); text-decoration: none; }
+  .toc ul { margin: .3rem 0; }
+  .diagram { background: #fff; border: 1px solid var(--border); border-radius: 10px; padding: 1.2rem;
+    margin: 1.2rem 0; font-family: 'SF Mono', Consolas, monospace; font-size: .85rem; }
+  .flow { display: flex; align-items: center; gap: .6rem; flex-wrap: wrap; justify-content: center; padding: .5rem 0; }
+  .box { border: 2px solid var(--accent); border-radius: 8px; padding: .6rem 1rem; background: #fdf6ee;
+    text-align: center; min-width: 120px; }
+  .box.fail { border-color: #b91c1c; background: #fef2f2; }
+  .arrow { font-size: 1.4rem; color: var(--muted); }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; font-size: .92rem; }
+  th, td { border: 1px solid var(--border); padding: .5rem .7rem; text-align: left; }
+  th { background: #f0ede6; }
+  .quiz-q { background: #fff; border: 1px solid var(--border); border-radius: 10px;
+    padding: 1.2rem 1.5rem; margin: 1.2rem 0; }
+  .quiz-opt { display: block; width: 100%; text-align: left; padding: .6rem 1rem; margin: .4rem 0;
+    border: 1px solid var(--border); border-radius: 6px; background: #fff; cursor: pointer;
+    font-family: inherit; font-size: .95rem; }
+  .quiz-opt:hover { background: #f5f2ec; }
+  .quiz-opt:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  .feedback { display: none; margin-top: .6rem; padding: .6rem 1rem; border-radius: 6px; font-size: .9rem; }
+  .feedback.correct { background: #ecfdf3; color: #166534; border-left: 3px solid #16a34a; }
+  .feedback.incorrect { background: #fef2f2; color: #991b1b; border-left: 3px solid #dc2626; }
+  @media (max-width: 600px) { body { padding: 1rem; } .flow { flex-direction: column; } }
+</style>
+</head>
+<body>
+
+<h1>Ping-pong the zoom auto-cycle</h1>
+<p style="color:var(--muted); margin-top:-.5rem;">Prepared 2026-09-07 · PR #223</p>
+
+<div class="toc">
+<strong>Contents</strong>
+<ul>
+  <li><a href="#background">Background</a></li>
+  <li><a href="#intuition">The idea</a></li>
+  <li><a href="#code">The code</a></li>
+  <li><a href="#quiz">Quiz</a></li>
+</ul>
+</div>
+
+<h2 id="background">Background</h2>
+<p>The card renders the solar system into one SVG element, and it never redraws that SVG to zoom. Zooming is a <code>viewBox</code> swap: the SVG keeps all its coordinates, and the browser just decides how much of that coordinate space to fit on screen. A smaller <code>viewBox</code> width shows less of the scene, larger, so it reads as zoomed in.</p><p>There is a fixed ladder of four zoom rungs, defined in <code>src/card/zoom-levels.ts</code> as the <code>viewBox</code> width each one shows:</p><table><tr><th>rung</th><th>1</th><th>2</th><th>3</th><th>4</th></tr><tr><td>width</td><td>800</td><td>640</td><td>480</td><td>320</td></tr></table><p>The rungs are evenly spaced &mdash; 160 units apart &mdash; so stepping between two adjacent rungs is always the same visual distance. <code>ZoomController</code> owns which rung is current and animates the transition; <code>ZoomAnimator</code> is a tiny helper that eases a single number (the width) from one value to another over a fixed 2&nbsp;s, one <code>requestAnimationFrame</code> at a time.</p><p>Two config options drive an unattended slideshow of the zoom. <code>periodic_zoom_change</code> (on by default) tells the card to step the zoom once on every 60&nbsp;s refresh tick, until you touch the view yourself. <code>periodic_zoom_max</code> (default 4) is how far in it is allowed to go. <code>default_zoom</code> (default 1) is where the view starts and where the <strong>Now</strong> button returns it.</p><div class="callout"><strong>What was wrong.</strong> The cycle walked <code>1&nbsp;&rarr;&nbsp;2&nbsp;&rarr;&nbsp;3&nbsp;&rarr;&nbsp;4</code> and then, on the next tick, <em>snapped</em> straight back to rung&nbsp;1. That snap is a single 2&nbsp;s tween covering three rungs at once (width 320&nbsp;&rarr;&nbsp;800, 480 units) &mdash; so the reverse leg runs at three times the on-screen speed of every forward step, in the opposite direction. It is the one jarring moment in an otherwise calm drift. And it always returns to a hard-coded rung&nbsp;1, never to <code>default_zoom</code>: once the cycle takes the first step, the configured resting level is abandoned until you press Now.</p><p>Separately, the tween used a <em>cubic</em> ease-in-out. Cubic in/out barely moves for the first quarter of its duration, then accelerates hard through the middle and brakes hard at the end &mdash; a pronounced velocity spike. On a slow ambient move that reads as a lurch rather than a glide.</p>
+
+<h2 id="intuition">The idea</h2>
+<p>Instead of wrapping, <em>bounce</em>. When the cycle reaches an end of its travel, it turns around and walks back the way it came. Every step is then exactly one rung &mdash; one even 160-unit move &mdash; whether the cycle is heading in or heading out. There is no longer a special three-rung leg to run fast.</p><p>The two ends of the bounce are the two config values that already exist: <code>default_zoom</code> is the near end, <code>periodic_zoom_max</code> is the far end. With the defaults that is:</p><div class="diagram"><div class="flow"><div class="box">1</div><div class="arrow">&rarr;</div><div class="box">2</div><div class="arrow">&rarr;</div><div class="box">3</div><div class="arrow">&rarr;</div><div class="box">4</div><div class="arrow">&rarr;</div><div class="box">3</div><div class="arrow">&rarr;</div><div class="box">2</div><div class="arrow">&rarr;</div><div class="box">1</div><div class="arrow">&rarr;</div><div class="box">2&hellip;</div></div></div><p>A useful side effect: the cycle now passes back <em>through</em> <code>default_zoom</code> on every inward swing, which the old wrap never did once it left.</p><h3>Driving it from the real position, not a counter</h3><p>The tempting way to write a ping-pong is a step counter fed through a triangle wave &mdash; <code>level = f(tick_count, near, far)</code>. That would be a bug here. The two ends are <em>live config</em>: someone can edit <code>periodic_zoom_max</code> in the Lovelace editor while the cycle is running. A counter has no idea where the view actually sits, so if the max drops from 4 to 2 while the cycle is parked at rung 4, the next <code>f(&hellip;)</code> could jump the view several rungs at once &mdash; recreating exactly the lurch this change removes.</p><p>So the controller keeps a one-bit direction, <code>_periodicDirection</code> (<code>+1</code> out, <code>-1</code> in), and each tick moves <strong>&plusmn;1 from wherever the zoom currently is</strong>, flipping the direction first if that step would carry it past an end. Whatever state the level is in when the tick fires &mdash; stranded past the max by a config edit, left mid-ladder before Now &mdash; the next move is always a single rung, and the cycle self-corrects back into range without a jump.</p><table><tr><th>situation</th><th>next step</th></tr><tr><td>at rung 3, heading out</td><td>&rarr; 4, then flips to heading in</td></tr><tr><td><code>periodic_zoom_max</code> lowered 4&rarr;2 while parked at rung 4</td><td>&rarr; 3 &rarr; 2 &rarr; 3&hellip; one rung per tick, no jump</td></tr><tr><td><code>default_zoom</code> == <code>periodic_zoom_max</code> (ends coincide)</td><td>hold still &mdash; nowhere to cycle</td></tr><tr><td>after Now</td><td>direction reset to out, next step heads away from <code>default_zoom</code></td></tr></table><h3>And a gentler curve</h3><p>The tween swaps its cubic ease for a <em>sine</em> ease-in-out. The two curves agree exactly at the start, the midpoint and the end; in between, sine is the gentlest standard in/out shape &mdash; it leaves the mark smoothly and settles onto the target smoothly, with no mid-move speed-up. At a quarter of the way through a rung, cubic has covered 6.25% of the distance and is about to lunge; sine has covered 14.6% and is already coasting. Same 2&nbsp;s duration, same endpoints.</p>
+
+<h2 id="code">The code</h2>
+<p>Two source files, one small commit each.</p><h3><code>src/card/zoom-controller.ts</code> &mdash; the ping-pong</h3><p>A new field <code>private _periodicDirection: 1 | -1</code>, initialised to <code>1</code> in the constructor. <code>advancePeriodic()</code> &mdash; the method the 60&nbsp;s tick calls &mdash; is rewritten:</p><pre><code>const near = this._defaultZoomLevel;
+const far = this._periodicZoomMax;
+if (near &gt;= far) return;              // ends coincide: hold still
+let dir = this._periodicDirection;
+if (this._zoomLevel + dir &gt; far) dir = -1;
+else if (this._zoomLevel + dir &lt; near) dir = 1;
+this._periodicDirection = dir;
+this._setZoomLevel(this._zoomLevel + dir);</code></pre><p>The old body was a single line: <code>const next = this._zoomLevel &gt;= this._periodicZoomMax ? MIN_ZOOM : this._zoomLevel + 1</code>. The <code>near &gt;= far</code> guard returns before any side effect &mdash; no animation, no re-render &mdash; so a misconfigured card that sets <code>default_zoom</code> to the max simply sits still instead of eating a spurious tween every minute. <code>_setZoomLevel</code> still clamps its argument to the 1&ndash;4 ladder, so a redundant <code>as ZoomLevel</code> cast on the old line was dropped by the review's <code>/simplify</code> pass.</p><p><code>resetToDefault()</code> (the Now button) gains one line, <code>this._periodicDirection = 1</code>, so a resumed cycle heads outward from <code>default_zoom</code>. This line is belt-and-braces: if it were missing, the flip rule would still set <code>dir = 1</code> on the next tick, because the view is sitting at <code>near</code> and <code>near - 1 &lt; near</code>. It is kept as an explicit statement of the intended invariant.</p><h3><code>src/card/zoom-animator.ts</code> &mdash; the curve</h3><p>The private helper <code>easeInOutCubic(t)</code> becomes <code>easeInOutSine(t)</code>, body <code>-(Math.cos(Math.PI * t) - 1) / 2</code>, and the one call site inside <code>animateTo</code>'s frame step is updated. <code>ZOOM_ANIMATE_DURATION_MS</code> stays <code>2000</code>. Nothing else in the animator changes &mdash; it still tweens one number over a fixed duration, frame by frame.</p><h3>Tests</h3><p>In <code>zoom-controller.test.ts</code>, the test that pinned the old wrap now asserts the full ping-pong sequence <code>[2, 3, 2, 1, 2, 3]</code> from six <code>advancePeriodic()</code> calls, and a new test drives the config-edit-strands-the-level case &mdash; the one that distinguishes this design from a counter-based one. Three card-level tests in <code>card.auto-zoom.test.ts</code> that asserted the <code>&rarr; 1</code> snap were migrated to the turnaround behaviour and the <code>near&nbsp;&ge;&nbsp;far</code> hold. <code>zoom-animator.test.ts</code> gains one assertion: at a quarter of the tween the eased width is past where cubic would leave it. Coverage stays at 100%.</p>
+
+<h2 id="quiz">Quiz</h2>
+
+<div class="quiz-q">
+<p><strong>Why does the reverse leg of the old wrap-around cycle look faster than a forward step?</strong></p>
+<button class="quiz-opt" data-correct="true">It covers three ladder rungs (width 320 → 800) in the same fixed 2 s a one-rung step gets.</button>
+<button class="quiz-opt" data-correct="false">The cubic ease speeds up when the width increases.</button>
+<button class="quiz-opt" data-correct="false">It skips the easing and jumps straight to rung 1.</button>
+<button class="quiz-opt" data-correct="false">The animator shortens its duration for the return trip.</button>
+</div>
+
+<div class="quiz-q">
+<p><strong>What are the two turning points of the new ping-pong?</strong></p>
+<button class="quiz-opt" data-correct="false">`periodic_zoom_max` and whatever rung the user last set by hand.</button>
+<button class="quiz-opt" data-correct="false">`default_zoom` and rung 4.</button>
+<button class="quiz-opt" data-correct="true">`default_zoom` (near) and `periodic_zoom_max` (far).</button>
+<button class="quiz-opt" data-correct="false">Always rung 1 and rung 4, the ends of the fixed ladder.</button>
+</div>
+
+<div class="quiz-q">
+<p><strong>Why is the cycle driven by `±1 from the current level` rather than a step counter through a triangle wave?</strong></p>
+<button class="quiz-opt" data-correct="false">A counter would use more memory than a single direction bit.</button>
+<button class="quiz-opt" data-correct="false">A triangle wave cannot express an even number of rungs.</button>
+<button class="quiz-opt" data-correct="false">requestAnimationFrame cannot be driven from a counter.</button>
+<button class="quiz-opt" data-correct="true">The endpoints are live config; a counter is blind to the actual level, so a mid-run `periodic_zoom_max` edit could make it jump several rungs at once.</button>
+</div>
+
+<div class="quiz-q">
+<p><strong>With `default_zoom: 4` and the default `periodic_zoom_max: 4`, what does the auto-cycle do?</strong></p>
+<button class="quiz-opt" data-correct="false">Falls back to wrapping 4 → 1 → 2 → 3.</button>
+<button class="quiz-opt" data-correct="false">Bounces between rung 3 and rung 4.</button>
+<button class="quiz-opt" data-correct="true">Holds still — the `near &gt;= far` guard returns before any state change.</button>
+<button class="quiz-opt" data-correct="false">Throws a config validation error.</button>
+</div>
+
+<div class="quiz-q">
+<p><strong>How do the cubic and sine ease-in-out curves compare?</strong></p>
+<button class="quiz-opt" data-correct="false">They are identical; only the function name changed.</button>
+<button class="quiz-opt" data-correct="false">Sine finishes faster, so the tween duration was shortened to compensate.</button>
+<button class="quiz-opt" data-correct="false">Sine starts faster and ends slower than cubic.</button>
+<button class="quiz-opt" data-correct="true">They agree at t = 0, 0.5 and 1; between those points sine is gentler, with no mid-move velocity spike.</button>
+</div>
+
+<script>
+document.querySelectorAll('.quiz-q').forEach(q => {
+  q.querySelectorAll('.quiz-opt').forEach(opt => {
+    opt.addEventListener('click', () => {
+      if (opt.disabled) return;
+      q.querySelectorAll('.quiz-opt').forEach(b => { b.disabled = true; });
+      const correct = opt.dataset.correct === 'true';
+      const fb = document.createElement('div');
+      fb.className = 'feedback ' + (correct ? 'correct' : 'incorrect');
+      fb.textContent = correct
+        ? '✅ Correct.'
+        : '❌ Not quite — reread the section above.';
+      opt.insertAdjacentElement('afterend', fb);
+      fb.style.display = 'block';
+    });
+  });
+});
+</script>
+
+</body>
+</html>

--- a/docs/design-notes/issue-222-zoom-cycle-pingpong.html
+++ b/docs/design-notes/issue-222-zoom-cycle-pingpong.html
@@ -1,0 +1,495 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Ping-pong the zoom auto-cycle</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,ital@9..144,300..700,0..1&family=Source+Serif+4:opsz,wght@8..60,400;8..60,600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --paper: #eceef4;
+    --paper-raised: #ffffff;
+    --ink: #171b2b;
+    --ink-soft: #565d78;
+    --ink-faint: #888ea8;
+    --line: #d2d7e3;
+    --accent: #b3801f;
+    --accent-soft: #ecdaa8;
+    --cool: #3f6cae;
+    --ok: #1f7a4d;
+    --warn-bg: #fbf3e0;
+    --warn-line: #e0c078;
+    --shadow: 0 1px 2px rgba(23,27,43,0.06), 0 8px 24px rgba(23,27,43,0.05);
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --paper: #0e1017;
+      --paper-raised: #161925;
+      --ink: #eceef4;
+      --ink-soft: #a6abc1;
+      --ink-faint: #6b718e;
+      --line: #282c3c;
+      --accent: #e0b256;
+      --accent-soft: #40361f;
+      --cool: #89a6dc;
+      --ok: #5cc48c;
+      --warn-bg: #2c2416;
+      --warn-line: #665328;
+      --shadow: 0 1px 2px rgba(0,0,0,0.4), 0 12px 32px rgba(0,0,0,0.35);
+    }
+  }
+  :root[data-theme="dark"] {
+    --paper: #0e1017;
+    --paper-raised: #161925;
+    --ink: #eceef4;
+    --ink-soft: #a6abc1;
+    --ink-faint: #6b718e;
+    --line: #282c3c;
+    --accent: #e0b256;
+    --accent-soft: #40361f;
+    --cool: #89a6dc;
+    --ok: #5cc48c;
+    --warn-bg: #2c2416;
+    --warn-line: #665328;
+    --shadow: 0 1px 2px rgba(0,0,0,0.4), 0 12px 32px rgba(0,0,0,0.35);
+  }
+
+  * { box-sizing: border-box; }
+  body {
+    background: var(--paper);
+    color: var(--ink);
+    font-family: "Source Serif 4", Georgia, "Times New Roman", serif;
+    font-size: 16px;
+    line-height: 1.6;
+    padding: 4.5rem 1.5rem 6rem;
+    margin: 0;
+    -webkit-font-smoothing: antialiased;
+  }
+  .page { max-width: 880px; margin: 0 auto; }
+  .eyebrow {
+    font-family: "JetBrains Mono", monospace;
+    font-size: 0.72rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin: 0 0 0.9rem;
+  }
+  h1 {
+    font-family: "Fraunces", Georgia, serif;
+    font-weight: 600;
+    font-size: clamp(2rem, 5vw, 2.9rem);
+    line-height: 1.06;
+    letter-spacing: -0.01em;
+    text-wrap: balance;
+    margin: 0 0 1rem;
+  }
+  h2 {
+    font-family: "Fraunces", Georgia, serif;
+    font-weight: 600;
+    font-size: 1.5rem;
+    margin: 3.5rem 0 1rem;
+    padding-top: 1.6rem;
+    border-top: 1px solid var(--line);
+    text-wrap: balance;
+  }
+  h3 {
+    font-family: "Fraunces", Georgia, serif;
+    font-weight: 600;
+    font-size: 1.13rem;
+    margin: 2rem 0 0.6rem;
+  }
+  p { margin: 0 0 1rem; }
+  a { color: var(--accent); text-underline-offset: 2px; }
+  .lede { font-size: 1.16rem; color: var(--ink-soft); margin-bottom: 1.6rem; text-wrap: pretty; }
+  .meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1.4rem;
+    font-family: "JetBrains Mono", monospace;
+    font-size: 0.76rem;
+    color: var(--ink-faint);
+    margin-bottom: 2.4rem;
+  }
+  .badge {
+    display: inline-block;
+    font-family: "JetBrains Mono", monospace;
+    font-size: 0.7rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    padding: 0.28rem 0.66rem;
+    border-radius: 999px;
+    background: var(--accent-soft);
+    color: var(--accent);
+    border: 1px solid var(--warn-line);
+  }
+  ul, ol { margin: 0 0 1rem; padding-left: 1.3rem; }
+  li { margin-bottom: 0.45rem; }
+  code {
+    font-family: "JetBrains Mono", monospace;
+    font-size: 0.86em;
+    background: var(--accent-soft);
+    color: inherit;
+    padding: 0.1em 0.36em;
+    border-radius: 4px;
+  }
+  pre {
+    background: var(--paper-raised);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 1rem 1.15rem;
+    overflow-x: auto;
+    box-shadow: var(--shadow);
+    margin: 0 0 1.4rem;
+  }
+  pre code { background: none; padding: 0; font-size: 0.82rem; line-height: 1.55; }
+  pre .add { color: var(--ok); }
+  pre .del { color: #b3402f; }
+  :root:not([data-theme="light"]) pre .del { color: #e08a7a; }
+  @media (prefers-color-scheme: dark) { :root:not([data-theme="light"]) pre .del { color: #e08a7a; } }
+  pre .dim { color: var(--ink-faint); }
+  table { width: 100%; border-collapse: collapse; margin: 0 0 1.6rem; font-size: 0.92rem; }
+  th, td { text-align: left; padding: 0.6rem 0.8rem; border-bottom: 1px solid var(--line); vertical-align: top; }
+  th {
+    font-family: "JetBrains Mono", monospace;
+    font-size: 0.68rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+  }
+  td:first-child { white-space: nowrap; font-family: "JetBrains Mono", monospace; font-size: 0.82rem; }
+  .verdict {
+    border-left: 3px solid var(--accent);
+    padding: 0.4rem 0 0.4rem 1.1rem;
+    margin: 1.4rem 0;
+    font-size: 1.03rem;
+  }
+  .callout {
+    background: var(--warn-bg);
+    border: 1px solid var(--warn-line);
+    border-left-width: 3px;
+    border-radius: 6px;
+    padding: 0.9rem 1.15rem;
+    margin: 0 0 1.4rem;
+    font-size: 0.95rem;
+  }
+  .callout strong { color: var(--accent); }
+  .demo {
+    background: radial-gradient(120% 120% at 50% 40%, #1d2740 0%, #10141f 60%, #0b0e16 100%);
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    padding: 1.4rem 1.2rem 1rem;
+    margin: 0 0 1rem;
+    box-shadow: var(--shadow);
+  }
+  .demo svg { width: 100%; height: auto; display: block; }
+  .demo .cap {
+    font-family: "JetBrains Mono", monospace;
+    font-size: 0.68rem;
+    line-height: 1.5;
+    color: #aeb9c8;
+    margin-top: 0.7rem;
+  }
+  .demo .cap b { color: #fff; font-weight: 500; }
+  .seq {
+    font-family: "JetBrains Mono", monospace;
+    font-size: 0.95rem;
+    letter-spacing: 0.04em;
+  }
+  .seq .turn { color: var(--accent); font-weight: 500; }
+</style>
+</head>
+<body>
+<div class="page">
+  <p class="eyebrow">Issue #222 &middot; Design note</p>
+  <h1>Ping-pong the zoom auto-cycle</h1>
+  <p><span class="badge">approved</span></p>
+  <p class="lede">
+    The periodic zoom cycle steps one rung a minute to <code>periodic_zoom_max</code>, then
+    <em>snaps</em> straight back to level&nbsp;1 &mdash; one 2&nbsp;s tween covering three ladder
+    rungs at ~3&times; the speed of every other step, and it never revisits <code>default_zoom</code>
+    again. Make it a ping-pong that turns around at each end, and swap the easing curve for one that
+    doesn&rsquo;t lurch.
+  </p>
+  <p class="meta">
+    <span><a href="https://github.com/marcintk/ha-planetary-solar-system-card/issues/222">#222</a></span>
+    <span>2026-09-07</span>
+    <span>2 slices</span>
+  </p>
+
+  <h2>Problem</h2>
+  <p>
+    The auto-cycle lives in <code>ZoomController.advancePeriodic()</code>
+    (<code>src/card/zoom-controller.ts</code>). The card&rsquo;s 60&nbsp;s refresh timer
+    (<code>_refreshMs</code>, <code>src/card/card.ts</code>) calls <code>_zoom.tick()</code>, which
+    calls it while the cycle is on and the user hasn&rsquo;t taken the camera:
+  </p>
+  <pre><code>advancePeriodic(): void {
+  if (!this._initialized) return;
+  const fromWidth = this._size;
+  <span class="dim">// 1 &rarr; 2 &rarr; 3 &rarr; 4, then hard reset to 1</span>
+  const next = this._zoomLevel &gt;= this._periodicZoomMax ? MIN_ZOOM : this._zoomLevel + 1;
+  this._setZoomLevel(next as ZoomLevel);
+  this._apply(fromWidth);
+}</code></pre>
+  <p>
+    <code>_apply()</code> hands the width change to <code>ZoomAnimator.animateTo()</code>, which
+    tweens the on-screen viewBox width over <code>ZOOM_ANIMATE_DURATION_MS = 2000</code> with
+    <code>easeInOutCubic</code>. Two things read as unnatural:
+  </p>
+  <ul>
+    <li>
+      <strong>The snap-back.</strong> Every forward step moves one ladder rung
+      (widths <code>800&nbsp;&rarr;&nbsp;640&nbsp;&rarr;&nbsp;480&nbsp;&rarr;&nbsp;320</code>, an
+      even 160 units each) in 2&nbsp;s. The <code>4&nbsp;&rarr;&nbsp;1</code> reset moves
+      <em>three</em> rungs (<code>320&nbsp;&rarr;&nbsp;800</code>, 480 units) in the same 2&nbsp;s
+      &mdash; a lurching zoom-out at triple the speed of everything around it. And it abandons
+      <code>default_zoom</code> permanently after the very first step: the cycle only ever bounces
+      off hard-coded level&nbsp;1, never the level the card was configured to rest at.
+    </li>
+    <li>
+      <strong>The curve.</strong> <code>easeInOutCubic</code>
+      (<code>t&lt;.5 ? 4t&sup3; : 1-(-2t+2)&sup3;/2</code>) has a steep mid-move velocity spike
+      &mdash; it accelerates hard out of rest and brakes hard into the target. On a slow ambient
+      drift that reads as a shove, not a glide.
+    </li>
+  </ul>
+
+  <h2>The change</h2>
+  <p>
+    Bounce between two endpoints instead of wrapping:
+  </p>
+  <ul>
+    <li><strong>Near endpoint = <code>default_zoom</code></strong> (the controller already holds it
+      as <code>_defaultZoomLevel</code>). The cycle now passes back through the configured rest
+      level on every inward swing &mdash; the thing it never did before.</li>
+    <li><strong>Far endpoint = <code>periodic_zoom_max</code></strong>, unchanged meaning, no longer
+      a wrap point.</li>
+    <li>Default config (<code>default_zoom: 1</code>, <code>periodic_zoom_max: 4</code>):
+      <span class="seq">1 2 3 <span class="turn">4</span> 3 2 <span class="turn">1</span> 2 3 <span class="turn">4</span> &hellip;</span></li>
+    <li>Every step is exactly one rung, so the 2&nbsp;s tween is now a uniform visual speed in both
+      directions.</li>
+  </ul>
+  <p>
+    And in <code>zoom-animator.ts</code>, <code>easeInOutCubic</code> &rarr;
+    <code>easeInOutSine</code> (<code>-(cos(&pi;t)-1)/2</code>) &mdash; the gentlest standard
+    in/out curve, no velocity spike. Duration stays <code>2000</code>; the rAF frame loop is
+    untouched (it already renders at the display&rsquo;s native rate, so &ldquo;frames&rdquo;
+    needs no change). The 60&nbsp;s cadence and the uniform one-tick dwell on every rung are
+    unchanged.
+  </p>
+
+  <h2>Approach &mdash; designed twice</h2>
+  <h3>A. Stored direction on the controller <span style="color:var(--ok)">&larr; chosen</span></h3>
+  <p>
+    Add <code>_periodicDirection: 1 | -1</code> (init <code>1</code> = outward). Each tick, move
+    one rung the way we&rsquo;re going; if that would overshoot an endpoint, flip first:
+  </p>
+  <pre><code>advancePeriodic(): void {
+  if (!this._initialized) return;
+  const near = this._defaultZoomLevel;
+  const far = this._periodicZoomMax;
+  if (near &gt;= far) return;                       <span class="dim">// no room to cycle &mdash; hold still</span>
+  const fromWidth = this._size;
+  let dir = this._periodicDirection;
+  if (this._zoomLevel + dir &gt; far) dir = -1;
+  else if (this._zoomLevel + dir &lt; near) dir = 1;
+  this._periodicDirection = dir;
+  this._setZoomLevel((this._zoomLevel + dir) as ZoomLevel);
+  this._apply(fromWidth);
+}</code></pre>
+  <p>
+    <code>resetToDefault()</code> (the &ldquo;Now&rdquo; button) gains one line &mdash;
+    <code>this._periodicDirection = 1</code> &mdash; so a resumed cycle always heads outward from
+    <code>default_zoom</code>. The flip rule is self-correcting: whatever <code>_zoomLevel</code>
+    is when the tick fires (a config edit moved it, the user left it mid-ladder before Home), the
+    next move is always exactly &plusmn;1 rung from where the view actually sits.
+  </p>
+  <h3>B. Stateless triangle wave from a step counter</h3>
+  <p>
+    No direction field. Keep <code>_periodicStep</code>, increment it each tick, and map it through
+    a triangle wave of period <code>2&middot;(far&minus;near)</code> to get the level.
+    <code>resetToDefault()</code> zeroes the counter.
+  </p>
+  <pre><code>const span = far - near, phase = this._periodicStep++ % (2 * span);
+const level = near + (phase &lt;= span ? phase : 2 * span - phase);</code></pre>
+  <p>
+    Cleaner in the abstract &mdash; the turnaround is implicit, nothing to keep in sync. But the
+    wave is computed from an internal counter that is <em>blind to the actual <code>_zoomLevel</code></em>.
+    <code>configure()</code> mutates <code>_defaultZoomLevel</code> live from the Lovelace editor;
+    the next tick would then compute <code>triangle(newNear, far, step)</code> and jump the view
+    several rungs in one tween &mdash; reintroducing the exact multi-rung lurch this issue removes.
+  </p>
+  <div class="verdict">
+    <strong>A.</strong> The bug being fixed <em>is</em> a multi-rung jump. B&rsquo;s counter can
+    still produce one whenever anything else moves the zoom; A moves &plusmn;1 from the real
+    current rung every time, by construction. The cost is one boolean-ish field and a one-line
+    reset &mdash; cheap insurance against the failure mode we&rsquo;re here to kill.
+  </div>
+
+  <h2>What it looks like</h2>
+  <p>
+    Viewport width over time (one tick = 60&nbsp;s). Today&rsquo;s sawtooth vs. the ping-pong,
+    default config.
+  </p>
+  <div class="demo">
+    <svg viewBox="0 0 620 220" role="img" aria-label="Sawtooth versus triangle-wave zoom cycle">
+      <g font-family="'JetBrains Mono',monospace" font-size="10" fill="#7d8aa0">
+        <text x="0" y="14">rung 4 &mdash; zoomed in</text>
+        <text x="0" y="200">rung 1 &mdash; default</text>
+      </g>
+      <g stroke="#2a3346" stroke-width="1">
+        <line x1="40" y1="20" x2="600" y2="20"/>
+        <line x1="40" y1="80" x2="600" y2="80"/>
+        <line x1="40" y1="140" x2="600" y2="140"/>
+        <line x1="40" y1="200" x2="600" y2="200"/>
+      </g>
+      <!-- today: sawtooth 1-2-3-4 then snap to 1 -->
+      <polyline fill="none" stroke="#e08a7a" stroke-width="2" stroke-dasharray="4 3"
+        points="40,200 120,140 200,80 280,20 280,200 360,140 440,80 520,20 520,200 600,200"/>
+      <!-- new: triangle 1-2-3-4-3-2-1 -->
+      <polyline fill="none" stroke="#5cc48c" stroke-width="2.5"
+        points="40,200 120,140 200,80 280,20 360,80 440,140 520,200 600,140"/>
+    </svg>
+    <div class="cap">
+      <b style="color:#e08a7a">&mdash; &mdash;</b> today: three-rung snap-back every 4th tick &nbsp;&middot;&nbsp;
+      <b style="color:#5cc48c">&mdash;&mdash;</b> ping-pong: one rung per tick, turns at each end,
+      passes through <b>default</b> on every inward swing
+    </div>
+  </div>
+
+  <h2>Slices</h2>
+  <table>
+    <tr><th>#</th><th>Change</th><th>Red test</th></tr>
+    <tr>
+      <td>1&nbsp;&check;</td>
+      <td>
+        <strong>Shipped.</strong> Added <code>_periodicDirection: 1 | -1</code> (constructor init
+        <code>1</code>); rewrote <code>advancePeriodic()</code> per approach A &mdash; move
+        &plusmn;1 rung from the <em>actual</em> <code>_zoomLevel</code>, flip <code>dir</code>
+        before the write if it would overshoot <code>near</code>/<code>far</code>, and
+        <code>if (near &gt;= far) return</code> before any side effect. Added
+        <code>this._periodicDirection = 1</code> to <code>resetToDefault()</code>.
+        <code>tick()</code>, <code>_apply()</code>, the animator: untouched. Migrated the wrap
+        assertions in <code>zoom-controller.test.ts</code> (now the full <code>2 3 2 1 2 3</code>
+        ping-pong) and three <code>card.auto-zoom.test.ts</code> cases (turnaround at
+        <code>far</code>, inward swing, <code>near&nbsp;==&nbsp;far</code> holds still); added a
+        test for the reviewer&rsquo;s gap &mdash; a live <code>configure()</code> that strands the
+        level past a lowered <code>max</code> still steps one rung inward, not a jump.
+        <code>README.md</code> <code>periodic_zoom_max</code> row reworded. <code>/simplify</code>
+        dropped a redundant <code>as ZoomLevel</code> cast. Reviewer: no correctness bugs; suite
+        1663 green, <code>check:ci</code> clean. <em>Note: the <code>resetToDefault()</code>
+        direction line is provably dead &mdash; the flip rule re-derives <code>+1</code> at
+        <code>near</code> on the next tick regardless &mdash; kept as a documented invariant per
+        this note.</em>
+      </td>
+      <td>
+        <code>zoom-controller.test.ts</code> &gt; &ldquo;advancePeriodic ping-pongs between the
+        default and periodicZoomMax endpoints&rdquo; &mdash; <code>configure(1, true, 3, false)</code>
+        then six <code>advancePeriodic()</code> calls yield <code>[2, 3, 2, 1, 2, 3]</code> (was
+        <code>[2, 3, 1, 2, 3, 1]</code>). Diverges at call&nbsp;3, the far turnaround.
+      </td>
+    </tr>
+    <tr>
+      <td>2</td>
+      <td>
+        <strong>Soften the easing.</strong> In <code>zoom-animator.ts</code> rename
+        <code>easeInOutCubic</code> &rarr; <code>easeInOutSine</code>, body
+        <code>-(Math.cos(Math.PI * t) - 1) / 2</code>, update the call site and the function&rsquo;s
+        doc line. <code>ZOOM_ANIMATE_DURATION_MS</code> unchanged.
+      </td>
+      <td>
+        At quarter-duration (<code>flushFrame(500)</code> of the 2000&nbsp;ms tween,
+        <code>animateTo(800, 640, &hellip;)</code>) the eased width has progressed
+        <em>past</em> cubic&rsquo;s <code>4&middot;0.25&sup3; = 6.25%</code> &mdash;
+        <code>easeInOutSine(0.25) &approx; 14.6%</code>, so <code>width &lt; 790</code>
+        (cubic would still be <code>&gt; 790</code>). Pins the curve family, not just
+        &ldquo;monotonic between the endpoints&rdquo;.
+      </td>
+    </tr>
+  </table>
+
+  <h2>Test surface</h2>
+  <p>Breaks and must change (from recon):</p>
+  <table>
+    <tr><th>File</th><th>What moves</th></tr>
+    <tr>
+      <td>card/zoom-controller.test.ts</td>
+      <td><code>:107</code> &ldquo;advancePeriodic cycles up to periodicZoomMax then wraps to the
+        minimum&rdquo; &mdash; rewrite as a ping-pong: <code>configure(1,true,3,false)</code> then
+        <code>2 &rarr; 3 &rarr; 2 &rarr; 1 &rarr; 2</code>. <code>:244</code> &ldquo;resetToDefault
+        &hellip; lets the cycle resume&rdquo; still passes; add a direction-reset assertion. New
+        cases: bounce at the far end, bounce at the near end, <code>near &gt;= far</code> holds
+        still.</td>
+    </tr>
+    <tr>
+      <td>card/card.auto-zoom.test.ts</td>
+      <td><code>:53</code> &ldquo;wraps from MAX_ZOOM back to level 1&rdquo; (<code>default_zoom: 4</code>,
+        default <code>periodic_zoom_max: 4</code>) &mdash; that config is now <code>near == far</code>,
+        so it becomes &ldquo;holds at 4 when <code>default_zoom == periodic_zoom_max</code>&rdquo;.
+        <code>:91</code> &ldquo;Now button resumes &hellip;&rdquo; &mdash; still <code>1 &rarr; 2</code>
+        after Home, unchanged. Add a four-tick case asserting <code>1 2 3 4 3</code>.</td>
+    </tr>
+    <tr>
+      <td>card/zoom-animator.test.ts</td>
+      <td><code>:52</code> &ldquo;eases between the two widths&rdquo; checks the midpoint only
+        &mdash; both curves pass through <code>(0.5, 0.5)</code>, so it still passes untouched. The
+        new quarter-duration assertion (slice 2) is the curve tripwire.</td>
+    </tr>
+  </table>
+  <p>
+    Unaffected: everything that suspends the cycle on user takeover (<code>_userInteracted</code>
+    path, <code>tick()</code> no-ops after a manual zoom / drag), <code>isDefaultView</code> (still
+    returns <code>true</code> while the cycle owns the zoom, at any rung), the drag/pan math, the
+    snapshot suite (no SVG shape change).
+  </p>
+
+  <h2>Adjacent opportunities</h2>
+  <ul>
+    <li>
+      <strong>Folded in (docs).</strong> <code>README.md:72</code> &mdash;
+      <code>periodic_zoom_max</code> is described as &ldquo;Maximum zoom level for auto-cycle
+      (2&ndash;4)&rdquo;. Still accurate, but reword to say it&rsquo;s the far turnaround of a
+      ping-pong between it and <code>default_zoom</code>, not a wrap point. One-line doc edit in
+      slice&nbsp;1&rsquo;s PR.
+    </li>
+    <li>
+      <strong>Not folded in.</strong> <code>default_zoom</code> set to a rung &ge;
+      <code>periodic_zoom_max</code> now disables the cycle entirely (it can&rsquo;t
+      &ldquo;start zoomed in <em>and</em> cycle&rdquo; &mdash; the two endpoints would coincide).
+      Today that config gives a lopsided <code>4&rarr;1&rarr;2&rarr;3</code> loop. Accepted
+      trade-off (grill Q1); if anyone actually wants it, a separate
+      <code>periodic_zoom_min</code> key is the clean answer &mdash; own issue, not this one.
+    </li>
+    <li>
+      <strong>Not folded in.</strong> Exposing easing / duration as config keys &mdash; no demand,
+      and the point of this issue is a better <em>default</em> feel. Skip.
+    </li>
+    <li>
+      <strong>Enables.</strong> <a href="https://github.com/marcintk/ha-planetary-solar-system-card/issues/203">#203</a>
+      (realistic-distance orbit mode with fly-in/fly-out zoom) reuses the same
+      <code>ZoomAnimator</code>; a gentler shared curve is a free head start there. Not foreclosed,
+      not pulled forward.
+    </li>
+  </ul>
+
+  <h2>Design invariant preserved</h2>
+  <p>
+    The card still ships with the auto-cycle on (<code>periodic_zoom_change</code> default true),
+    still steps one rung per 60&nbsp;s refresh, still hands the camera back to the user on any zoom
+    / drag and resumes only on &ldquo;Now&rdquo;. The zoom ladder
+    (<code>ZOOM_LEVELS = {1:800, 2:640, 3:480, 4:320}</code>) and the
+    <code>MIN_ZOOM</code>/<code>MAX_ZOOM</code> clamp in <code>_setZoomLevel</code> are untouched.
+    The nav bar&rsquo;s AU-per-orbit labels, visibility cone, and back/forward date buttons are
+    unrelated and unchanged.
+  </p>
+  <div class="callout">
+    <strong>LESSONS.md.</strong> No prior entry for the zoom auto-cycle or the animation curve
+    &mdash; this is new ground. If anything transferable falls out of the build (most likely: the
+    &ldquo;move &plusmn;1 from the real position, don&rsquo;t recompute from a counter&rdquo; point
+    from approach A), <code>explain-it compound</code> logs it after slice&nbsp;1.
+  </div>
+</div>
+</body>
+</html>

--- a/docs/design-notes/issue-222-zoom-cycle-pingpong.html
+++ b/docs/design-notes/issue-222-zoom-cycle-pingpong.html
@@ -392,20 +392,23 @@ const level = near + (phase &lt;= span ? phase : 2 * span - phase);</code></pre>
       </td>
     </tr>
     <tr>
-      <td>2</td>
+      <td>2&nbsp;&check;</td>
       <td>
-        <strong>Soften the easing.</strong> In <code>zoom-animator.ts</code> rename
+        <strong>Shipped.</strong> <code>zoom-animator.ts</code>: renamed
         <code>easeInOutCubic</code> &rarr; <code>easeInOutSine</code>, body
-        <code>-(Math.cos(Math.PI * t) - 1) / 2</code>, update the call site and the function&rsquo;s
-        doc line. <code>ZOOM_ANIMATE_DURATION_MS</code> unchanged.
+        <code>-(Math.cos(Math.PI * t) - 1) / 2</code>, call site + doc comment updated.
+        <code>ZOOM_ANIMATE_DURATION_MS</code> stays <code>2000</code>; no logic change.
+        The existing midpoint ease test still passes untouched (both curves hit
+        <code>0.5</code> at <code>t = 0.5</code>). Suite 1664 green. Nothing to compound &mdash;
+        a curve-taste swap, no new failure class.
       </td>
       <td>
-        At quarter-duration (<code>flushFrame(500)</code> of the 2000&nbsp;ms tween,
-        <code>animateTo(800, 640, &hellip;)</code>) the eased width has progressed
-        <em>past</em> cubic&rsquo;s <code>4&middot;0.25&sup3; = 6.25%</code> &mdash;
-        <code>easeInOutSine(0.25) &approx; 14.6%</code>, so <code>width &lt; 790</code>
-        (cubic would still be <code>&gt; 790</code>). Pins the curve family, not just
-        &ldquo;monotonic between the endpoints&rdquo;.
+        <code>zoom-animator.test.ts</code> &gt; &ldquo;uses a sine ease-in-out, not cubic
+        (gentler start)&rdquo; &mdash; at quarter-duration (<code>flushFrame(500)</code> of the
+        2000&nbsp;ms tween, <code>animateTo(800, 640, &hellip;)</code>) the width is
+        <code>&lt; 785</code>: <code>easeInOutSine(0.25) &approx; 14.6%</code> &rarr; ~776.6,
+        where cubic&rsquo;s <code>6.25%</code> gave exactly 790. Pins the curve family, not just
+        monotonicity.
       </td>
     </tr>
   </table>

--- a/src/card/zoom-animator.ts
+++ b/src/card/zoom-animator.ts
@@ -34,7 +34,7 @@ export class ZoomAnimator {
       const elapsed = timestamp - startTime;
       const t = Math.min(elapsed / ZOOM_ANIMATE_DURATION_MS, 1);
 
-      onStep(fromWidth + (toWidth - fromWidth) * easeInOutCubic(t));
+      onStep(fromWidth + (toWidth - fromWidth) * easeInOutSine(t));
 
       if (t < 1) {
         this._animationId = requestAnimationFrame(step);
@@ -55,6 +55,8 @@ export class ZoomAnimator {
   }
 }
 
-function easeInOutCubic(t: number): number {
-  return t < 0.5 ? 4 * t * t * t : 1 - (-2 * t + 2) ** 3 / 2;
+// Sine ease-in-out: a real camera-dolly move that drifts off the mark and settles onto the
+// target, with none of the mid-move velocity spike a cubic curve pushes through.
+function easeInOutSine(t: number): number {
+  return -(Math.cos(Math.PI * t) - 1) / 2;
 }

--- a/src/card/zoom-controller.ts
+++ b/src/card/zoom-controller.ts
@@ -34,6 +34,10 @@ export class ZoomController {
   private _defaultZoomLevel: ZoomLevel;
   private _periodicZoomChange: boolean;
   private _periodicZoomMax: number;
+  // Which way the auto-cycle is currently walking the zoom: +1 out toward periodicZoomMax,
+  // -1 back toward default_zoom. Flips at each endpoint so the cycle ping-pongs rather than
+  // snapping back.
+  private _periodicDirection: 1 | -1;
   private _animate: boolean;
   private _userInteracted: boolean;
   private _onChange: () => void;
@@ -54,6 +58,7 @@ export class ZoomController {
     this._defaultZoomLevel = DEFAULT_ZOOM_LEVEL;
     this._periodicZoomChange = false;
     this._periodicZoomMax = MAX_ZOOM;
+    this._periodicDirection = 1;
     this._animate = false;
     this._userInteracted = false;
     this._onChange = onChange;
@@ -152,6 +157,8 @@ export class ZoomController {
    */
   resetToDefault(): void {
     this._userInteracted = false;
+    // A resumed cycle heads outward from the default again.
+    this._periodicDirection = 1;
     if (!this._initialized || this._zoomLevel === this._defaultZoomLevel) return;
     const fromWidth = this._size;
     this._setZoomLevel(this._defaultZoomLevel);
@@ -184,11 +191,19 @@ export class ZoomController {
     if (this._periodicZoomChange && !this._userInteracted) this.advancePeriodic();
   }
 
+  // Ping-pongs the zoom between default_zoom (near) and periodicZoomMax (far), reversing at
+  // each endpoint rather than snapping back to the near end.
   advancePeriodic(): void {
     if (!this._initialized) return;
+    const near = this._defaultZoomLevel;
+    const far = this._periodicZoomMax;
+    if (near >= far) return; // no room to cycle, hold still
     const fromWidth = this._size;
-    const next = this._zoomLevel >= this._periodicZoomMax ? MIN_ZOOM : this._zoomLevel + 1;
-    this._setZoomLevel(next as ZoomLevel);
+    let dir = this._periodicDirection;
+    if (this._zoomLevel + dir > far) dir = -1;
+    else if (this._zoomLevel + dir < near) dir = 1;
+    this._periodicDirection = dir;
+    this._setZoomLevel(this._zoomLevel + dir);
     this._apply(fromWidth);
   }
 

--- a/test/card/card.auto-zoom.test.ts
+++ b/test/card/card.auto-zoom.test.ts
@@ -50,14 +50,18 @@ describe("SolarViewCard auto_zoom", () => {
       card.remove();
     });
 
-    it("wraps from MAX_ZOOM back to level 1", () => {
+    it("holds still when default_zoom leaves no room to cycle", () => {
       vi.useFakeTimers();
       const card = document.createElement("ha-planetary-solar-system-card-test");
+      // default_zoom 4 == the default periodic_zoom_max 4: the two ping-pong
+      // endpoints coincide, so the cycle has nowhere to go.
       card.setConfig({ periodic_zoom_change: true, default_zoom: 4 });
       document.body.appendChild(card);
       expect(card._zoom.zoomLevel).toBe(4);
       vi.advanceTimersByTime(60000);
-      expect(card._zoom.zoomLevel).toBe(1);
+      expect(card._zoom.zoomLevel).toBe(4);
+      vi.advanceTimersByTime(60000);
+      expect(card._zoom.zoomLevel).toBe(4);
       card.remove();
     });
 
@@ -176,7 +180,7 @@ describe("SolarViewCard auto_zoom", () => {
       vi.useRealTimers();
     });
 
-    it("wraps at configured max level instead of MAX_ZOOM", () => {
+    it("turns around at the configured max level instead of MAX_ZOOM", () => {
       vi.useFakeTimers();
       const card = document.createElement("ha-planetary-solar-system-card-test");
       card.setConfig({ periodic_zoom_change: true, periodic_zoom_max: 3 });
@@ -187,11 +191,13 @@ describe("SolarViewCard auto_zoom", () => {
       vi.advanceTimersByTime(60000);
       expect(card._zoom.zoomLevel).toBe(3);
       vi.advanceTimersByTime(60000);
+      expect(card._zoom.zoomLevel).toBe(2);
+      vi.advanceTimersByTime(60000);
       expect(card._zoom.zoomLevel).toBe(1);
       card.remove();
     });
 
-    it("defaults to MAX_ZOOM (4) when periodic_zoom_max is not set", () => {
+    it("defaults the far endpoint to MAX_ZOOM (4) when periodic_zoom_max is not set", () => {
       vi.useFakeTimers();
       const card = document.createElement("ha-planetary-solar-system-card-test");
       card.setConfig({ periodic_zoom_change: true });
@@ -201,7 +207,7 @@ describe("SolarViewCard auto_zoom", () => {
       vi.advanceTimersByTime(60000);
       expect(card._zoom.zoomLevel).toBe(4);
       vi.advanceTimersByTime(60000);
-      expect(card._zoom.zoomLevel).toBe(1);
+      expect(card._zoom.zoomLevel).toBe(3);
       card.remove();
     });
 

--- a/test/card/zoom-animator.test.ts
+++ b/test/card/zoom-animator.test.ts
@@ -62,6 +62,19 @@ describe("ZoomAnimator", () => {
     expect(mid).toBeLessThan(800);
   });
 
+  it("uses a sine ease-in-out, not cubic (gentler start)", () => {
+    const animator = new ZoomAnimator();
+    const widths: number[] = [];
+    animator.animateTo(800, 640, (w) => widths.push(w));
+
+    flushFrame(0);
+    flushFrame(500); // quarter of the 2000ms duration
+    const quarter = widths.at(-1) as number;
+    // sine ease-in-out yields ~776.6 here; cubic yields 790.
+    expect(quarter).toBeLessThan(785);
+    expect(quarter).toBeGreaterThan(770);
+  });
+
   it("lands exactly on the target and stops", () => {
     const animator = new ZoomAnimator();
     const widths: number[] = [];

--- a/test/card/zoom-controller.test.ts
+++ b/test/card/zoom-controller.test.ts
@@ -104,7 +104,7 @@ describe("ZoomController zoom actions", () => {
     expect(onChange).toHaveBeenCalledTimes(2); // the no-op zoomOut doesn't notify
   });
 
-  it("advancePeriodic cycles up to periodicZoomMax then wraps to the minimum", () => {
+  it("advancePeriodic ping-pongs between the default and periodicZoomMax endpoints", () => {
     const zoom = new ZoomController(
       () => {},
       () => {}
@@ -112,12 +112,31 @@ describe("ZoomController zoom actions", () => {
     zoom.configure(1, true, 3, false);
     zoom.ensureInitialized();
 
+    const sequence: (number | null)[] = [];
+    for (let i = 0; i < 6; i++) {
+      zoom.advancePeriodic();
+      sequence.push(zoom.zoomLevel);
+    }
+    expect(sequence).toEqual([2, 3, 2, 1, 2, 3]);
+  });
+
+  it("advancePeriodic steps one rung back into range after a config edit strands the level past the max", () => {
+    const zoom = new ZoomController(
+      () => {},
+      () => {}
+    );
+    zoom.configure(1, true, 4, false);
+    zoom.ensureInitialized();
+    zoom.advancePeriodic();
+    zoom.advancePeriodic();
+    zoom.advancePeriodic();
+    expect(zoom.zoomLevel).toBe(4); // cycled out to the old max
+
+    zoom.configure(1, true, 2, false); // max lowered under the current level
+    zoom.advancePeriodic();
+    expect(zoom.zoomLevel).toBe(3); // one rung inward, not a jump to the new max
     zoom.advancePeriodic();
     expect(zoom.zoomLevel).toBe(2);
-    zoom.advancePeriodic();
-    expect(zoom.zoomLevel).toBe(3);
-    zoom.advancePeriodic();
-    expect(zoom.zoomLevel).toBe(1);
   });
 
   it("tick advances only when periodicZoomChange is enabled", () => {


### PR DESCRIPTION
## What

The periodic zoom auto-cycle (`periodic_zoom_change`) stepped `1→2→3→4` then snapped straight back to `1` — a single 2s tween across three ladder rungs at ~3× the on-screen speed of every forward step, and it abandoned `default_zoom` permanently after the first step.

**Slice 1** — `ZoomController.advancePeriodic()` now ping-pongs between `default_zoom` (near) and `periodic_zoom_max` (far): `1→2→3→4→3→2→1→2…`, one even rung per tick, turning around at each end. A stored `_periodicDirection` flips at the endpoints and resets outward on **Now**. Moving ±1 from the *actual* current level (not a counter) keeps a live `periodic_zoom_max` edit from jumping the view multiple rungs. `default_zoom >= periodic_zoom_max` holds still.

**Slice 2** — `zoom-animator.ts`: `easeInOutCubic` → `easeInOutSine`, so the tween leaves and settles gently instead of lurching through the middle. Duration (2000ms) and the 60s cadence are unchanged.

## Notes

- `README.md` `periodic_zoom_max` row reworded — it's the far turnaround now, not a wrap point.
- Three `card.auto-zoom.test.ts` cases migrated off the old snap-back; new `zoom-controller.test.ts` cases for the ping-pong sequence and the config-strands-the-level edge.
- Design note + explain-diff ship in the diff. LESSONS entry: *a bounded cycle that reverses at its ends is driven relative to its current state, never recomputed from an absolute counter.*
- Full suite 1664 pass, coverage 100%, `check:ci` clean.

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Siauu79TbnGhCfTi2iPESp