### PR TITLE
refactor(renderer): dedupe defs/shade helpers, drop dead code

### DIFF
--- a/docs/design-notes/issue-199-sphere-shading.html
+++ b/docs/design-notes/issue-199-sphere-shading.html
@@ -509,7 +509,9 @@
   <ul>
     <li><strong>Remove <code>sunwardHalfDiscPaths</code>.</strong> After slice 1 nothing in
       <code>src/</code> calls it. &rarr; cleanup issue: delete it and its tests, folding any
-      still-useful pole geometry into <code>terminatorShadowPath</code>.</li>
+      still-useful pole geometry into <code>terminatorShadowPath</code>.
+      <strong>Done</strong> &mdash; issue #224, the function and its <code>describe</code> block
+      deleted; no pole geometry needed folding in.</li>
     <li><strong>Specular blob for icy bodies.</strong> The per-body rotate
       <code>&lt;g&gt;</code> from slice 2 could later carry a small bright highlight blob.
       Noted, not built.</li>

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -1,6 +1,12 @@
 import type { TemplateResult } from "lit";
 import { html, LitElement, nothing } from "lit";
-import type { CardConfig, Colors, HASSConfig, ShadeOptions } from "../types.js";
+import {
+  type CardConfig,
+  type Colors,
+  DEFAULT_SHADE,
+  type HASSConfig,
+  type ShadeOptions,
+} from "../types.js";
 import { parseCardConfig } from "./card-config.js";
 import { cardStyles } from "./card-styles.js";
 import { buildGalleryCaption, buildStatusBarView, discStyle } from "./card-template.js";
@@ -84,7 +90,7 @@ export class SolarViewCard extends LitElement {
     this._colors = {};
     this._refreshMs = 60000;
     this._eclipticView = false;
-    this._shade = { sphere: true, dayNight: true };
+    this._shade = DEFAULT_SHADE;
     this._theme = "auto";
     this._heightStyle = "";
     this._solarView = new SolarView(this._zoom);

--- a/src/card/solar-view.ts
+++ b/src/card/solar-view.ts
@@ -1,5 +1,12 @@
 import { renderSolarSystem } from "../renderer/index.js";
-import type { Colors, Hemisphere, LocationData, PanZoomState, ShadeOptions } from "../types.js";
+import {
+  type Colors,
+  DEFAULT_SHADE,
+  type Hemisphere,
+  type LocationData,
+  type PanZoomState,
+  type ShadeOptions,
+} from "../types.js";
 import type { ZoomController } from "./zoom-controller.js";
 
 /**
@@ -27,7 +34,7 @@ export class SolarView {
     locationData: LocationData | null,
     colors: Colors,
     eclipticView: boolean,
-    shade: ShadeOptions = { sphere: true, dayNight: true }
+    shade: ShadeOptions = DEFAULT_SHADE
   ): void {
     while (container.firstChild) container.removeChild(container.firstChild);
     const { svg, updateMarkers, updateHalo } = renderSolarSystem(

--- a/src/renderer/bodies.ts
+++ b/src/renderer/bodies.ts
@@ -1,10 +1,16 @@
-import type { CelestialBody, CometVisualEllipse, ShadeOptions } from "../types.js";
+import {
+  type CelestialBody,
+  type CometVisualEllipse,
+  DEFAULT_SHADE,
+  type ShadeOptions,
+} from "../types.js";
 import type { EclipticViewDirection } from "./svg-utils.js";
 import {
   BODY_LABEL_ATTRS,
   CENTER,
   createSvgElement,
   DEFAULT_LABEL_COLOR,
+  getOrCreateDefs,
   type OrbitTransformComponents,
   orbitTransformComponents,
   radiusFromAU,
@@ -43,8 +49,7 @@ const SPRITE_SOFT =
  * zoom-1 default (VIEW_SIZE * HALO_VIEW_FRACTION); updateHalo rescales it as the view zooms.
  */
 export function renderSunHalo(svg: SVGElement): void {
-  const defs =
-    svg.querySelector("defs") || svg.insertBefore(createSvgElement("defs", {}), svg.firstChild);
+  const defs = getOrCreateDefs(svg);
   const grad = createSvgElement("radialGradient", { id: "sun-halo" });
   const stop = (offset: string, color: string, opacity: string) =>
     grad.appendChild(
@@ -80,8 +85,7 @@ export function renderSphereSprite(
   r: number,
   color: string
 ): void {
-  const defs =
-    svg.querySelector("defs") || svg.insertBefore(createSvgElement("defs", {}), svg.firstChild);
+  const defs = getOrCreateDefs(svg);
   const tintId = `tint-${color.replace(/[^a-z0-9]/gi, "")}`;
   if (!defs.querySelector(`#${tintId}`)) {
     const cr = Number.parseInt(color.slice(1, 3), 16) / 255;
@@ -231,8 +235,7 @@ export function renderBodyShadow(
   // rotated rect and masked so it stops at the core (the terminator path already covers
   // that, no double wash).
   const phiDeg = (Math.atan2(y - CENTER, x - CENTER) * 180) / Math.PI;
-  const defs =
-    svg.querySelector("defs") || svg.insertBefore(createSvgElement("defs", {}), svg.firstChild);
+  const defs = getOrCreateDefs(svg);
   const clip = createSvgElement("clipPath", { id: "saturn-shadow" });
   clip.appendChild(
     createSvgElement("rect", {
@@ -276,7 +279,7 @@ export function renderBody(
   y: number,
   body: CelestialBody,
   showLabel = true,
-  shade: ShadeOptions = { sphere: true, dayNight: true }
+  shade: ShadeOptions = DEFAULT_SHADE
 ): void {
   const atCenter = x === CENTER && y === CENTER;
   // Draw the body form — 3d Lambert sphere sprite or a flat 2d disc — then, off-centre, layer
@@ -314,7 +317,7 @@ export function renderSaturn(
   x: number,
   y: number,
   body: CelestialBody,
-  shade: ShadeOptions = { sphere: true, dayNight: true }
+  shade: ShadeOptions = DEFAULT_SHADE
 ): void {
   const coreR = Math.round(body.size / 2);
   if (shade.sphere) {

--- a/src/renderer/comets.ts
+++ b/src/renderer/comets.ts
@@ -1,4 +1,4 @@
-import type { Comet, CometVisualEllipse, ShadeOptions } from "../types.js";
+import { type Comet, type CometVisualEllipse, DEFAULT_SHADE, type ShadeOptions } from "../types.js";
 import { ORBIT_COLOR, renderBodyShadow, renderSphereSprite } from "./bodies.js";
 import type { EclipticViewDirection } from "./svg-utils.js";
 import {
@@ -73,7 +73,7 @@ export function renderCometBody(
   sunX: number,
   sunY: number,
   dynamicTailLength?: number,
-  shade: ShadeOptions = { sphere: true, dayNight: true }
+  shade: ShadeOptions = DEFAULT_SHADE
 ): void {
   // Direction away from the Sun
   const dx = x - sunX;

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -5,13 +5,14 @@ import {
   calculatePlanetOrbit,
 } from "../astronomy/orbital-mechanics.js";
 import { EARTH, MOON, MOON_PIXEL_OFFSET, PLANETS, SUN } from "../astronomy/planet-data.js";
-import type {
-  Colors,
-  Hemisphere,
-  LocationData,
-  PanZoomState,
-  ShadeOptions,
-  ViewPosition,
+import {
+  type Colors,
+  DEFAULT_SHADE,
+  type Hemisphere,
+  type LocationData,
+  type PanZoomState,
+  type ShadeOptions,
+  type ViewPosition,
 } from "../types.js";
 import {
   HALO_VIEW_FRACTION,
@@ -44,7 +45,7 @@ export function renderSolarSystem(
   locationData: LocationData | null = null,
   colors: Colors = {},
   eclipticView = false,
-  shade: ShadeOptions = { sphere: true, dayNight: true }
+  shade: ShadeOptions = DEFAULT_SHADE
 ): {
   svg: SVGSVGElement;
   positions: ViewPosition[];

--- a/src/renderer/observer.ts
+++ b/src/renderer/observer.ts
@@ -8,7 +8,14 @@ import {
 } from "../astronomy/solar-position.js";
 import type { Colors, LocationData } from "../types.js";
 import type { EclipticViewDirection } from "./svg-utils.js";
-import { CENTER, createSvgElement, MAX_RADIUS, polarOffset, VIEW_SIZE } from "./svg-utils.js";
+import {
+  CENTER,
+  createSvgElement,
+  getOrCreateDefs,
+  MAX_RADIUS,
+  polarOffset,
+  VIEW_SIZE,
+} from "./svg-utils.js";
 
 const NEEDLE_COLOR = "color-mix(in srgb, currentColor 70%, transparent)";
 
@@ -159,8 +166,7 @@ function renderVisibilityCone(
   // SVG path: MoveTo apex, LineTo left edge, Arc to right edge, ClosePath
   const pathD = `M ${anchorX} ${anchorY} L ${left.x} ${left.y} A ${D} ${D} 0 ${largeArcFlag} ${sweepFlag} ${right.x} ${right.y} Z`;
 
-  const defs =
-    svg.querySelector("defs") || svg.insertBefore(createSvgElement("defs", {}), svg.firstChild);
+  const defs = getOrCreateDefs(svg);
 
   const clipPath = createSvgElement("clipPath", { id: clipId });
   clipPath.appendChild(createSvgElement("path", { d: pathD }));

--- a/src/renderer/seasons.ts
+++ b/src/renderer/seasons.ts
@@ -1,6 +1,6 @@
 import type { Colors, Hemisphere } from "../types.js";
 import type { EclipticViewDirection } from "./svg-utils.js";
-import { CENTER, createSvgElement, MAX_RADIUS, VIEW_SIZE } from "./svg-utils.js";
+import { CENTER, createSvgElement, getOrCreateDefs, MAX_RADIUS, VIEW_SIZE } from "./svg-utils.js";
 
 const DEFAULT_SEASON_LINE_COLOR = "color-mix(in srgb, currentColor 25%, transparent)";
 const DEFAULT_SEASON_LABEL_COLOR = "color-mix(in srgb, currentColor 50%, transparent)";
@@ -78,8 +78,7 @@ export function renderSeasonOverlay(
   ];
 
   const labelRadius = MAX_RADIUS + 20;
-  const defs =
-    svg.querySelector("defs") || svg.insertBefore(createSvgElement("defs", {}), svg.firstChild);
+  const defs = getOrCreateDefs(svg);
 
   arcDefs.forEach((season, i) => {
     const pathId = `season-arc-${i}`;

--- a/src/renderer/svg-utils.ts
+++ b/src/renderer/svg-utils.ts
@@ -97,51 +97,14 @@ export function polarFromFocus(
 }
 
 /**
- * The two half-disc SVG paths for a body lit from `lightFrom` (the Sun by default): a `litD`
- * half bulging toward the light and a `darkD` half bulging away, split along the diameter
- * perpendicular to the body->light vector. Returns null when the body sits on the light
- * source (no meaningful direction).
- *
- * This deliberately takes no eclipticViewDirection: the split direction comes from the
- * screen-space delta between two already-placed points (body and light), not from an
- * orbital angle, so the +/-1 ecliptic mirror does not apply here.
- */
-export function sunwardHalfDiscPaths(
-  x: number,
-  y: number,
-  r: number,
-  lightFrom: { x: number; y: number } = { x: CENTER, y: CENTER }
-): { litD: string; darkD: string } | null {
-  const dx = lightFrom.x - x;
-  const dy = lightFrom.y - y;
-  if (Math.hypot(dx, dy) < 1e-9) {
-    return null;
-  }
-  const phi = Math.atan2(dy, dx);
-  const p1 = {
-    x: x + r * Math.cos(phi + Math.PI / 2),
-    y: y + r * Math.sin(phi + Math.PI / 2),
-  };
-  const p2 = {
-    x: x + r * Math.cos(phi - Math.PI / 2),
-    y: y + r * Math.sin(phi - Math.PI / 2),
-  };
-  // Screen y is downward: going p1 -> p2 the short way through the phi direction
-  // (toward the light) is sweep-flag 0; the opposite half is sweep-flag 1.
-  const arc = (sweep: number) => `M ${p1.x} ${p1.y} A ${r} ${r} 0 0 ${sweep} ${p2.x} ${p2.y} Z`;
-  return { litD: arc(0), darkD: arc(1) };
-}
-
-/**
  * The SVG path `d` for the dark, anti-sunward region of a body disc lit from `lightFrom`
  * (the Sun by default): the two `phi ± 90°` poles joined by an anti-sunward semicircle and
  * then a shallow terminator arc that bows `bow·r` deep into the dark side, so the lit face
  * reads as more than a flat half. Returns null when the body sits on the light source (no
  * meaningful direction).
  *
- * Like sunwardHalfDiscPaths this takes no eclipticViewDirection: `phi` is the screen-space
- * delta between two already-placed points (body and light), not an orbital angle, so the
- * ±1 ecliptic mirror does not apply here.
+ * Takes no eclipticViewDirection: `phi` is the screen-space delta between two already-placed
+ * points (body and light), not an orbital angle, so the ±1 ecliptic mirror does not apply here.
  */
 export function terminatorShadowPath(
   x: number,
@@ -230,4 +193,15 @@ export function createSvgElement<K extends keyof SVGElementTagNameMap>(
     el.setAttribute(k, String(v));
   }
   return el as SVGElementTagNameMap[K];
+}
+
+/**
+ * The svg's `<defs>` node, created as the first child if it doesn't exist yet. Every renderer
+ * that stashes a gradient/clip/filter reaches for `<defs>` the same way — one helper so a
+ * change to how that node is managed (ordering, namespacing) lands in exactly one place.
+ */
+export function getOrCreateDefs(svg: SVGElement): SVGDefsElement {
+  return (
+    svg.querySelector("defs") ?? svg.insertBefore(createSvgElement("defs", {}), svg.firstChild)
+  );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,9 @@ export interface ShadeOptions {
   dayNight: boolean;
 }
 
+/** The product default — both switches on. The single source every render entry point defaults to. */
+export const DEFAULT_SHADE: ShadeOptions = { sphere: true, dayNight: true };
+
 export interface ViewPosition {
   name: string;
   x: number;

--- a/test/renderer/svg-utils.test.ts
+++ b/test/renderer/svg-utils.test.ts
@@ -5,12 +5,12 @@ import {
   CENTER,
   createSvgElement,
   ellipseFromApsides,
+  getOrCreateDefs,
   MAX_RADIUS,
   MIN_RADIUS,
   polarFromFocus,
   polarOffset,
   SVG_NS,
-  sunwardHalfDiscPaths,
   terminatorShadowPath,
   VIEW_SIZE,
 } from "../../src/renderer/svg-utils.js";
@@ -43,6 +43,24 @@ describe("createSvgElement", () => {
   it("creates element with no attributes when attrs is empty", () => {
     const el = createSvgElement("g", {});
     expect(el.attributes.length).toBe(0);
+  });
+});
+
+describe("getOrCreateDefs", () => {
+  it("inserts a <defs> as the first child when the svg has none", () => {
+    const svg = createSvgElement("svg", {});
+    svg.appendChild(createSvgElement("circle", {}));
+    const defs = getOrCreateDefs(svg);
+    expect(defs.tagName).toBe("defs");
+    expect(svg.firstChild).toBe(defs);
+  });
+
+  it("returns the existing <defs> without adding a second one", () => {
+    const svg = createSvgElement("svg", {});
+    const first = getOrCreateDefs(svg);
+    const second = getOrCreateDefs(svg);
+    expect(second).toBe(first);
+    expect(svg.querySelectorAll("defs").length).toBe(1);
   });
 });
 
@@ -134,120 +152,6 @@ describe("polarOffset", () => {
   });
 });
 
-describe("sunwardHalfDiscPaths", () => {
-  // Pull every number out of a path "d" string, in order. For our half-discs the
-  // shape is "M sx sy A rx ry x-axis-rotation large-arc-flag sweep-flag ex ey Z",
-  // so numbers are [sx, sy, rx, ry, xrot, largeArc, sweep, ex, ey].
-  function nums(d: string): number[] {
-    return (d.match(/-?\d+(?:\.\d+)?/g) ?? []).map(Number);
-  }
-  function startPoint(d: string): { x: number; y: number } {
-    const n = nums(d);
-    return { x: n[0], y: n[1] };
-  }
-  function endPoint(d: string): { x: number; y: number } {
-    const n = nums(d);
-    return { x: n[n.length - 2], y: n[n.length - 1] };
-  }
-  function sweepFlag(d: string): number {
-    return nums(d)[6];
-  }
-  function dist(a: { x: number; y: number }, b: { x: number; y: number }): number {
-    return Math.hypot(a.x - b.x, a.y - b.y);
-  }
-  // Independent reconstruction of a semicircular arc's midpoint from its chord
-  // endpoints, its center, and the SVG sweep flag. Verified against SVG's
-  // "positive angle = visually clockwise" rule: for start S, end E, chord
-  // direction d = unit(E - S), sweep=1 puts the bulge at center + r*(dy, -dx),
-  // sweep=0 at center + r*(-dy, dx).
-  function arcMidpoint(d: string, cx: number, cy: number, r: number): { x: number; y: number } {
-    const s = startPoint(d);
-    const e = endPoint(d);
-    const len = Math.hypot(e.x - s.x, e.y - s.y);
-    const dx = (e.x - s.x) / len;
-    const dy = (e.y - s.y) / len;
-    const [nx, ny] = sweepFlag(d) === 1 ? [dy, -dx] : [-dy, dx];
-    return { x: cx + r * nx, y: cy + r * ny };
-  }
-
-  it("returns null when (x, y) coincides with an explicit lightFrom", () => {
-    expect(sunwardHalfDiscPaths(123, 456, 10, { x: 123, y: 456 })).toBe(null);
-  });
-
-  it("returns null for the default lightFrom (CENTER) when the body is at CENTER", () => {
-    expect(sunwardHalfDiscPaths(CENTER, CENTER, 12)).toBe(null);
-  });
-
-  it("returns two d strings that start with M, carry an 'r r' arc, and end with Z", () => {
-    const result = sunwardHalfDiscPaths(300, 250, 10);
-    expect(result).not.toBeNull();
-    const { litD, darkD } = result as { litD: string; darkD: string };
-    for (const d of [litD, darkD]) {
-      expect(d.startsWith("M")).toBe(true);
-      expect(d).toContain("A 10 10");
-      expect(d.trim().endsWith("Z")).toBe(true);
-    }
-  });
-
-  it("splits along the diameter perpendicular to the body->light vector, with shared endpoints at distance r", () => {
-    const x = 300;
-    const y = 250;
-    const r = 10;
-    const light = { x: CENTER, y: CENTER };
-    const result = sunwardHalfDiscPaths(x, y, r);
-    const { litD, darkD } = result as { litD: string; darkD: string };
-
-    // Independent geometry: the split is perpendicular to the body->light
-    // direction, so the diameter ends sit at phi +/- 90 degrees.
-    const phi = Math.atan2(light.y - y, light.x - x);
-    const p1 = {
-      x: x + r * Math.cos(phi + Math.PI / 2),
-      y: y + r * Math.sin(phi + Math.PI / 2),
-    };
-    const p2 = {
-      x: x + r * Math.cos(phi - Math.PI / 2),
-      y: y + r * Math.sin(phi - Math.PI / 2),
-    };
-
-    for (const d of [litD, darkD]) {
-      const s = startPoint(d);
-      const e = endPoint(d);
-      expect(dist(s, { x, y })).toBeCloseTo(r, 6);
-      expect(dist(e, { x, y })).toBeCloseTo(r, 6);
-      const onDiameter =
-        (dist(s, p1) < 1e-6 && dist(e, p2) < 1e-6) || (dist(s, p2) < 1e-6 && dist(e, p1) < 1e-6);
-      expect(onDiameter).toBe(true);
-    }
-
-    const litEnds = [startPoint(litD), endPoint(litD)];
-    const darkEnds = [startPoint(darkD), endPoint(darkD)];
-    const sameEndpoints =
-      (dist(litEnds[0], darkEnds[0]) < 1e-6 && dist(litEnds[1], darkEnds[1]) < 1e-6) ||
-      (dist(litEnds[0], darkEnds[1]) < 1e-6 && dist(litEnds[1], darkEnds[0]) < 1e-6);
-    expect(sameEndpoints).toBe(true);
-  });
-
-  it("litD bulges toward the light and darkD away; the two halves sweep opposite ways", () => {
-    const x = 300;
-    const y = 250;
-    const r = 10;
-    const light = { x: CENTER, y: CENTER };
-    const result = sunwardHalfDiscPaths(x, y, r);
-    const { litD, darkD } = result as { litD: string; darkD: string };
-
-    expect(sweepFlag(litD)).not.toBe(sweepFlag(darkD));
-
-    const litMid = arcMidpoint(litD, x, y, r);
-    const darkMid = arcMidpoint(darkD, x, y, r);
-    expect(dist(litMid, light)).toBeLessThan(dist(darkMid, light));
-
-    // The lit arc's midpoint is the circle point pointing straight at the light.
-    const phi = Math.atan2(light.y - y, light.x - x);
-    expect(litMid.x).toBeCloseTo(x + r * Math.cos(phi), 6);
-    expect(litMid.y).toBeCloseTo(y + r * Math.sin(phi), 6);
-  });
-});
-
 describe("terminatorShadowPath", () => {
   function nums(s: string): number[] {
     return (s.match(/-?\d+(?:\.\d+)?/g) ?? []).map(Number);
@@ -326,7 +230,9 @@ describe("terminatorShadowPath", () => {
     // The terminator arc bows away from the light. It renders from pole2 (where the
     // first arc ended) back to the M start point, so reconstruct its midpoint from
     // that chord direction, the ellipse cross-axis (bow*r), and the SVG sweep flag
-    // (same "positive angle = visually clockwise" rule the sunwardHalfDiscPaths tests use).
+    // (SVG's "positive angle = visually clockwise" rule: for start S, end E, chord
+    // direction d = unit(E - S), sweep=1 puts the bulge at center + r*(dy, -dx),
+    // sweep=0 at center + r*(-dy, dx)).
     const sweep = arc1Nums[4];
     const len = dist(start, pole2);
     const dx = (start.x - pole2.x) / len;


### PR DESCRIPTION
Pre-release cleanup batch — the three findings from `/code-review` on `v3.1.0..HEAD`. No behaviour change.

## Changes

| # | Finding | Fix |
|---|---------|-----|
| #224 | `sunwardHalfDiscPaths` exported + unit-tested, zero `src/` callers since #199 slice 1 | Delete the function and its `describe` block; note it done in the #199 design note |
| #225 | `querySelector("defs") \|\| insertBefore(...)` idiom copy-pasted 5× | Extract `getOrCreateDefs(svg)` into `svg-utils.ts`; route `bodies.ts` ×3, `observer.ts`, `seasons.ts` through it |
| #226 | `{ sphere: true, dayNight: true }` literal at 6 entry points | Add `DEFAULT_SHADE` to `types.ts`; reference it from `card.ts`, `solar-view.ts`, `bodies.ts` ×2, `comets.ts`, `index.ts` |

## Verification

- `npm run check:ci` — typecheck + biome + prettier green
- `npm test` — 1661 passed
- `npm run test:coverage` — 100% (statements / branches / functions / lines)
- `npm run build` — bundle builds clean

Closes #224, closes #225, closes #226.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Siauu79TbnGhCfTi2iPESp