### PR TITLE
docs: clarify badge labels (Socket.dev, CodeQL Analysis)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ discussion][discussions].
 [![License][license-shield]][license] ![Maintenance][maintenance-shield]
 [![Coverage][coverage-shield]][ci] [![Downloads][downloads-shield]][releases]
 
-[![Build and Test][ci-shield]][ci] [![CodeQL][codeql-shield]][codeql]
-[![OpenSSF Scorecard][scorecard-shield]][scorecard] [![Socket][socket-shield]][socket]
+[![Build and Test][ci-shield]][ci] [![CodeQL Analysis][codeql-shield]][codeql]
+[![OpenSSF Scorecard][scorecard-shield]][scorecard] [![Socket.dev][socket-shield]][socket]
 
 ## Installation
 
@@ -215,4 +215,4 @@ a pipeline stall doesn't break the feed.
 [scorecard-shield]:
   https://api.securityscorecards.dev/projects/github.com/marcintk/ha-planetary-solar-system-card/badge
 [socket]: https://github.com/marcintk/ha-planetary-solar-system-card/blob/main/socket.yml
-[socket-shield]: https://img.shields.io/badge/Socket-Firewall%20%2B%20Scanning-fb3387.svg
+[socket-shield]: https://img.shields.io/badge/Socket.dev-Firewall%20%2B%20Scanning-fb3387.svg


### PR DESCRIPTION
Small README wording fixes:
- Socket badge label/alt-text: `Socket` → `Socket.dev` (explicit, matches convention of other badges)
- CodeQL badge alt-text: `CodeQL` → `CodeQL Analysis` (matches the workflow's actual rendered badge text)

No functional changes.