### PR TITLE
chore: add CodeRabbit config for automated PR review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -19,26 +19,10 @@ reviews:
     - "!dist/**"
     - "!**/*.min.js"
     - "!package-lock.json"
-  path_instructions:
-    - path: "src/**/*.ts"
-      instructions: >
-        This is a Home Assistant Lit custom card (TypeScript, Rollup build).
-        Flag correctness bugs and simplification opportunities. Note that
-        `src/renderer` draws the solar system via imperative SVG DOM
-        manipulation rebuilt on every update() call — this is intentional,
-        not a Lit anti-pattern. Any coordinate math derived from an angle
-        must go through `polarOffset()` in `renderer/svg-utils.ts`; a
-        hand-written `y + dir * dist * Math.sin(angle)` duplicate is a bug,
-        not a style nit.
-    - path: "test/**/*.ts"
-      instructions: >
-        Coverage must stay at 100% (project invariant). Flag any change
-        that reduces coverage or removes an assertion without a replacement.
-    - path: ".github/workflows/**"
-      instructions: >
-        Workflow actions must stay pinned to commit SHAs (not tags) per the
-        project's security hardening. Flag any action reference that is a
-        version tag instead of a full-length SHA.
+  # No path_instructions here: CodeRabbit auto-detects and applies root
+  # CLAUDE.md as coding guidelines, so the project's architecture invariants
+  # (SVG imperative rebuild, polarOffset mirror rule, 100% coverage, SHA-pinned
+  # workflow actions) live in one place instead of being duplicated here.
 
 chat:
   auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -13,6 +13,8 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
+    # 0 = never auto-pause; keep reviewing every subsequent commit on a PR.
+    auto_pause_after_reviewed_commits: 0
   path_filters:
     - "!dist/**"
     - "!**/*.min.js"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,42 @@
+# CodeRabbit configuration
+# https://docs.coderabbit.ai/reference/configuration
+
+language: "en-US"
+
+reviews:
+  profile: "chill"
+  # Submits a formal APPROVE/REQUEST_CHANGES review (not just comments),
+  # auto-approving once CodeRabbit's comments are resolved, the latest
+  # commit was reviewed, and checks pass. This is what satisfies the
+  # branch-protection "1 approving review" rule for a solo maintainer.
+  request_changes_workflow: true
+  auto_review:
+    enabled: true
+    drafts: false
+  path_filters:
+    - "!dist/**"
+    - "!**/*.min.js"
+    - "!package-lock.json"
+  path_instructions:
+    - path: "src/**/*.ts"
+      instructions: >
+        This is a Home Assistant Lit custom card (TypeScript, Rollup build).
+        Flag correctness bugs and simplification opportunities. Note that
+        `src/renderer` draws the solar system via imperative SVG DOM
+        manipulation rebuilt on every update() call — this is intentional,
+        not a Lit anti-pattern. Any coordinate math derived from an angle
+        must go through `polarOffset()` in `renderer/svg-utils.ts`; a
+        hand-written `y + dir * dist * Math.sin(angle)` duplicate is a bug,
+        not a style nit.
+    - path: "test/**/*.ts"
+      instructions: >
+        Coverage must stay at 100% (project invariant). Flag any change
+        that reduces coverage or removes an assertion without a replacement.
+    - path: ".github/workflows/**"
+      instructions: >
+        Workflow actions must stay pinned to commit SHAs (not tags) per the
+        project's security hardening. Flag any action reference that is a
+        version tag instead of a full-length SHA.
+
+chat:
+  auto_reply: true


### PR DESCRIPTION
Adds `.coderabbit.yaml` so CodeRabbit reviews PRs automatically and submits a formal approve/request-changes review (via `request_changes_workflow: true`), satisfying the branch-protection "1 approving review" rule for a solo maintainer and addressing the OSSF Scorecard [Code-Review check](https://github.com/marcintk/ha-planetary-solar-system-card/security/code-scanning/21).

Path instructions point CodeRabbit at the project's real invariants: the `polarOffset()` mirror rule in the renderer, the 100% coverage requirement, and SHA-pinned workflow actions.

This PR itself is a live test of the setup — expecting CodeRabbit to post a review here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository configuration for automated code reviews.
  * Enabled formal review workflows, automatic reviews for non-draft changes, and chat responses.
  * Added review guidance for source code, tests, and workflow files while excluding generated and minified files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->