### PR TITLE
security: add CodeQL, OpenSSF Scorecard, and SECURITY.md

### DIFF
--- a/.github/workflows/hacs-validation.yml
+++ b/.github/workflows/hacs-validation.yml
@@ -8,6 +8,9 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,43 @@
+name: Scorecard supply-chain security
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "23 7 * * 1"
+  push:
+    branches: ["main"]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ discussion][discussions].
 [![hacs_badge][hacs-shield]][hacs] [![GitHub Release][releases-shield]][releases]
 [![License][license-shield]][license] ![Maintenance][maintenance-shield]
 [![Coverage][coverage-shield]][ci] [![Downloads][downloads-shield]][releases]
-[![Build and Test][ci-shield]][ci]
+[![Build and Test][ci-shield]][ci] [![CodeQL][codeql-shield]][codeql]
+[![OpenSSF Scorecard][scorecard-shield]][scorecard]
 
 ## Installation
 
@@ -205,3 +206,10 @@ a pipeline stall doesn't break the feed.
 [coverage-shield]: https://img.shields.io/badge/coverage-100%25-brightgreen
 [downloads-shield]:
   https://img.shields.io/github/downloads/marcintk/ha-planetary-solar-system-card/total?label=downloads
+[codeql]: https://github.com/marcintk/ha-planetary-solar-system-card/security/code-scanning
+[codeql-shield]:
+  https://github.com/marcintk/ha-planetary-solar-system-card/actions/workflows/github-code-scanning/codeql/badge.svg
+[scorecard]:
+  https://securityscorecards.dev/viewer/?uri=github.com/marcintk/ha-planetary-solar-system-card
+[scorecard-shield]:
+  https://api.securityscorecards.dev/projects/github.com/marcintk/ha-planetary-solar-system-card/badge

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ discussion][discussions].
 [![hacs_badge][hacs-shield]][hacs] [![GitHub Release][releases-shield]][releases]
 [![License][license-shield]][license] ![Maintenance][maintenance-shield]
 [![Coverage][coverage-shield]][ci] [![Downloads][downloads-shield]][releases]
+
 [![Build and Test][ci-shield]][ci] [![CodeQL][codeql-shield]][codeql]
 [![OpenSSF Scorecard][scorecard-shield]][scorecard]
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest released version of this card is supported with security fixes. Older versions
+should be upgraded via HACS.
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities privately using
+[GitHub Security Advisories](https://github.com/marcintk/ha-planetary-solar-system-card/security/advisories/new)
+rather than opening a public issue.
+
+If you're unable to use GitHub Security Advisories, open a regular issue asking for a private
+contact channel and avoid describing the vulnerability publicly.
+
+You should expect an initial response within a week. This is a hobby project maintained in spare
+time, so please be patient.


### PR DESCRIPTION
Addresses layers 1 and 2 of #244 (own source + build/project hygiene).

- **CodeQL** (layer 1): enabled via GitHub's default setup (TypeScript) — no workflow file needed, runs automatically.
- **OpenSSF Scorecard** (layer 2): new `scorecard.yml` workflow, weekly + on push to `main`, uploads SARIF to code scanning.
- **SECURITY.md**: private disclosure via GitHub Security Advisories.
- **README badges** for CodeQL and Scorecard.

Already satisfied before this PR (verified, not touched here):
- Dependabot already covers both `npm` and `github-actions` ecosystems.
- Branch protection on `main` already requires status checks + PR review.

Left for follow-up (needs a manual, non-scriptable step):
- **Socket.dev** (layer 3, supply chain): install the Socket GitHub App at the account level and enable this repo, then add its badge. This can't be done via API/CLI — needs the GitHub App install flow in a browser.
- Optionally raise `required_approving_review_count` above 0 on branch protection.

First CodeQL and Scorecard runs will show up in the Security tab once this merges; Scorecard's `Binary-Artifacts` check will likely flag the inline base64 sprite in `src/renderer/bodies.ts` and the `docs/card.js` symlink per the issue's note — worth a look once we see the actual score.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kqs8RuqtJTvpM3YL5QCPkE