### PR TITLE
ci: pass PAT to scorecard-action for branch-protection check

### DIFF
--- a/.github/workflows/ossf-scorecard-analysis.yml
+++ b/.github/workflows/ossf-scorecard-analysis.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
+          repo_token: ${{ secrets.SCORECARD_READ_TOKEN }}
           publish_results: true
 
       - name: Upload artifact

--- a/.github/workflows/ossf-scorecard-analysis.yml
+++ b/.github/workflows/ossf-scorecard-analysis.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
-          repo_token: ${{ secrets.SCORECARD_READ_TOKEN }}
+          repo_token: ${{ secrets.OSSF_SCORECARD_READ_TOKEN }}
           publish_results: true
 
       - name: Upload artifact


### PR DESCRIPTION
The default `GITHUB_TOKEN` can't read classic branch-protection rules, causing the OSSF Scorecard **Branch-Protection** check to fail with:

```
internal error: error during branchesHandler.setup: internal error: some github tokens can't read classic branch protection rules
```

Wires `repo_token: ${{ secrets.SCORECARD_READ_TOKEN }}` into the scorecard-action step, per [Scorecard's fine-grained auth docs](https://github.com/ossf/scorecard-action/blob/main/docs/authentication/fine-grained-auth-token.md).

**Requires a repo secret before this takes effect**: `SCORECARD_READ_TOKEN`, a fine-grained PAT scoped to this repo only with **Administration: Read-only** permission. Not yet created — do not merge until it's set.