### PR TITLE
security: pin all workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24.x
           cache: npm
@@ -32,7 +32,7 @@ jobs:
 
       - name: Coverage summary
         if: always()
-        uses: davelosert/vitest-coverage-report-action@v2
+        uses: davelosert/vitest-coverage-report-action@c4bbc33a89b7ace0e63d35f1f7d4bcee31155a73 # v2
         with:
           json-summary-path: coverage/coverage-summary.json
           file-coverage-mode: changes

--- a/.github/workflows/deploy-demo-page.yml
+++ b/.github/workflows/deploy-demo-page.yml
@@ -25,11 +25,11 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24.x
           cache: npm
@@ -54,11 +54,11 @@ jobs:
           rm -f _site/card.js
           cp dist/card.js _site/card.js
 
-      - uses: actions/configure-pages@v6
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
 
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: _site
 
       - id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5

--- a/.github/workflows/hacs-validation.yml
+++ b/.github/workflows/hacs-validation.yml
@@ -16,9 +16,9 @@ jobs:
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: HACS Action
-        uses: hacs/action@22.5.0
+        uses: hacs/action@d556e736723344f83838d08488c983a15381059a # 22.5.0
         with:
           category: plugin

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -13,7 +13,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
@@ -47,7 +47,7 @@ jobs:
           fi
           echo "Tag v$CURR is valid (previous release: v$PREV)"
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24.x"
           cache: npm
@@ -71,7 +71,7 @@ jobs:
         run: echo "name=$(node -p "require('./package.json').name")" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3
         with:
           tag_name: ${{ github.ref_name }}
           files: dist/${{ steps.name.outputs.name }}.js

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
@@ -31,13 +31,13 @@ jobs:
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@faaca9a8f6edddba5725ffe5adefdab6669a2eca # v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Addresses Scorecard's \`Pinned-Dependencies\` check (4/10) and the 17 corresponding open CodeQL alerts (one per unpinned \`uses:\` line, visible under [Security > Code scanning](https://github.com/marcintk/ha-planetary-solar-system-card/security/code-scanning)).

Pinned every action across all 5 workflows to its resolved commit SHA, keeping a \`# vX.Y.Z\` comment for readability:

| Action | Was | Now |
|---|---|---|
| actions/checkout | v7 | 3d3c42e |
| actions/setup-node | v7 | 8207627 |
| davelosert/vitest-coverage-report-action | v2 | c4bbc33 |
| actions/configure-pages | v6 | 45bfe01 |
| actions/upload-pages-artifact | v5 | fc324d3 |
| actions/deploy-pages | v5 | 368f825 |
| hacs/action | 22.5.0 | d556e73 |
| softprops/action-gh-release | v3 | efb3536 |
| actions/upload-artifact | v4 | ea165f8 |
| github/codeql-action/upload-sarif | v3 | faaca9a |

Every SHA was checked against \`repos/{repo}/commits/{sha}\` (a 200 there means it's an actual commit) before use — #248 pinned \`ossf/scorecard-action\` to an annotated tag *object*'s own SHA instead of the commit it points to, which Scorecard's own publish step rejected as an "imposter commit" (fixed in #249). Same class of mistake, avoided here.

No version or behavior changes — same released versions, just SHA-pinned.