### PR TITLE
fix(renderer): harden renderSphereSprite hex parsing (#230)

### DIFF
--- a/src/renderer/bodies.ts
+++ b/src/renderer/bodies.ts
@@ -33,6 +33,22 @@ const shadeFill = (color: string): Record<string, string | number> => ({
   "fill-opacity": SHADE_OPACITY,
 });
 
+/**
+ * `#rgb` / `#rrggbb` -> canonical lowercase `#rrggbb`. Shorthand is expanded; anything else
+ * (a named colour, `rgb()`, a malformed string) throws instead of flowing `NaN` into the tint
+ * <feColorMatrix> `values`, which renders that body's 3d sprite untinted with no error (#230).
+ * Every current caller passes a 6-digit hex from planet-data / comet-data, so this only fires
+ * if bad colour data is introduced.
+ */
+export function normalizeHex(color: string): string {
+  const m = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(color);
+  if (!m) {
+    throw new Error(`expected an #rgb or #rrggbb colour, got ${JSON.stringify(color)}`);
+  }
+  const h = m[1].toLowerCase();
+  return `#${h.length === 3 ? h.replace(/./g, (c) => c + c) : h}`;
+}
+
 export const HALO_VIEW_FRACTION = 0.33;
 
 // Pre-rendered 128px Lambert sphere for `display: 3d`, generated once (scripts/gen-sphere-sprites.mjs) and
@@ -103,11 +119,12 @@ export function renderSphereSprite(
 ): void {
   const defs = getOrCreateDefs(svg);
   ensureSpriteSymbol(defs);
-  const tintId = `tint-${color.replace(/[^a-z0-9]/gi, "")}`;
+  const hex = normalizeHex(color);
+  const tintId = `tint-${hex.slice(1)}`;
   if (!defs.querySelector(`#${tintId}`)) {
-    const cr = Number.parseInt(color.slice(1, 3), 16) / 255;
-    const cg = Number.parseInt(color.slice(3, 5), 16) / 255;
-    const cb = Number.parseInt(color.slice(5, 7), 16) / 255;
+    const cr = Number.parseInt(hex.slice(1, 3), 16) / 255;
+    const cg = Number.parseInt(hex.slice(3, 5), 16) / 255;
+    const cb = Number.parseInt(hex.slice(5, 7), 16) / 255;
     const filter = createSvgElement("filter", {
       id: tintId,
       "color-interpolation-filters": "sRGB",

--- a/test/renderer/bodies.test.ts
+++ b/test/renderer/bodies.test.ts
@@ -469,6 +469,25 @@ describe("renderSphereSprite", () => {
     expect(vals[6]).toBeCloseTo(0x7f / 255, 5);
     expect(vals[12]).toBeCloseTo(0xc4 / 255, 5);
   });
+
+  it("expands #rgb shorthand to the same tint as its #rrggbb form (#230)", () => {
+    const svg = createSvg();
+    renderSphereSprite(svg, 10, 10, 8, "#abc");
+
+    const fcm = svg.querySelector("defs filter#tint-aabbcc feColorMatrix");
+    expect(fcm).not.toBeNull();
+    const vals = fcm.getAttribute("values").trim().split(/\s+/).map(Number);
+    expect(vals[0]).toBeCloseTo(0xaa / 255, 5);
+    expect(vals[6]).toBeCloseTo(0xbb / 255, 5);
+    expect(vals[12]).toBeCloseTo(0xcc / 255, 5);
+  });
+
+  it("throws on a non-hex colour rather than emitting a NaN tint matrix (#230)", () => {
+    const svg = createSvg();
+    expect(() => renderSphereSprite(svg, 10, 10, 8, "rebeccapurple")).toThrow(/#rrggbb/);
+    expect(() => renderSphereSprite(svg, 10, 10, 8, "#12345")).toThrow(/#rrggbb/);
+    expect(svg.querySelector('defs filter[id^="tint-"]')).toBeNull();
+  });
 });
 
 describe("renderSunHalo", () => {


### PR DESCRIPTION
Closes #230.

`renderSphereSprite` parsed `body.color` as strict `#rrggbb` with `color.slice()`. A future 3-digit hex (`#abc`) or named colour in `planet-data` / `comet-data` would give `color.slice(5, 7) === ""` → `Number.parseInt("", 16) === NaN` → a `feColorMatrix` `values` string carrying `NaN`, i.e. an invalid tint filter that renders that body untinted with no error.

## Change

- New `normalizeHex()`: expands `#rgb` → `#rrggbb` (lowercase) and **throws** on anything that isn't a hex colour.
- `renderSphereSprite` routes `color` through it before the channel math and keys the tint `<filter>` id off the normalised hex.

Not a live bug — every current caller passes a 6-digit hex, and output for those is unchanged. This converts a silent latent corruption into a loud failure and adds `#rgb` support for free.

## Tests

- `#abc` expands to the same tint matrix as `#aabbcc`
- non-hex (`rebeccapurple`, `#12345`) throws and emits no `tint-*` filter
- full suite green, coverage 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Siauu79TbnGhCfTi2iPESp