### PR TITLE
fix: pin ossf/scorecard-action to a real tag

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@55891bbd73f2425e97637d96e306fc9d491d0b21 # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
The Scorecard workflow added in #247 failed on its first run:

> Unable to resolve action \`ossf/scorecard-action@v2\`, unable to find version \`v2\`

Unlike \`actions/checkout\`, \`actions/upload-artifact\`, and \`github/codeql-action\`, \`ossf/scorecard-action\` doesn't publish a floating major \`v2\` tag — only full \`vX.Y.Z\` releases. Pinned to \`v2.4.4\` by commit SHA, which also happens to be what Scorecard's own Pinned-CI-Actions check wants to see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
