### PR TITLE
security: add Socket.dev supply-chain scanning + firewall gate

### DIFF
--- a/.github/actions/socket-firewall/action.yml
+++ b/.github/actions/socket-firewall/action.yml
@@ -1,0 +1,19 @@
+name: "Socket Firewall npm install"
+description: >
+  Runs an npm command through Socket Firewall (free edition, no API key) so a malicious/typosquat
+  package can't install even between Dependabot's weekly runs.
+inputs:
+  command:
+    description: 'npm subcommand to run through sfw, e.g. "ci" or "install"'
+    required: false
+    default: "ci"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      with:
+        mode: firewall-free
+
+    - shell: bash
+      run: sfw npm ${{ inputs.command }}

--- a/.github/workflows/card-build-and-test.yml
+++ b/.github/workflows/card-build-and-test.yml
@@ -25,7 +25,10 @@ jobs:
           node-version: 24.x
           cache: npm
 
-      - run: npm ci
+      - uses: ./.github/actions/socket-firewall
+        with:
+          command: ci
+
       - run: npm run build --if-present
       - run: npm run check:ci
       - run: npm run test:coverage

--- a/.github/workflows/card-deploy-demo-page.yml
+++ b/.github/workflows/card-deploy-demo-page.yml
@@ -34,7 +34,9 @@ jobs:
           node-version: 24.x
           cache: npm
 
-      - run: npm ci
+      - uses: ./.github/actions/socket-firewall
+        with:
+          command: ci
 
       - name: Set version from latest git tag
         run: |

--- a/.github/workflows/card-publish-release.yml
+++ b/.github/workflows/card-publish-release.yml
@@ -3,8 +3,8 @@ name: Card Publish Release
 on:
   push:
     tags:
-      - 'v*.*.*'
-      - 'v*.*.*-*'
+      - "v*.*.*"
+      - "v*.*.*-*"
 
 permissions:
   contents: read
@@ -54,7 +54,10 @@ jobs:
           node-version: "24.x"
           cache: npm
 
-      - run: npm ci
+      - uses: ./.github/actions/socket-firewall
+        with:
+          command: ci
+
       - run: npm test
 
       - name: Derive version from tag

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ discussion][discussions].
 [![Coverage][coverage-shield]][ci] [![Downloads][downloads-shield]][releases]
 
 [![Build and Test][ci-shield]][ci] [![CodeQL][codeql-shield]][codeql]
-[![OpenSSF Scorecard][scorecard-shield]][scorecard]
+[![OpenSSF Scorecard][scorecard-shield]][scorecard] [![Socket][socket-shield]][socket]
 
 ## Installation
 
@@ -214,3 +214,5 @@ a pipeline stall doesn't break the feed.
   https://securityscorecards.dev/viewer/?uri=github.com/marcintk/ha-planetary-solar-system-card
 [scorecard-shield]:
   https://api.securityscorecards.dev/projects/github.com/marcintk/ha-planetary-solar-system-card/badge
+[socket]: https://github.com/marcintk/ha-planetary-solar-system-card/blob/main/socket.yml
+[socket-shield]: https://img.shields.io/badge/Socket-Firewall%20%2B%20Scanning-fb3387.svg

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,21 @@
 # Security Policy
 
+## Automated Scanning
+
+This repo runs several automated checks against every push and pull request:
+
+- **[CodeQL](https://github.com/marcintk/ha-planetary-solar-system-card/security/code-scanning)** —
+  static analysis of the TypeScript/JavaScript source.
+- **[OSSF Scorecard](https://securityscorecards.dev/viewer/?uri=github.com/marcintk/ha-planetary-solar-system-card)**
+  — scores the repo's supply-chain hygiene (branch protection, action pinning, CI hardening).
+- **[Dependabot](https://github.com/marcintk/ha-planetary-solar-system-card/security/dependabot)** —
+  weekly update PRs for vulnerable npm and GitHub Actions dependencies.
+- **[Socket](https://socket.dev)** — scans `package.json`/lockfile changes on every PR for malware,
+  typosquats, and other supply-chain risks in new or changed dependencies, and its Firewall (`sfw`)
+  gates `npm ci` in CI so a malicious package can't install even between Dependabot's weekly runs.
+  Repo policy is checked in at
+  [`socket.yml`](https://github.com/marcintk/ha-planetary-solar-system-card/blob/main/socket.yml).
+
 ## Supported Versions
 
 Only the latest released version of this card is supported with security fixes. Older versions

--- a/socket.yml
+++ b/socket.yml
@@ -1,0 +1,20 @@
+version: 2
+
+# Checked-in Socket.dev policy — makes explicit in the repo what would otherwise live only
+# in the dashboard. See docs/socket-yml at https://docs.socket.dev/docs/socket-yml.
+
+# Only the npm manifests actually gate installs/releases here — no need to re-scan on every
+# unrelated source change.
+triggerPaths:
+  - "package.json"
+  - "package-lock.json"
+
+issueRules:
+  malware: true
+  telemetry: false
+
+githubApp:
+  enabled: true
+  dependencyOverviewEnabled: true
+  pullRequestAlertsEnabled: true
+  projectReportsEnabled: true


### PR DESCRIPTION
## Summary
- `socket.yml`: checked-in Socket policy (trigger paths, issue rules, GitHub App settings) — makes the dashboard-configured Socket.dev integration explicit in the repo.
- `.github/actions/socket-firewall`: composite action wrapping `SocketDev/action@v1.3.2` (firewall-free mode, no API key) + `sfw npm <command>`, reused by `card-build-and-test`, `card-publish-release`, `card-deploy-demo-page` to gate every `npm ci` in CI against malicious/typosquat packages.
- `README.md`: Socket badge next to CodeQL/Scorecard.
- `SECURITY.md`: documents the full automated scanning stack (CodeQL/Scorecard/Dependabot/Socket).

## Verification
CI on this PR must pass, in particular the Socket Firewall step in `card-build-and-test` — that's the real test of whether `sfw npm ci` works as expected in this repo's Node 24 / npm setup.