### PR TITLE
fix: pin ossf/scorecard-action to the actual commit, not the tag object

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@55891bbd73f2425e97637d96e306fc9d491d0b21 # v2.4.4
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
The Scorecard run on \`main\` succeeded end-to-end but its publish step failed silently in the logs:

> error sending scorecard results to webapp: http response 400, workflow verification failed: imposter commit: 55891bbd73f2425e97637d96e306fc9d491d0b21 does not belong to ossf/scorecard-action

The SHA I pinned in #248 was the annotated tag *object*'s own SHA (\`git/refs/tags/v2.4.4\` -> object.sha), not the commit it points to (\`git/tags/<that sha>\` -> object.sha). \`actions/checkout\`-style resolution is fine with either, but Scorecard's server-side provenance check for \`publish_results\` walks the real commit graph and correctly rejects a tag-object SHA as not being an actual commit.

Fixed by pinning to the peeled commit SHA. This is why the securityscorecards.dev viewer reports the repo as unknown/invalid — no result has ever successfully published.