### PR TITLE
refactor(renderer): make renderBodyShadow reach a required param

### DIFF
--- a/src/renderer/bodies.ts
+++ b/src/renderer/bodies.ts
@@ -223,8 +223,8 @@ export function renderOrbit(
 }
 
 /**
- * The astronomical day/night overlay (config `shading: true`). For a lone body (reach ===
- * coreR) it washes the anti-sunward region dark — bounded by an elliptical terminator that
+ * The astronomical day/night overlay (config `shading: true`). For a lone body (pass `reach ===
+ * coreR`) it washes the anti-sunward region dark — bounded by an elliptical terminator that
  * bows `TERMINATOR_BOW` into the dark side (see terminatorShadowPath), the dark side darker
  * but not black. phi comes from the screen-space vector to the Sun at CENTER, so no
  * eclipticViewDirection (not an orbital angle — CLAUDE.md, #94). No-op at CENTER (the Sun).
@@ -240,7 +240,7 @@ export function renderBodyShadow(
   x: number,
   y: number,
   coreR: number,
-  reach = coreR,
+  reach: number,
   shadeColor: string
 ): void {
   // No-op at CENTER (the Sun): terminatorShadowPath is null exactly there.


### PR DESCRIPTION
Round 3 (final) of the pre-release cleanup batch — the one finding from the third `/code-review` pass on `v3.1.0..HEAD`. Direct follow-up to #228.

## Change

#228 made `renderBodyShadow`'s `shadeColor` required but left `reach = coreR` as a defaulted param *ahead* of it. The default is dead (all three call sites — `renderBody`, `renderSaturn`, `renderCometBody` — pass `reach` explicitly) and the signature is misleading: it reads as though `renderBodyShadow(svg, x, y, coreR)` were a valid lone-body call, when omitting `reach` would feed `shadeFill(undefined)` a broken `color-mix`.

Drop the default; type it `reach: number`. Zero call-site churn.

## Verification

- `npm run check:ci` — green
- `npm test` — 1661 passed
- `npm run test:coverage` — 100% (one dead branch removed: 653 → 652)
- `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Siauu79TbnGhCfTi2iPESp