### PR TITLE
docs: use OpenSSF/CodeQL banner labels, custom scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ discussion][discussions].
 [![License][license-shield]][license] ![Maintenance][maintenance-shield]
 [![Coverage][coverage-shield]][ci] [![Downloads][downloads-shield]][releases]
 
-[![Build and Test][ci-shield]][ci] [![CodeQL Analysis][codeql-shield]][codeql]
-[![OpenSSF Scorecard][scorecard-shield]][scorecard] [![Socket.dev][socket-shield]][socket]
+[![Build and Test][ci-shield]][ci] [![CodeQL][codeql-shield]][codeql]
+[![OpenSSF][scorecard-shield]][scorecard] [![Socket.dev][socket-shield]][socket]
 
 ## Installation
 
@@ -213,6 +213,6 @@ a pipeline stall doesn't break the feed.
 [scorecard]:
   https://securityscorecards.dev/viewer/?uri=github.com/marcintk/ha-planetary-solar-system-card
 [scorecard-shield]:
-  https://api.securityscorecards.dev/projects/github.com/marcintk/ha-planetary-solar-system-card/badge
+  https://img.shields.io/ossf-scorecard/github.com/marcintk/ha-planetary-solar-system-card?label=OpenSSF&style=flat
 [socket]: https://github.com/marcintk/ha-planetary-solar-system-card/blob/main/socket.yml
 [socket-shield]: https://img.shields.io/badge/Socket.dev-Firewall%20%2B%20Scanning-fb3387.svg


### PR DESCRIPTION
README badge wording:
- CodeQL badge alt text: `CodeQL Analysis` → `CodeQL`
- Scorecard badge: alt text `OpenSSF Scorecard` → `OpenSSF`, and the badge image now points directly at img.shields.io with `label=OpenSSF` instead of OSSF's default lowercase `openssf scorecard` label
- Socket.dev badge unchanged from previous PR

No workflow files touched. No functional changes.